### PR TITLE
Fix release workflow permission issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         fi
 
         createdb -h $PWD/tmp_check_shared -p 55433 contrib_regression
-        if ! make installcheck PGHOST=$PWD/tmp_check_shared PGPORT=55433; then
+        if ! sudo env "PATH=$PATH" make installcheck PGHOST=$PWD/tmp_check_shared PGPORT=55433; then
           echo "Tests failed. Showing regression diffs:"
           if [ -f test/regression.diffs ]; then
             cat test/regression.diffs


### PR DESCRIPTION
## Summary
- Fixes release workflow permission issue during make installcheck

## Problem  
The release workflow was failing with "Permission denied" when make installcheck tried to reinstall the extension. The tests were passing but the installation step failed.

## Solution
Use `sudo` for `make installcheck` to match the permissions used during `sudo make install`.

## Test plan
- [ ] CI tests pass
- [ ] Release workflow will be tested after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)