### PR TITLE
Bump version to 0.0.6-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 EXTENSION = pg_textsearch
-DATA = sql/pg_textsearch--0.0.5.sql \
+DATA = sql/pg_textsearch--0.0.6-dev.sql \
        sql/pg_textsearch--0.0.1--0.0.3.sql \
        sql/pg_textsearch--0.0.2--0.0.3.sql \
        sql/pg_textsearch--0.0.3--0.0.4.sql \
-       sql/pg_textsearch--0.0.4--0.0.5.sql
+       sql/pg_textsearch--0.0.4--0.0.5.sql \
+       sql/pg_textsearch--0.0.5--0.0.6-dev.sql
 
 # Source files
 # Full build - debugging initialization crash

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports:
 - PostgreSQL text search configurations (english, french, german, etc.)
 - bm25 index and bm25query data type for fast ranked searches
 
-🚀 **Development Status**: v0.0.5 - Memtable-based
+🚀 **Development Status**: v0.0.6-dev - Memtable-based
 implementation is in place and working. This is prerelease software and should not be used in production.
 
 ## Historical note

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,20 +8,11 @@
 | v0.0.2 | Oct 2025 | Bug fixes, stability improvements |
 | v0.0.3 | Nov 2025 | Crash recovery, concurrency fixes, string-based architecture |
 | v0.0.4 | Nov 2025 | BM25 score validation, PostgreSQL 18 support |
+| v0.0.5 | Dec 2025 | Segment infrastructure, auto-spill, hierarchical merging |
 
-## Current (v0.0.5)
+## Current (v0.0.6-dev)
 
-Naive segment implementation - scalable beyond main memory.
-
-| Feature | Status |
-|---------|--------|
-| Segment infrastructure (disk storage) | Done |
-| Segment query execution | Done |
-| Auto-spill memtable to segments | Done |
-| Segment chain traversal | Done |
-| Crash recovery for segments | Done |
-| Segment compaction | Not started |
-| DELETE/UPDATE propagation to segments | Not started |
+Development version - segment improvements in progress.
 
 ## Future
 

--- a/pg_textsearch.control
+++ b/pg_textsearch.control
@@ -1,5 +1,5 @@
 # pg_textsearch extension
 comment = 'Full-text search with BM25 ranking'
-default_version = '0.0.5'
+default_version = '0.0.6-dev'
 module_pathname = '$libdir/pg_textsearch'
 relocatable = true

--- a/sql/pg_textsearch--0.0.5--0.0.6-dev.sql
+++ b/sql/pg_textsearch--0.0.5--0.0.6-dev.sql
@@ -1,0 +1,2 @@
+-- Upgrade from 0.0.5 to 0.0.6-dev
+-- No schema changes in this version

