### PR TITLE
Improve README examples and add crash recovery note

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ disk segments. When the memtable reaches this many posting entries, it
 automatically flushes to a segment at transaction commit. This keeps memory
 usage bounded while maintaining good query performance.
 
+**Crash recovery**: The memtable is rebuilt from the heap on startup, so no
+data is lost if Postgres crashes before spilling to disk.
+
 ## Examples
 
 ### Basic Search
@@ -232,10 +235,10 @@ INSERT INTO articles (title, content) VALUES
     ('Search Technology', 'Full text search enables finding relevant documents quickly'),
     ('Information Retrieval', 'BM25 is a ranking function used in search engines');
 
--- Find relevant documents (index auto-detected from column)
-SELECT title, content <@> to_bm25query('database search', 'articles_idx') as score
+-- Find relevant documents
+SELECT title, content <@> 'database search' as score
 FROM articles
-ORDER BY content <@> 'database search';
+ORDER BY score;
 ```
 
 Also supports different languages and custom parameters:


### PR DESCRIPTION
## Summary

- Simplify the example query to use `ORDER BY score` instead of repeating the expression
- Add crash recovery note explaining that memtable is rebuilt from heap on startup

Feedback from code review on the v0.0.6 release.