### PR TITLE
Remove to_bm25vector and document development functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,6 @@ CREATE INDEX docs_idx ON documents USING bm25(content) WITH (text_config='englis
 SELECT schemaname, tablename, indexname, idx_scan, idx_tup_read, idx_tup_fetch
 FROM pg_stat_user_indexes
 WHERE indexrelid::regclass::text ~ 'pg_textsearch';
-
--- Debug index internal structure (shows term dictionary and posting lists)
-SELECT bm25_dump_index('index_name');
 ```
 
 ### Configuration
@@ -377,6 +374,32 @@ Available configurations depend on your Postgres installation:
 (29 rows)
 ```
 Further language support is available via extensions such as [zhparser](https://github.com/amutu/zhparser).
+
+### Development Functions
+
+These functions are for debugging and development use only. Their interface may
+change in future releases without notice.
+
+Function | Description
+--- | ---
+bm25_dump_index(index_name) → text | Dump internal index structure (truncated)
+bm25_dump_index(index_name, file_path) → text | Dump full index structure to file
+bm25_summarize_index(index_name) → text | Show index statistics without content
+bm25_spill_index(index_name) → int4 | Force memtable spill to disk segment
+
+```sql
+-- Quick overview of index statistics
+SELECT bm25_summarize_index('docs_idx');
+
+-- Detailed dump for debugging (truncated output)
+SELECT bm25_dump_index('docs_idx');
+
+-- Full dump to file (includes hex data)
+SELECT bm25_dump_index('docs_idx', '/tmp/docs_idx_dump.txt');
+
+-- Force spill to disk (returns number of entries spilled)
+SELECT bm25_spill_index('docs_idx');
+```
 
 ## Development
 

--- a/sql/pg_textsearch--0.0.6-dev.sql
+++ b/sql/pg_textsearch--0.0.6-dev.sql
@@ -43,12 +43,6 @@ CREATE TYPE bm25vector (
     ALIGNMENT = int4
 );
 
--- Convert text to a bm25vector, using specified index
-CREATE FUNCTION to_bm25vector(input_text text, index_name text)
-RETURNS bm25vector
-AS 'MODULE_PATHNAME', 'to_tpvector'
-LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 -- bm25query type
 
 CREATE FUNCTION bm25query_in(cstring)

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -43,19 +43,6 @@ Not-null constraints:
 
 -- Test basic index operations
 INSERT INTO test_docs (content) VALUES ('new document for testing');
--- Test that to_bm25vector works with our indexes
-SELECT to_bm25vector('test document content', 'docs_english_idx');
-                 to_bm25vector                  
-------------------------------------------------
- docs_english_idx:{content:1,document:1,test:1}
-(1 row)
-
-SELECT to_bm25vector('test document content', 'docs_simple_idx');
-                 to_bm25vector                 
------------------------------------------------
- docs_simple_idx:{content:1,document:1,test:1}
-(1 row)
-
 -- Test that index options are correctly stored and retrievable
 SELECT
     i.relname as index_name,
@@ -71,23 +58,6 @@ ORDER BY i.relname;
  docs_english_idx | has_options
  docs_simple_idx  | has_options
 (2 rows)
-
--- Test vectorization with both indexes
-SELECT
-    'docs_english_idx' as index_name,
-    to_bm25vector('postgresql database system', 'docs_english_idx') as vector;
-    index_name    |                       vector                       
-------------------+----------------------------------------------------
- docs_english_idx | docs_english_idx:{databas:1,postgresql:1,system:1}
-(1 row)
-
-SELECT
-    'docs_simple_idx' as index_name,
-    to_bm25vector('postgresql database system', 'docs_simple_idx') as vector;
-   index_name    |                       vector                       
------------------+----------------------------------------------------
- docs_simple_idx | docs_simple_idx:{database:1,postgresql:1,system:1}
-(1 row)
 
 -- Cleanup
 DROP INDEX docs_english_idx;

--- a/test/expected/index_1.out
+++ b/test/expected/index_1.out
@@ -41,19 +41,6 @@ Indexes:
 
 -- Test basic index operations
 INSERT INTO test_docs (content) VALUES ('new document for testing');
--- Test that to_bm25vector works with our indexes
-SELECT to_bm25vector('test document content', 'docs_english_idx');
-                 to_bm25vector                  
-------------------------------------------------
- docs_english_idx:{content:1,document:1,test:1}
-(1 row)
-
-SELECT to_bm25vector('test document content', 'docs_simple_idx');
-                 to_bm25vector                 
------------------------------------------------
- docs_simple_idx:{content:1,document:1,test:1}
-(1 row)
-
 -- Test that index options are correctly stored and retrievable
 SELECT
     i.relname as index_name,
@@ -69,23 +56,6 @@ ORDER BY i.relname;
  docs_english_idx | has_options
  docs_simple_idx  | has_options
 (2 rows)
-
--- Test vectorization with both indexes
-SELECT
-    'docs_english_idx' as index_name,
-    to_bm25vector('postgresql database system', 'docs_english_idx') as vector;
-    index_name    |                       vector                       
-------------------+----------------------------------------------------
- docs_english_idx | docs_english_idx:{databas:1,postgresql:1,system:1}
-(1 row)
-
-SELECT
-    'docs_simple_idx' as index_name,
-    to_bm25vector('postgresql database system', 'docs_simple_idx') as vector;
-   index_name    |                       vector                       
------------------+----------------------------------------------------
- docs_simple_idx | docs_simple_idx:{database:1,postgresql:1,system:1}
-(1 row)
 
 -- Cleanup
 DROP INDEX docs_english_idx;

--- a/test/expected/strings.out
+++ b/test/expected/strings.out
@@ -84,21 +84,7 @@ NOTICE:  BM25 index scan: tid=(0,4), BM25_score=-4.4319
   4 | Error in file /usr/local/lib/postgresql/extensions/tapir/src... | -4.4319
 (2 rows)
 
--- Test 4: Test vectorization of very long URLs
-SELECT to_bm25vector('https://www.very-long-domain-name-for-testing-url-tokenization.example.com/extremely/long/path/with/many/segments/and/parameters?param1=value1&param2=value2&param3=value3', 'long_strings_idx');
-                                                                                                                                                                          to_bm25vector                                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- long_strings_idx:{/extremely/long/path/with/many/segments/and/parameters?param1=value1&param2=value2&param3=value3:1,www.very-long-domain-name-for-testing-url-tokenization.example.com:1,www.very-long-domain-name-for-testing-url-tokenization.example.com/extremely/long/path/with/many/segments/and/parameters?param1=value1&param2=value2&param3=value3:1}
-(1 row)
-
--- Test 5: Test extremely long single term handling
-SELECT to_bm25vector('supercalifragilisticexpialidociouspneumonoultramicroscopicsilicovolcanoconiosisantidisestablishmentarianism', 'long_strings_idx');
-                                                         to_bm25vector                                                         
--------------------------------------------------------------------------------------------------------------------------------
- long_strings_idx:{supercalifragilisticexpialidociouspneumonoultramicroscopicsilicovolcanoconiosisantidisestablishmentarian:1}
-(1 row)
-
--- Test 6: Test mixed long and short terms
+-- Test 4: Test mixed long and short terms
 SELECT * FROM (
     SELECT id, ROUND((content <@> 'algorithm bm25')::numeric, 4) as score
     FROM long_string_docs
@@ -120,7 +106,7 @@ NOTICE:  BM25 index scan: tid=(0,7), BM25_score=-0.5925
   7 | -0.5925
 (5 rows)
 
--- Test 7: Performance test with multiple long term queries
+-- Test 5: Performance test with multiple long term queries
 SELECT * FROM (
     SELECT
         id,
@@ -141,16 +127,7 @@ NOTICE:  BM25 index scan: tid=(0,10), BM25_score=-0.7182
  10 | json     |          -0.7182
 (3 rows)
 
--- Test 8: Test URL tokenization specifics
-SELECT
-    'URL components' as test_type,
-    to_bm25vector('https://example.com/path?param=value', 'long_strings_idx') as url_vector;
-   test_type    |                                     url_vector                                      
-----------------+-------------------------------------------------------------------------------------
- URL components | long_strings_idx:{/path?param=value:1,example.com:1,example.com/path?param=value:1}
-(1 row)
-
--- Test 9: Test that very long terms don't cause memory issues
+-- Test 6: Test that very long terms don't cause memory issues
 INSERT INTO long_string_docs (content, category) VALUES
     ('This document contains a ridiculously long compound word: ' ||
      'antidisestablishmentarianismpneumonoultramicroscopicsilicovolcanoconiosis' ||
@@ -175,7 +152,7 @@ NOTICE:  BM25 index scan: tid=(0,7), BM25_score=-1.5143
   7 | Function name: tp_calculate_bm25_relevance_score_w... | -1.5143
 (3 rows)
 
--- Test 10: Memory usage statistics after indexing long strings
+-- Test 7: Memory usage statistics after indexing long strings
 SELECT
     COUNT(*) as total_documents,
     AVG(LENGTH(content)) as avg_content_length,
@@ -188,7 +165,7 @@ FROM long_string_docs;
               11 | 179.7272727272727273 |                268 |              4 |                   0
 (1 row)
 
--- Test 11: Test stack/heap threshold boundary (1KB limit for alloca)
+-- Test 8: Test stack/heap threshold boundary (1KB limit for alloca)
 INSERT INTO long_string_docs (content, category) VALUES
     -- Just under 1KB threshold (should use stack allocation)
     ('Short term: ' || REPEAT('stackallocation', 40), 'stack_test'),
@@ -219,7 +196,7 @@ ORDER BY content_length;
  14 | mixed_allocation |           1730 | Heap allocation likely  | -1.3618
 (3 rows)
 
--- Test 12: Extreme length document (tests PostgreSQL's text limit handling)
+-- Test 9: Extreme length document (tests PostgreSQL's text limit handling)
 INSERT INTO long_string_docs (content, category) VALUES
     ('Extreme test: ' || REPEAT('This is a very long repeated phrase for testing PostgreSQL text limits and our hybrid stack heap allocation strategy. ', 200), 'extreme');
 -- Verify extreme length document indexing

--- a/test/expected/vector.out
+++ b/test/expected/vector.out
@@ -41,53 +41,6 @@ SELECT 'docs_vector_idx:{}'::bm25vector;
  docs_vector_idx:{}
 (1 row)
 
--- Test to_bm25vector function
-SELECT to_bm25vector('hello world', 'docs_vector_idx');
-           to_bm25vector           
------------------------------------
- docs_vector_idx:{hello:1,world:1}
-(1 row)
-
-SELECT to_bm25vector('postgresql search', 'docs_vector_idx');
-              to_bm25vector              
------------------------------------------
- docs_vector_idx:{postgresql:1,search:1}
-(1 row)
-
--- Test to_bm25vector edge cases
-SELECT to_bm25vector('', 'docs_vector_idx');  -- empty text
-   to_bm25vector    
---------------------
- docs_vector_idx:{}
-(1 row)
-
-SELECT to_bm25vector('hello, world! How are you? I''m fine.', 'docs_vector_idx');  -- punctuation
-                to_bm25vector                 
-----------------------------------------------
- docs_vector_idx:{fine:1,hello:1,m:1,world:1}
-(1 row)
-
-SELECT to_bm25vector('Testing 123 with numbers and text', 'docs_vector_idx');  -- numbers
-                 to_bm25vector                  
-------------------------------------------------
- docs_vector_idx:{123:1,number:1,test:1,text:1}
-(1 row)
-
--- Test that different queries create different vectors
-SELECT to_bm25vector('hello', 'docs_vector_idx') = to_bm25vector('world', 'docs_vector_idx');
- ?column? 
-----------
- f
-(1 row)
-
--- Test error cases (bm25vector <@> bm25vector operator removed for consistency)
--- Test nonexistent index error
-\set VERBOSITY terse
-\set ON_ERROR_STOP off
-SELECT to_bm25vector('test text', 'nonexistent_index');
-ERROR:  index "nonexistent_index" not found
-\set ON_ERROR_STOP on
-\set VERBOSITY default
 -- Test pg_textsearch scoring using text <@> bm25query operations
 -- Note: Uses to_bm25query since ORDER BY is on alias not directly on operator
 SELECT
@@ -122,36 +75,7 @@ ORDER BY (content <@> to_bm25query('postgresql', 'docs_vector_idx'))::float8 +
  hello world example         |           0.0000 |       0.0000
 (5 rows)
 
--- Test vector serialization/deserialization
-SELECT to_bm25vector('hello', 'docs_vector_idx')::text;
-       to_bm25vector       
----------------------------
- docs_vector_idx:{hello:1}
-(1 row)
-
-SELECT to_bm25vector('test word', 'docs_vector_idx')::text;
-          to_bm25vector          
----------------------------------
- docs_vector_idx:{test:1,word:1}
-(1 row)
-
--- Test with longer text
-SELECT to_bm25vector('this is a longer test with multiple words and repetitions test test', 'docs_vector_idx');
-                        to_bm25vector                         
---------------------------------------------------------------
- docs_vector_idx:{longer:1,multipl:1,repetit:1,test:3,word:1}
-(1 row)
-
 -- Test bm25vector equality operator
-SELECT
-    to_bm25vector('hello world', 'docs_vector_idx') = to_bm25vector('hello world', 'docs_vector_idx') as should_be_true,
-    to_bm25vector('hello world', 'docs_vector_idx') = to_bm25vector('world hello', 'docs_vector_idx') as depends_on_order;
- should_be_true | depends_on_order 
-----------------+------------------
- t              | t
-(1 row)
-
--- Test direct bm25vector equality (including order-independence fix)
 SELECT 'docs_vector_idx:{hello:1,world:2}'::bm25vector = 'docs_vector_idx:{hello:1,world:2}'::bm25vector;
  ?column? 
 ----------
@@ -184,16 +108,6 @@ NOTICE:  BM25 index build started for relation docs_simple_idx
 NOTICE:  Using text search configuration: simple
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 5 documents, avg_length=4.00, text_config='simple' (k1=1.20, b=0.75)
--- Compare stemmed vs non-stemmed
-SELECT
-    'running' as query,
-    to_bm25vector('running runner runs', 'docs_vector_idx') as english_stemmed,
-    to_bm25vector('running runner runs', 'docs_simple_idx') as simple_no_stem;
-  query  |         english_stemmed          |               simple_no_stem                
----------+----------------------------------+---------------------------------------------
- running | docs_vector_idx:{run:2,runner:1} | docs_simple_idx:{runner:1,running:1,runs:1}
-(1 row)
-
 -- Test scoring consistency: ORDER BY vs standalone scoring
 \echo 'Testing ORDER BY vs standalone scoring consistency'
 Testing ORDER BY vs standalone scoring consistency

--- a/test/sql/index.sql
+++ b/test/sql/index.sql
@@ -29,10 +29,6 @@ CREATE INDEX docs_simple_idx ON test_docs USING bm25(content) WITH (text_config=
 -- Test basic index operations
 INSERT INTO test_docs (content) VALUES ('new document for testing');
 
--- Test that to_bm25vector works with our indexes
-SELECT to_bm25vector('test document content', 'docs_english_idx');
-SELECT to_bm25vector('test document content', 'docs_simple_idx');
-
 -- Test that index options are correctly stored and retrievable
 SELECT
     i.relname as index_name,
@@ -43,15 +39,6 @@ SELECT
 FROM pg_class i
 WHERE i.relname IN ('docs_english_idx', 'docs_simple_idx')
 ORDER BY i.relname;
-
--- Test vectorization with both indexes
-SELECT
-    'docs_english_idx' as index_name,
-    to_bm25vector('postgresql database system', 'docs_english_idx') as vector;
-
-SELECT
-    'docs_simple_idx' as index_name,
-    to_bm25vector('postgresql database system', 'docs_simple_idx') as vector;
 
 -- Cleanup
 DROP INDEX docs_english_idx;

--- a/test/sql/strings.sql
+++ b/test/sql/strings.sql
@@ -70,13 +70,7 @@ SELECT * FROM (
 ) AS subquery
 ORDER BY score, id;
 
--- Test 4: Test vectorization of very long URLs
-SELECT to_bm25vector('https://www.very-long-domain-name-for-testing-url-tokenization.example.com/extremely/long/path/with/many/segments/and/parameters?param1=value1&param2=value2&param3=value3', 'long_strings_idx');
-
--- Test 5: Test extremely long single term handling
-SELECT to_bm25vector('supercalifragilisticexpialidociouspneumonoultramicroscopicsilicovolcanoconiosisantidisestablishmentarianism', 'long_strings_idx');
-
--- Test 6: Test mixed long and short terms
+-- Test 4: Test mixed long and short terms
 SELECT * FROM (
     SELECT id, ROUND((content <@> 'algorithm bm25')::numeric, 4) as score
     FROM long_string_docs
@@ -85,7 +79,7 @@ SELECT * FROM (
 ) AS subquery
 ORDER BY score, id;
 
--- Test 7: Performance test with multiple long term queries
+-- Test 5: Performance test with multiple long term queries
 SELECT * FROM (
     SELECT
         id,
@@ -97,12 +91,7 @@ SELECT * FROM (
 ) AS subquery
 ORDER BY multi_term_score, id;
 
--- Test 8: Test URL tokenization specifics
-SELECT
-    'URL components' as test_type,
-    to_bm25vector('https://example.com/path?param=value', 'long_strings_idx') as url_vector;
-
--- Test 9: Test that very long terms don't cause memory issues
+-- Test 6: Test that very long terms don't cause memory issues
 INSERT INTO long_string_docs (content, category) VALUES
     ('This document contains a ridiculously long compound word: ' ||
      'antidisestablishmentarianismpneumonoultramicroscopicsilicovolcanoconiosis' ||
@@ -119,7 +108,7 @@ SELECT * FROM (
 ) AS subquery
 ORDER BY score, id;
 
--- Test 10: Memory usage statistics after indexing long strings
+-- Test 7: Memory usage statistics after indexing long strings
 SELECT
     COUNT(*) as total_documents,
     AVG(LENGTH(content)) as avg_content_length,
@@ -128,7 +117,7 @@ SELECT
     COUNT(CASE WHEN LENGTH(content) > 500 THEN 1 END) as very_long_documents
 FROM long_string_docs;
 
--- Test 11: Test stack/heap threshold boundary (1KB limit for alloca)
+-- Test 8: Test stack/heap threshold boundary (1KB limit for alloca)
 INSERT INTO long_string_docs (content, category) VALUES
     -- Just under 1KB threshold (should use stack allocation)
     ('Short term: ' || REPEAT('stackallocation', 40), 'stack_test'),
@@ -154,7 +143,7 @@ WHERE category IN ('stack_test', 'heap_test', 'mixed_allocation')
     AND content <@> 'term allocation' < 0
 ORDER BY content_length;
 
--- Test 12: Extreme length document (tests PostgreSQL's text limit handling)
+-- Test 9: Extreme length document (tests PostgreSQL's text limit handling)
 INSERT INTO long_string_docs (content, category) VALUES
     ('Extreme test: ' || REPEAT('This is a very long repeated phrase for testing PostgreSQL text limits and our hybrid stack heap allocation strategy. ', 200), 'extreme');
 


### PR DESCRIPTION
## Summary

- Remove `to_bm25vector` SQL function (the internal C function `to_tpvector` is still used by the index implementation)
- Add Development Functions section to README documenting `bm25_dump_index`, `bm25_summarize_index`, and `bm25_spill_index`
- Mark these functions clearly as for development use and subject to change in future releases

## Testing

- All 29 regression tests pass
- Concurrency and segment tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)