--- a/sql/pg_textsearch--0.0.6-dev.sql
+++ b/sql/pg_textsearch--0.0.6-dev.sql
@@ -1,0 +1,180 @@
+-- pg_textsearch extension version 0.0.6-dev
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_textsearch" to load this file. \quit
+
+-- Access method
+
+CREATE FUNCTION tp_handler(internal)
+RETURNS index_am_handler
+AS 'MODULE_PATHNAME', 'tp_handler'
+LANGUAGE C;
+
+CREATE ACCESS METHOD bm25 TYPE INDEX HANDLER tp_handler;
+
+-- bm25vector type
+
+CREATE FUNCTION bm25vector_in(cstring)
+RETURNS bm25vector
+AS 'MODULE_PATHNAME', 'tpvector_in'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION bm25vector_out(bm25vector)
+RETURNS cstring
+AS 'MODULE_PATHNAME', 'tpvector_out'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION bm25vector_recv(internal)
+RETURNS bm25vector
+AS 'MODULE_PATHNAME', 'tpvector_recv'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION bm25vector_send(bm25vector)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'tpvector_send'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE TYPE bm25vector (
+    INPUT = bm25vector_in,
+    OUTPUT = bm25vector_out,
+    RECEIVE = bm25vector_recv,
+    SEND = bm25vector_send,
+    STORAGE = extended,
+    ALIGNMENT = int4
+);
+
+-- Convert text to a bm25vector, using specified index
+CREATE FUNCTION to_bm25vector(input_text text, index_name text)
+RETURNS bm25vector
+AS 'MODULE_PATHNAME', 'to_tpvector'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- bm25query type
+
+CREATE FUNCTION bm25query_in(cstring)
+RETURNS bm25query
+AS 'MODULE_PATHNAME', 'tpquery_in'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION bm25query_out(bm25query)
+RETURNS cstring
+AS 'MODULE_PATHNAME', 'tpquery_out'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION bm25query_recv(internal)
+RETURNS bm25query
+AS 'MODULE_PATHNAME', 'tpquery_recv'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION bm25query_send(bm25query)
+RETURNS bytea
+AS 'MODULE_PATHNAME', 'tpquery_send'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE TYPE bm25query (
+    INPUT = bm25query_in,
+    OUTPUT = bm25query_out,
+    RECEIVE = bm25query_recv,
+    SEND = bm25query_send,
+    STORAGE = extended,
+    ALIGNMENT = int4
+);
+
+-- Convert text to bm25query
+CREATE FUNCTION to_bm25query(input_text text)
+RETURNS bm25query
+AS 'MODULE_PATHNAME', 'to_tpquery_text'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION to_bm25query(input_text text, index_name text)
+RETURNS bm25query
+AS 'MODULE_PATHNAME', 'to_tpquery_text_index'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+
+-- Equality function: bm25vector = bm25vector → boolean
+CREATE FUNCTION bm25vector_eq(bm25vector, bm25vector)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tpvector_eq'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Create the = operator for equality
+CREATE OPERATOR = (
+    LEFTARG = bm25vector,
+    RIGHTARG = bm25vector,
+    FUNCTION = bm25vector_eq,
+    COMMUTATOR = =,
+    HASHES
+);
+
+
+-- BM25 scoring function for text <@> bm25query operations
+CREATE FUNCTION text_bm25query_score(left_text text, right_query bm25query)
+RETURNS float8
+AS 'MODULE_PATHNAME', 'text_tpquery_score'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- bm25query equality function
+CREATE FUNCTION bm25query_eq(bm25query, bm25query)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tpquery_eq'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+
+
+-- <@> operator for text <@> bm25query operations
+CREATE OPERATOR <@> (
+    LEFTARG = text,
+    RIGHTARG = bm25query,
+    PROCEDURE = text_bm25query_score
+);
+
+-- = operator for bm25query equality
+CREATE OPERATOR = (
+    LEFTARG = bm25query,
+    RIGHTARG = bm25query,
+    FUNCTION = bm25query_eq,
+    COMMUTATOR = =,
+    HASHES
+);
+
+-- Support function for calculating BM25 distances (negative scores for ASC ordering)
+CREATE FUNCTION bm25_distance(text, bm25query) RETURNS float8
+    AS 'MODULE_PATHNAME', 'tp_distance'
+    LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- bm25 operator class for text columns
+CREATE OPERATOR CLASS text_bm25_ops
+DEFAULT FOR TYPE text USING bm25 AS
+    OPERATOR    1   <@> (text, bm25query) FOR ORDER BY float_ops,
+    FUNCTION    8   bm25_distance(text, bm25query);
+
+-- Debug function to dump index contents (memtable and segments)
+-- Single argument version returns truncated output as text
+CREATE FUNCTION bm25_dump_index(text) RETURNS text
+    AS 'MODULE_PATHNAME', 'tp_dump_index'
+    LANGUAGE C STRICT STABLE;
+
+-- Two argument version writes full dump (with hex) to file
+CREATE FUNCTION bm25_dump_index(text, text) RETURNS text
+    AS 'MODULE_PATHNAME', 'tp_dump_index'
+    LANGUAGE C STRICT STABLE;
+
+-- Display warning about prerelease status
+DO $$
+BEGIN
+    RAISE INFO 'pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.';
+    RAISE INFO 'This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.';
+END
+$$;
+
+-- Function to force segment write (spill memtable to disk)
+CREATE OR REPLACE FUNCTION bm25_spill_index(index_name text)
+RETURNS int4
+AS 'MODULE_PATHNAME', 'tp_spill_memtable'
+LANGUAGE C VOLATILE STRICT;
+
+-- Fast summary function showing only statistics (no content dump)
+CREATE FUNCTION bm25_summarize_index(text) RETURNS text
+    AS 'MODULE_PATHNAME', 'tp_summarize_index'
+    LANGUAGE C STRICT STABLE;

--- a/src/mod.c
+++ b/src/mod.c
@@ -20,7 +20,7 @@
 #include "state.h"
 
 #if PG_VERSION_NUM >= 180000
-PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "0.0.5");
+PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "0.0.6-dev");
 #else
 PG_MODULE_MAGIC;
 #endif

--- a/test/expected/aerodocs.out
+++ b/test/expected/aerodocs.out
@@ -4,7 +4,7 @@
 -- Tests both dataset loading and pg_textsearch scoring functionality with the <@> operator
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 -- Enable score logging for testing

