### PR TITLE
Release v0.1.0 (first open-source release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
   workflow_dispatch:  # Allow manual testing
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v0.0.6
+## v0.1.0
+
+First open-source release!
 
 ### New Features
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 EXTENSION = pg_textsearch
-DATA = sql/pg_textsearch--0.0.6.sql \
+DATA = sql/pg_textsearch--0.1.0.sql \
        sql/pg_textsearch--0.0.1--0.0.2.sql \
        sql/pg_textsearch--0.0.2--0.0.3.sql \
        sql/pg_textsearch--0.0.3--0.0.4.sql \
        sql/pg_textsearch--0.0.4--0.0.5.sql \
-       sql/pg_textsearch--0.0.5--0.0.6.sql
+       sql/pg_textsearch--0.0.5--0.1.0.sql
 
 # Source files
 # Full build - debugging initialization crash

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Modern ranked text search for Postgres.
 
 🎉 **Now Open Source!** We're excited to share pg_textsearch with the community.
 
-🚀 **Status**: v0.0.6 (prerelease) - Feature-complete but not yet optimized.
-Not recommended for production use.
+🚀 **Status**: v0.1.0 (prerelease) - Feature-complete but not yet optimized.
+Not recommended for production use. See [ROADMAP.md](ROADMAP.md) for what's next.
 
 ![Tapir and Friends](images/tapir_and_friends.png)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,30 +9,24 @@
 | v0.0.3 | Nov 2025 | Crash recovery, concurrency fixes, string-based architecture |
 | v0.0.4 | Nov 2025 | BM25 score validation, PostgreSQL 18 support |
 | v0.0.5 | Dec 2025 | Segment infrastructure, auto-spill, hierarchical merging |
-| v0.0.6 | Dec 2025 | Implicit index resolution, partitioned table support |
+| v0.1.0 | Dec 2025 | First open-source release, implicit index resolution, partitioned tables |
 
-## Current (v0.0.7-dev)
+## Current (v0.1.1-dev)
 
-Development version targeting segment optimizations.
+Development version targeting optimizations.
 
 ## Future
 
-### v0.0.7 - Optimized Segments
+### v0.1.x - Optimizations
 
 Performance and space efficiency improvements.
 
 - **Compression**: Delta encoding for posting lists, bitpacking
 - **Skip lists**: Fast intersection for multi-term queries
 - **Block-Max WAND**: Early termination for top-k queries
-
-### v0.0.8 - Background Compaction
-
-Move compaction off the critical path.
-
 - **Background worker**: Async segment merging
-- **Observability**: Progress tracking, statistics
 
-### v0.1 - Production Ready
+### v1.0 - Production Ready
 
 First production-quality release.
 
@@ -40,7 +34,7 @@ First production-quality release.
 - Benchmark validation
 - Backwards compatibility commitments begin
 
-### Future (Post v0.1)
+### Future (Post v1.0)
 
 - **Boolean queries**: AND/OR/NOT via `@@` operator
 - YOUR IDEA HERE

--- a/pg_textsearch.control
+++ b/pg_textsearch.control
@@ -1,5 +1,5 @@
 # pg_textsearch extension
 comment = 'Full-text search with BM25 ranking'
-default_version = '0.0.6'
+default_version = '0.1.0'
 module_pathname = '$libdir/pg_textsearch'
 relocatable = true

--- a/sql/pg_textsearch--0.0.5--0.1.0.sql
+++ b/sql/pg_textsearch--0.0.5--0.1.0.sql
@@ -1,4 +1,4 @@
--- Upgrade from 0.0.5 to 0.0.6
+-- Upgrade from 0.0.5 to 0.1.0
 
 -- Create the new scoring functions with bm25_ prefix
 CREATE FUNCTION bm25_text_bm25query_score(left_text text, right_query bm25query)

--- a/sql/pg_textsearch--0.1.0.sql
+++ b/sql/pg_textsearch--0.1.0.sql
@@ -1,4 +1,4 @@
--- pg_textsearch extension version 0.0.6
+-- pg_textsearch extension version 0.1.0
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_textsearch" to load this file. \quit
@@ -174,7 +174,7 @@ CREATE FUNCTION bm25_dump_index(text, text) RETURNS text
 -- Display warning about prerelease status
 DO $$
 BEGIN
-    RAISE INFO 'pg_textsearch v0.0.6: This is prerelease software and should not be used in production.';
+    RAISE INFO 'pg_textsearch v0.1.0: This is prerelease software and should not be used in production.';
     RAISE INFO 'This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.';
 END
 $$;

--- a/test/expected/aerodocs.out
+++ b/test/expected/aerodocs.out
@@ -4,7 +4,7 @@
 -- Tests both dataset loading and pg_textsearch scoring functionality with the <@> operator
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 -- Enable score logging for testing

--- a/test/expected/aerodocs_1.out
+++ b/test/expected/aerodocs_1.out
@@ -4,7 +4,7 @@
 -- Tests both dataset loading and pg_textsearch scoring functionality with the <@> operator
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 -- Enable score logging for testing

--- a/test/expected/basic.out
+++ b/test/expected/basic.out
@@ -1,7 +1,7 @@
 -- Basic functionality tests for pg_textsearch extension
 -- Test extension creation
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/deletion.out
+++ b/test/expected/deletion.out
@@ -1,7 +1,7 @@
 -- Test handling of row deletions in indexed tables
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 CREATE TABLE deletion_test (

--- a/test/expected/dropped.out
+++ b/test/expected/dropped.out
@@ -1,7 +1,7 @@
 -- Test behavior when using a dropped index name in queries
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 CREATE TABLE dropped_idx_test (

--- a/test/expected/empty.out
+++ b/test/expected/empty.out
@@ -1,7 +1,7 @@
 -- Test handling of empty and whitespace-only documents
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table with various empty/whitespace content
 CREATE TABLE empty_docs (

--- a/test/expected/implicit.out
+++ b/test/expected/implicit.out
@@ -1,7 +1,7 @@
 -- Test implicit index resolution via planner hook
 -- Tests that to_bm25query() without an index name automatically finds the BM25 index
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table with BM25 index
 CREATE TABLE implicit_docs (

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -1,7 +1,7 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/index_1.out
+++ b/test/expected/index_1.out
@@ -1,7 +1,7 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/inheritance.out
+++ b/test/expected/inheritance.out
@@ -1,7 +1,7 @@
 -- Test BM25 index behavior with table inheritance
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- =============================================================================
 -- Test 1: PostgreSQL native table inheritance

--- a/test/expected/limits.out
+++ b/test/expected/limits.out
@@ -3,7 +3,7 @@
 SET log_duration = off;
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/limits_1.out
+++ b/test/expected/limits_1.out
@@ -3,7 +3,7 @@
 SET log_duration = off;
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/lock.out
+++ b/test/expected/lock.out
@@ -1,7 +1,7 @@
 -- Test lock upgrade from shared to exclusive within a single transaction
 -- This exercises the tp_acquire_index_lock upgrade path
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table and index
 CREATE TABLE lock_upgrade_test (

--- a/test/expected/manyterms.out
+++ b/test/expected/manyterms.out
@@ -2,7 +2,7 @@
 -- This test creates enough unique terms to trigger hash table resize
 -- and verifies the system continues to work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/memory.out
+++ b/test/expected/memory.out
@@ -1,7 +1,7 @@
 -- Test memory limit enforcement for pg_textsearch indexes
 -- Create extension if not exists
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 DROP TABLE IF EXISTS memory_test CASCADE;

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -9,7 +9,7 @@
 -- Known issue: Query code only searches L0 segments (level_heads[0]).
 -- After merge, data in L1 won't be found until this is fixed.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = false;

--- a/test/expected/mixed.out
+++ b/test/expected/mixed.out
@@ -2,7 +2,7 @@
 -- This test verifies that concurrent access to shared memory structures is safe
 -- and that operations like inserts, searches, and index building work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/partitioned.out
+++ b/test/expected/partitioned.out
@@ -16,7 +16,7 @@
 -- partition-local statistics.
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Load validation functions
 \set ECHO none

--- a/test/expected/partitioned_1.out
+++ b/test/expected/partitioned_1.out
@@ -16,7 +16,7 @@
 -- partition-local statistics.
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Load validation functions
 \set ECHO none

--- a/test/expected/queries.out
+++ b/test/expected/queries.out
@@ -1,7 +1,7 @@
 -- This test demonstrates top-k pg_textsearch query patterns for efficient text search
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/schema.out
+++ b/test/expected/schema.out
@@ -1,7 +1,7 @@
 -- Test case: schema
 -- Tests index operations with schema-qualified tables
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring1.out
+++ b/test/expected/scoring1.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring2.out
+++ b/test/expected/scoring2.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 5 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring3.out
+++ b/test/expected/scoring3.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 3 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring4.out
+++ b/test/expected/scoring4.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 1 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring5.out
+++ b/test/expected/scoring5.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 3 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/scoring6.out
+++ b/test/expected/scoring6.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 3 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = true;

--- a/test/expected/segment.out
+++ b/test/expected/segment.out
@@ -2,7 +2,7 @@
 -- Tests segment query functionality with multiple spill cycles and
 -- post-spill inserts
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 \set ECHO none
 SET pg_textsearch.log_scores = false;

--- a/test/expected/strings.out
+++ b/test/expected/strings.out
@@ -1,7 +1,7 @@
 -- Test long string handling including URLs, paths, and long terms
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/unsupported.out
+++ b/test/expected/unsupported.out
@@ -1,7 +1,7 @@
 -- Test cases for queries that are NOT YET fully supported
 -- These document known limitations of the current implicit index resolution
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Setup test tables
 CREATE TABLE docs (

--- a/test/expected/unsupported_1.out
+++ b/test/expected/unsupported_1.out
@@ -1,7 +1,7 @@
 -- Test cases for queries that are NOT YET fully supported
 -- These document known limitations of the current implicit index resolution
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Setup test tables
 CREATE TABLE docs (

--- a/test/expected/updates.out
+++ b/test/expected/updates.out
@@ -2,7 +2,7 @@
 -- This test reproduces the NULL index_state crash reported in production
 -- Install the extension if not already installed
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Test basic UPDATE operations
 CREATE TABLE update_test (

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -1,7 +1,7 @@
 -- Test VACUUM behavior with BM25 indexes
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Create test table
 CREATE TABLE vacuum_test (

--- a/test/expected/vector.out
+++ b/test/expected/vector.out
@@ -1,7 +1,7 @@
 -- Test bm25vector type and operators functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v0.0.6: This is prerelease software and should not be used in production.
+INFO:  pg_textsearch v0.1.0: This is prerelease software and should not be used in production.
 INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;


### PR DESCRIPTION
## Summary

Replaces v0.0.6 with v0.1.0 - a nicer version number for the first open-source release.

Changes:
- Rename version from 0.0.6 to 0.1.0 everywhere
- Fix release workflow duplicate trigger (removed `release: published` trigger)
- Add workflow_dispatch for manual testing
- Add roadmap link to README

## Before merging

Delete the v0.0.6 release and tag:
```bash
gh release delete v0.0.6 --yes
git push origin :refs/tags/v0.0.6
```

## After merging

Tag the release:
```bash
git checkout main && git pull
git tag -a v0.1.0 -m "Release v0.1.0"
git push origin v0.1.0
```