### PR TITLE
Fix release workflow to use dedicated test PostgreSQL instance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,44 @@ jobs:
     - name: Run full test suite
       run: |
         export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
-        make installcheck
-        TEST_SIZE_MULTIPLIER=3.0 make test-concurrency
+
+        # Verify extension is installed
+        echo "Checking if pg_textsearch.so is installed..."
+        ls -la /usr/lib/postgresql/${{ matrix.pg_version }}/lib/pg_textsearch.so
+
+        # Run the test setup manually since extension is already installed
+        rm -rf tmp_check_shared
+        mkdir -p tmp_check_shared
+        initdb -D tmp_check_shared/data --auth-local=trust --auth-host=trust
+        echo "port = 55433" >> tmp_check_shared/data/postgresql.conf
+        echo "log_statement = 'all'" >> tmp_check_shared/data/postgresql.conf
+        echo "shared_buffers = 256MB" >> tmp_check_shared/data/postgresql.conf
+        echo "max_connections = 20" >> tmp_check_shared/data/postgresql.conf
+        echo "unix_socket_directories = '$PWD/tmp_check_shared'" >> tmp_check_shared/data/postgresql.conf
+
+        # Try to start PostgreSQL and show logs if it fails
+        if ! pg_ctl start -D tmp_check_shared/data -l tmp_check_shared/data/logfile -w; then
+          echo "PostgreSQL failed to start. Log contents:"
+          cat tmp_check_shared/data/logfile
+          exit 1
+        fi
+
+        createdb -h $PWD/tmp_check_shared -p 55433 contrib_regression
+        if ! make installcheck PGHOST=$PWD/tmp_check_shared PGPORT=55433; then
+          echo "Tests failed. Showing regression diffs:"
+          if [ -f test/regression.diffs ]; then
+            cat test/regression.diffs
+          fi
+          pg_ctl stop -D tmp_check_shared/data -l tmp_check_shared/data/logfile || true
+          rm -rf tmp_check_shared || true
+          exit 1
+        fi
+
+        # Run concurrency tests with test database
+        TEST_SIZE_MULTIPLIER=3.0 PGHOST=$PWD/tmp_check_shared PGPORT=55433 make test-concurrency
+
+        pg_ctl stop -D tmp_check_shared/data -l tmp_check_shared/data/logfile
+        rm -rf tmp_check_shared
 
     - name: Package extension
       run: |


### PR DESCRIPTION
## Summary
- Fixes release workflow test failures by using a dedicated PostgreSQL instance
- Aligns release workflow testing with CI workflow approach

## Problem
The release workflow was failing with all regression tests showing exit code 3, indicating the extension couldn't be loaded properly. This happened after the rename from tapir to pg_textsearch.

## Solution
Modified the release workflow to:
- Create a dedicated PostgreSQL instance using `initdb` on port 55433
- Configure the test instance with proper settings
- Run tests against the dedicated instance instead of system PostgreSQL
- Clean up the test instance after completion

This approach is identical to what the CI workflow uses, ensuring consistent test execution.

## Test plan
- [x] CI workflow continues to pass
- [ ] Release workflow will be tested when this PR is merged and a new tag is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)