### PR TITLE
Add COST 1000 to text_bm25query_score for planner optimization

### DIFF
--- a/sql/pg_textsearch--0.0.5--0.0.6-dev.sql
+++ b/sql/pg_textsearch--0.0.5--0.0.6-dev.sql
@@ -1,2 +1,5 @@
 -- Upgrade from 0.0.5 to 0.0.6-dev
--- No schema changes in this version
+
+-- Update function cost to help planner prefer index scans over seq scan + sort.
+-- Standalone BM25 scoring is expensive (~14μs per doc for tokenization alone).
+ALTER FUNCTION text_bm25query_score(text, bm25query) COST 1000;

--- a/sql/pg_textsearch--0.0.6-dev.sql
+++ b/sql/pg_textsearch--0.0.6-dev.sql
@@ -109,10 +109,14 @@ CREATE OPERATOR = (
 
 
 -- BM25 scoring function for text <@> bm25query operations
+--
+-- COST 1000: Standalone scoring is expensive. Each call parses document text
+-- with to_tsvector (~14μs per doc), opens the index, looks up IDF values, and
+-- calculates BM25 scores. High cost helps planner prefer index scans.
 CREATE FUNCTION text_bm25query_score(left_text text, right_query bm25query)
 RETURNS float8
 AS 'MODULE_PATHNAME', 'text_tpquery_score'
-LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE COST 1000;
 
 -- bm25query equality function
 CREATE FUNCTION bm25query_eq(bm25query, bm25query)


### PR DESCRIPTION
## Summary
- Add COST 1000 to `text_bm25query_score` function to help planner prefer index scans

## Background
Standalone BM25 scoring is expensive: each call parses document text with `to_tsvector` (~14μs per doc), opens the index, looks up IDF values, and calculates BM25 scores.

Without proper cost estimation, the planner may choose sequential scan + sort over index scan, leading to slow queries on large tables.

**Empirical basis:** Indexing 2.1M slack messages took 37s on release build. ~80% is tokenization = ~14μs per document, which is ~140x `cpu_operator_cost`. We use COST 1000 to strongly prefer index scans.

## Testing
Existing tests pass. This is a planner hint only - no functional change.