--- a/test/expected/basic.out
+++ b/test/expected/basic.out
@@ -1,7 +1,7 @@
 -- Basic functionality tests for pg_textsearch extension
 -- Test extension creation
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/deletion.out
+++ b/test/expected/deletion.out
@@ -1,7 +1,7 @@
 -- Test handling of row deletions in indexed tables
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 CREATE TABLE deletion_test (

--- a/test/expected/dropped.out
+++ b/test/expected/dropped.out
@@ -1,7 +1,7 @@
 -- Test behavior when using a dropped index name in queries
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 CREATE TABLE dropped_idx_test (

--- a/test/expected/empty.out
+++ b/test/expected/empty.out
@@ -1,7 +1,7 @@
 -- Test handling of empty and whitespace-only documents
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table with various empty/whitespace content
 CREATE TABLE empty_docs (

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -1,7 +1,7 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/index_1.out
+++ b/test/expected/index_1.out
@@ -1,7 +1,7 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/inheritance.out
+++ b/test/expected/inheritance.out
@@ -1,7 +1,7 @@
 -- Test BM25 index behavior with table inheritance and partitioning
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Test 1: PostgreSQL native table inheritance
 -- Create parent and child tables

--- a/test/expected/limits.out
+++ b/test/expected/limits.out
@@ -3,7 +3,7 @@
 SET log_duration = off;
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/lock.out
+++ b/test/expected/lock.out
@@ -1,7 +1,7 @@
 -- Test lock upgrade from shared to exclusive within a single transaction
 -- This exercises the tp_acquire_index_lock upgrade path
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table and index
 CREATE TABLE lock_upgrade_test (

--- a/test/expected/manyterms.out
+++ b/test/expected/manyterms.out
@@ -2,7 +2,7 @@
 -- This test creates enough unique terms to trigger hash table resize
 -- and verifies the system continues to work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/memory.out
+++ b/test/expected/memory.out
@@ -1,7 +1,7 @@
 -- Test memory limit enforcement for pg_textsearch indexes
 -- Create extension if not exists
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 DROP TABLE IF EXISTS memory_test CASCADE;

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -9,7 +9,7 @@
 -- Known issue: Query code only searches L0 segments (level_heads[0]).
 -- After merge, data in L1 won't be found until this is fixed.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = false;

--- a/test/expected/mixed.out
+++ b/test/expected/mixed.out
@@ -2,7 +2,7 @@
 -- This test verifies that concurrent access to shared memory structures is safe
 -- and that operations like inserts, searches, and index building work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/queries.out
+++ b/test/expected/queries.out
@@ -1,7 +1,7 @@
 -- This test demonstrates top-k pg_textsearch query patterns for efficient text search
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/queries_1.out
+++ b/test/expected/queries_1.out
@@ -1,7 +1,7 @@
 -- This test demonstrates top-k pg_textsearch query patterns for efficient text search
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/schema.out
+++ b/test/expected/schema.out
@@ -1,7 +1,7 @@
 -- Test case: schema
 -- Tests index operations with schema-qualified tables
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring1.out
+++ b/test/expected/scoring1.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring2.out
+++ b/test/expected/scoring2.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 5 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring3.out
+++ b/test/expected/scoring3.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 3 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring4.out
+++ b/test/expected/scoring4.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 1 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring5.out
+++ b/test/expected/scoring5.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 3 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring6.out
+++ b/test/expected/scoring6.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 3 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/segment.out
+++ b/test/expected/segment.out
@@ -2,7 +2,7 @@
 -- Tests segment query functionality with multiple spill cycles and
 -- post-spill inserts
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = false;

--- a/test/expected/strings.out
+++ b/test/expected/strings.out
@@ -1,7 +1,7 @@
 -- Test long string handling including URLs, paths, and long terms
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/updates.out
+++ b/test/expected/updates.out
@@ -2,7 +2,7 @@
 -- This test reproduces the NULL index_state crash reported in production
 -- Install the extension if not already installed
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Test basic UPDATE operations
 CREATE TABLE update_test (

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -1,7 +1,7 @@
 -- Test VACUUM behavior with BM25 indexes
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 CREATE TABLE vacuum_test (

--- a/test/expected/vector.out
+++ b/test/expected/vector.out
@@ -1,7 +1,7 @@
 -- Test bm25vector type and operators functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.5: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.0.6-dev: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;


### PR DESCRIPTION
## Summary
- Post-release version bump from v0.0.5 to 0.0.6-dev
- Updates version strings in control file, source code, docs, and tests
- Creates new SQL file and migration script for the new version
- Adds v0.0.5 to release history in ROADMAP.md

## Testing
All 26 regression tests pass.