### PR TITLE
Add regression test for lock upgrade path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ PG_CPPFLAGS = -I$(srcdir)/src -g -O0 -Wall -Wextra -Wunused-function -Wunused-va
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic deletion vacuum dropped empty index inheritance limits manyterms memory mixed queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 strings updates vector
+REGRESS = aerodocs basic deletion vacuum dropped empty index inheritance limits lock manyterms memory mixed queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 strings updates vector
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/test/expected/lock.out
+++ b/test/expected/lock.out
@@ -1,0 +1,66 @@
+-- Test lock upgrade from shared to exclusive within a single transaction
+-- This exercises the tp_acquire_index_lock upgrade path
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+INFO:  pg_textsearch v0.0.5-dev: This is prerelease software and should not be used in production.
+-- Create test table and index
+CREATE TABLE lock_upgrade_test (
+    id SERIAL PRIMARY KEY,
+    content TEXT NOT NULL
+);
+INSERT INTO lock_upgrade_test (content) VALUES
+    ('database systems and concurrent access'),
+    ('full text search indexing'),
+    ('query optimization techniques');
+CREATE INDEX lock_upgrade_idx ON lock_upgrade_test USING bm25(content)
+    WITH (text_config='english', k1=1.2, b=0.75);
+NOTICE:  BM25 index build started for relation lock_upgrade_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 3 documents, avg_length=3.67, text_config='english' (k1=1.20, b=0.75)
+-- Test: Single transaction that first reads (shared lock) then writes (exclusive lock)
+-- This should trigger the lock upgrade path in tp_acquire_index_lock
+BEGIN;
+-- First operation: SELECT acquires shared lock
+SELECT id, content
+FROM lock_upgrade_test
+WHERE content <@> to_bm25query('database', 'lock_upgrade_idx') < -0.001
+ORDER BY content <@> to_bm25query('database', 'lock_upgrade_idx')
+LIMIT 5;
+ id |                content                 
+----+----------------------------------------
+  1 | database systems and concurrent access
+(1 row)
+
+-- Second operation: INSERT in same transaction should upgrade to exclusive lock
+INSERT INTO lock_upgrade_test (content) VALUES
+    ('new document about database concurrency');
+-- Verify the insert worked
+SELECT COUNT(*) FROM lock_upgrade_test;
+ count 
+-------
+     4
+(1 row)
+
+COMMIT;
+-- Verify final state
+SELECT COUNT(*) FROM lock_upgrade_test;
+ count 
+-------
+     4
+(1 row)
+
+-- Test that subsequent operations work normally
+SELECT id, content
+FROM lock_upgrade_test
+WHERE content <@> to_bm25query('database concurrency', 'lock_upgrade_idx') < -0.001
+ORDER BY content <@> to_bm25query('database concurrency', 'lock_upgrade_idx')
+LIMIT 5;
+ id |                 content                 
+----+-----------------------------------------
+  1 | database systems and concurrent access
+  4 | new document about database concurrency
+(2 rows)
+
+-- Clean up
+DROP TABLE lock_upgrade_test CASCADE;
+DROP EXTENSION pg_textsearch;

--- a/test/sql/lock.sql
+++ b/test/sql/lock.sql
@@ -1,0 +1,52 @@
+-- Test lock upgrade from shared to exclusive within a single transaction
+-- This exercises the tp_acquire_index_lock upgrade path
+
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+-- Create test table and index
+CREATE TABLE lock_upgrade_test (
+    id SERIAL PRIMARY KEY,
+    content TEXT NOT NULL
+);
+
+INSERT INTO lock_upgrade_test (content) VALUES
+    ('database systems and concurrent access'),
+    ('full text search indexing'),
+    ('query optimization techniques');
+
+CREATE INDEX lock_upgrade_idx ON lock_upgrade_test USING bm25(content)
+    WITH (text_config='english', k1=1.2, b=0.75);
+
+-- Test: Single transaction that first reads (shared lock) then writes (exclusive lock)
+-- This should trigger the lock upgrade path in tp_acquire_index_lock
+BEGIN;
+
+-- First operation: SELECT acquires shared lock
+SELECT id, content
+FROM lock_upgrade_test
+WHERE content <@> to_bm25query('database', 'lock_upgrade_idx') < -0.001
+ORDER BY content <@> to_bm25query('database', 'lock_upgrade_idx')
+LIMIT 5;
+
+-- Second operation: INSERT in same transaction should upgrade to exclusive lock
+INSERT INTO lock_upgrade_test (content) VALUES
+    ('new document about database concurrency');
+
+-- Verify the insert worked
+SELECT COUNT(*) FROM lock_upgrade_test;
+
+COMMIT;
+
+-- Verify final state
+SELECT COUNT(*) FROM lock_upgrade_test;
+
+-- Test that subsequent operations work normally
+SELECT id, content
+FROM lock_upgrade_test
+WHERE content <@> to_bm25query('database concurrency', 'lock_upgrade_idx') < -0.001
+ORDER BY content <@> to_bm25query('database concurrency', 'lock_upgrade_idx')
+LIMIT 5;
+
+-- Clean up
+DROP TABLE lock_upgrade_test CASCADE;
+DROP EXTENSION pg_textsearch;


### PR DESCRIPTION
Add test that exercises the lock upgrade from shared to exclusive within a single transaction. Tests the tp_acquire_index_lock() upgrade path when SELECT (shared lock) is followed by INSERT (exclusive lock) in the same transaction.

Extracted from #26 as a standalone test addition.

## Testing
- New test passes in regression suite
- All 24 regression tests pass