### PR TITLE
Fix release workflow permission error

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -80,6 +80,9 @@ jobs:
 
     - name: Verify package architecture
       run: |
+        # Fix permissions after Docker build (Docker runs as root)
+        sudo chown -R $USER:$USER dist/
+
         # Extract and check the actual binary architecture
         mkdir -p check-arch
         dpkg-deb -x dist/*.deb check-arch/


### PR DESCRIPTION
## Summary
- Fixes the zip archive creation failure in the AMD64 build due to permission denied error
- The Docker container runs as root, creating dist/ directory owned by root
- Added chown command to fix directory ownership before creating zip archive

## Issue
The v0.0.2 release workflow failed with:
```
zip I/O error: Permission denied
zip error: Could not create output file (pg-textsearch-v0.0.2-pg17-amd64.zip)
```

## Testing
The fix adds `sudo chown -R $USER:$USER dist/` after the Docker build completes to ensure the GitHub Actions runner user can write to the directory.

This should allow the release workflow to complete successfully.