### PR TITLE
Fix compiler warnings and standardize header guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,19 @@ pip install pre-commit && pre-commit install
 
 ### Code Style
 
+We follow PostgreSQL coding conventions. Key points:
+
 - **Line limit**: 79 characters
 - **Indentation**: Tabs
 - **Brace style**: Allman (opening braces on new lines)
-- **Naming**: PostgreSQL conventions (snake_case)
+- **Naming**: snake_case for functions and variables
 - **Comments**: 2 spaces before trailing comments
+- **Headers**: Use `#pragma once` instead of include guards
+- **Includes**: `postgres.h` must be the first include, followed by standard
+  library headers (with `<>`), then project headers (with `""`)
+
+See the [PostgreSQL coding conventions](https://www.postgresql.org/docs/current/source-format.html)
+for more details.
 
 Format your code before committing:
 ```sh

--- a/src/constants.h
+++ b/src/constants.h
@@ -57,3 +57,13 @@
 #define TP_TRANCHE_POSTING	   1002
 #define TP_TRANCHE_CORPUS	   1003
 #define TP_TRANCHE_DOC_LENGTHS 1004
+
+/*
+ * Global GUC variables declared in mod.c
+ * Note: tp_relopt_kind is declared in index.c as it requires
+ * access/reloptions.h
+ */
+extern bool tp_log_scores;
+extern int	tp_bulk_load_threshold;
+extern int	tp_memtable_spill_threshold;
+extern int	tp_segments_per_level;

--- a/src/dump.c
+++ b/src/dump.c
@@ -247,7 +247,6 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 	int				   segment_count   = 0;
 	uint32			   segment_terms   = 0;
 	uint32			   segment_docs	   = 0;
-	uint64			   segment_tokens  = 0;
 	uint32			   recovery_pages  = 0;
 	uint32			   recovery_docids = 0;
 
@@ -438,7 +437,6 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 					level_segment_count++;
 					segment_terms += header->num_terms;
 					segment_docs += header->num_docs;
-					segment_tokens += header->total_tokens;
 					segment_pages += header->num_pages;
 					seg_size = (Size)header->num_pages * BLCKSZ;
 
@@ -468,7 +466,7 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 		{
 			dump_printf(
 					out,
-					"  Total: %d segments, %lu pages (%.1fMB), "
+					"  Total: %d segments, " UINT64_FORMAT " pages (%.1fMB), "
 					"%u terms, %u docs\n",
 					segment_count,
 					segment_pages,

--- a/src/dump.h
+++ b/src/dump.h
@@ -4,8 +4,7 @@
  *
  * dump.h - Index dump and debugging utilities
  */
-#ifndef DUMP_H
-#define DUMP_H
+#pragma once
 
 #include <postgres.h>
 
@@ -24,7 +23,7 @@ typedef struct DumpOutput
 
 /* Initialize for string output (SQL return) */
 static inline void
-dump_init_string(DumpOutput *out, StringInfo str)
+pg_attribute_unused() dump_init_string(DumpOutput *out, StringInfo str)
 {
 	out->str	   = str;
 	out->fp		   = NULL;
@@ -33,7 +32,7 @@ dump_init_string(DumpOutput *out, StringInfo str)
 
 /* Initialize for file output */
 static inline void
-dump_init_file(DumpOutput *out, FILE *fp)
+pg_attribute_unused() dump_init_file(DumpOutput *out, FILE *fp)
 {
 	out->str	   = NULL;
 	out->fp		   = fp;
@@ -41,11 +40,12 @@ dump_init_file(DumpOutput *out, FILE *fp)
 }
 
 /* Printf-style output */
-static inline void dump_printf(DumpOutput *out, const char *fmt, ...)
-		pg_attribute_printf(2, 3);
+static inline void pg_attribute_unused()
+		dump_printf(DumpOutput *out, const char *fmt, ...)
+				pg_attribute_printf(2, 3);
 
 static inline void
-dump_printf(DumpOutput *out, const char *fmt, ...)
+pg_attribute_unused() dump_printf(DumpOutput *out, const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
@@ -77,7 +77,7 @@ dump_printf(DumpOutput *out, const char *fmt, ...)
 
 /* Check if we should truncate output (only in string mode) */
 static inline bool
-dump_should_truncate(DumpOutput *out, size_t limit)
+pg_attribute_unused() dump_should_truncate(DumpOutput *out, size_t limit)
 {
 	if (out->full_dump)
 		return false;
@@ -92,5 +92,3 @@ extern void tp_dump_index_to_output(const char *index_name, DumpOutput *out);
 /* Summarize index function - declared in dump.c */
 extern void
 tp_summarize_index_to_output(const char *index_name, DumpOutput *out);
-
-#endif /* DUMP_H */

--- a/src/index.h
+++ b/src/index.h
@@ -9,6 +9,7 @@
 #include <postgres.h>
 
 #include <access/amapi.h>
+#include <access/reloptions.h>
 #include <storage/block.h>
 #include <storage/bufpage.h>
 
@@ -120,8 +121,8 @@ extern bool tp_process_document_text(
 		Relation		   index_rel,
 		int32			  *doc_length_out);
 
-/* GUC variable for logging BM25 scores */
-extern bool tp_log_scores;
+/* Relation options kind - initialized in mod.c */
+extern relopt_kind tp_relopt_kind;
 
 /* IDF sum calculation for average IDF */
 extern void tp_calculate_idf_sum(TpLocalIndexState *index_state);

--- a/src/metapage.c
+++ b/src/metapage.c
@@ -39,7 +39,7 @@ typedef struct TpDocidWriterState
 {
 	Oid			index_oid;	/* Index this state is for */
 	BlockNumber last_page;	/* Last docid page written to */
-	int			num_docids; /* Number of docids on that page */
+	uint32		num_docids; /* Number of docids on that page */
 	bool		valid;		/* Is this cache entry valid? */
 } TpDocidWriterState;
 
@@ -428,7 +428,6 @@ tp_recover_from_docid_pages(Relation index)
 	TpDocidPageHeader *docid_header;
 	ItemPointer		   docids;
 	BlockNumber		   current_page;
-	int				   total_recovered = 0;
 
 	/* Get the metapage to find the first docid page */
 	metabuf = ReadBuffer(index, TP_METAPAGE_BLKNO);
@@ -464,7 +463,7 @@ tp_recover_from_docid_pages(Relation index)
 		docids = (ItemPointer)((char *)docid_header +
 							   sizeof(TpDocidPageHeader));
 
-		for (int i = 0; i < docid_header->num_docids; i++)
+		for (uint32 i = 0; i < docid_header->num_docids; i++)
 		{
 			ItemPointer		   ctid = &docids[i];
 			Relation		   heap_rel;
@@ -569,7 +568,6 @@ tp_recover_from_docid_pages(Relation index)
 						}
 						pfree(terms);
 						pfree(frequencies);
-						total_recovered++;
 					}
 
 					/* Free the vector */

--- a/src/mod.c
+++ b/src/mod.c
@@ -20,6 +20,7 @@
 #include <utils/inval.h>
 
 #include "constants.h"
+#include "index.h"
 #include "memtable/memtable.h"
 #include "memtable/posting.h"
 #include "planner.h"

--- a/src/segment/dictionary.h
+++ b/src/segment/dictionary.h
@@ -4,8 +4,7 @@
  *
  * dictionary.h - Term dictionary for disk segments
  */
-#ifndef DICTIONARY_H
-#define DICTIONARY_H
+#pragma once
 
 #include "postgres.h"
 #include "utils/dsa.h"
@@ -28,5 +27,3 @@ typedef struct TermInfo
 extern TermInfo *
 tp_build_dictionary(struct TpLocalIndexState *state, uint32 *num_terms);
 extern void tp_free_dictionary(TermInfo *terms, uint32 num_terms);
-
-#endif /* DICTIONARY_H */

--- a/src/segment/segment.h
+++ b/src/segment/segment.h
@@ -4,8 +4,7 @@
  *
  * segment.h - Disk-based segment structures
  */
-#ifndef SEGMENT_H
-#define SEGMENT_H
+#pragma once
 
 #include "access/htup_details.h"
 #include "postgres.h"
@@ -258,5 +257,3 @@ extern void tp_process_term_in_segments(
 /* Look up doc_freq for a term from segments (for operator scoring) */
 extern uint32 tp_segment_get_doc_freq(
 		Relation index, BlockNumber first_segment, const char *term);
-
-#endif /* SEGMENT_H */

--- a/src/segment/segment_merge.c
+++ b/src/segment/segment_merge.c
@@ -4,19 +4,18 @@
  *
  * segment_merge.c - Segment merge for LSM-style compaction
  */
+#include <postgres.h>
+
+#include <access/relation.h>
+#include <miscadmin.h>
+#include <storage/bufmgr.h>
+#include <utils/memutils.h>
+#include <utils/timestamp.h>
+
 #include "../constants.h"
 #include "../metapage.h"
-#include "access/relation.h"
-#include "miscadmin.h"
-#include "postgres.h"
 #include "segment.h"
 #include "segment_merge.h"
-#include "storage/bufmgr.h"
-#include "utils/memutils.h"
-#include "utils/timestamp.h"
-
-/* External GUC from mod.c */
-extern int tp_segments_per_level;
 
 /*
  * Merge source state - tracks current position in each source segment

--- a/src/segment/segment_merge.h
+++ b/src/segment/segment_merge.h
@@ -4,8 +4,7 @@
  *
  * segment_merge.h - Segment merge for LSM-style compaction
  */
-#ifndef SEGMENT_MERGE_H
-#define SEGMENT_MERGE_H
+#pragma once
 
 #include "postgres.h"
 #include "storage/block.h"
@@ -50,5 +49,3 @@ extern BlockNumber tp_merge_level_segments(Relation index, uint32 level);
  *   level - The level to check (0 = L0, 1 = L1, etc.)
  */
 extern void tp_maybe_compact_level(Relation index, uint32 level);
-
-#endif /* SEGMENT_MERGE_H */

--- a/src/segment/segment_query.c
+++ b/src/segment/segment_query.c
@@ -225,16 +225,16 @@ tp_segment_posting_iterator_next(
  */
 void
 tp_process_term_in_segments(
-		Relation		   index,
-		BlockNumber		   first_segment,
-		const char		  *term,
-		float4			   idf,
-		float4			   query_frequency,
-		float4			   k1,
-		float4			   b,
-		float4			   avg_doc_len,
-		void			  *doc_scores_hash,
-		TpLocalIndexState *local_state)
+		Relation					   index,
+		BlockNumber					   first_segment,
+		const char					  *term,
+		float4						   idf,
+		float4						   query_frequency,
+		float4						   k1,
+		float4						   b,
+		float4						   avg_doc_len,
+		void						  *doc_scores_hash,
+		TpLocalIndexState *local_state pg_attribute_unused())
 {
 	BlockNumber				 current = first_segment;
 	TpSegmentReader			*reader	 = NULL;

--- a/src/state.c
+++ b/src/state.c
@@ -24,6 +24,7 @@
 #include <utils/rel.h>
 #include <utils/snapmgr.h>
 
+#include "constants.h"
 #include "index.h"
 #include "memtable/posting.h"
 #include "memtable/stringtable.h"
@@ -32,9 +33,6 @@
 #include "segment/segment.h"
 #include "segment/segment_merge.h"
 #include "state.h"
-
-/* External GUCs from mod.c */
-extern int tp_bulk_load_threshold;
 
 /* Cache of local index states */
 static HTAB *local_state_cache = NULL;


### PR DESCRIPTION
## Summary
- Fix all compiler warnings for a clean build with `-Wall -Wextra`
- Standardize header files to use `#pragma once`
- Suppress false-positive clangd warnings for static inline functions

## Changes
- Add extern declarations for GUC variables in constants.h and index.h
- Fix format specifiers: use `UINT64_FORMAT` instead of `%lu` for uint64
- Fix sign comparison warnings in metapage.c (use uint32 for loop variables)
- Remove unused variables (`total_recovered`, `segment_tokens`)
- Mark unused parameter with `pg_attribute_unused()` in segment_query.c
- Fix declaration-after-statement warning in index.c
- Add `isset_offset` field to `relopt_parse_elt` initializers
- Convert remaining headers to use `#pragma once`
- Add `pg_attribute_unused()` to static inline functions in dump.h

## Testing
- All 29 regression tests pass
- Format check passes