### PR TITLE
fix binaries releases

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -195,7 +195,7 @@ jobs:
         # The TimescaleDB builder image should have build tools installed
         # Build the extension
         cd /build
-        export PG_CONFIG=/usr/local/bin/pg_config
+        export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
         make clean
         CFLAGS="-O3 -DNDEBUG" make
 


### PR DESCRIPTION
This PR adds validation to verify PostgreSQL version in release packages and fixes the build script to use the correct version-specific pg_config, preventing pg18 archives from containing pg17 binaries.

related with https://iobeam.slack.com/archives/C09C0ML1XG8/p1763474708641179