### PR TITLE
Add path filters to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'sql/**'
+      - 'Makefile'
+      - 'pg_textsearch.control'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'sql/**'
+      - 'Makefile'
+      - 'pg_textsearch.control'
+      - '.github/workflows/ci.yml'
 
 jobs:
   test:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,8 +3,16 @@ name: Code Formatting Check
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - '.clang-format'
+      - '.github/workflows/formatting.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - '.clang-format'
+      - '.github/workflows/formatting.yml'
 
 jobs:
   format-check:

--- a/.github/workflows/sanitizer-build-and-test.yml
+++ b/.github/workflows/sanitizer-build-and-test.yml
@@ -3,8 +3,22 @@ name: Sanitizer test
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'sql/**'
+      - 'Makefile'
+      - 'pg_textsearch.control'
+      - '.github/workflows/sanitizer-build-and-test.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'sql/**'
+      - 'Makefile'
+      - 'pg_textsearch.control'
+      - '.github/workflows/sanitizer-build-and-test.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
Skip CI/sanitizer/formatting checks when only non-code files change:
- **ci.yml**: only runs for `src/`, `test/`, `sql/`, `Makefile` changes
- **sanitizer-build-and-test.yml**: same
- **formatting.yml**: only runs for `src/` and `.clang-format` changes

This avoids running expensive checks for benchmark, docs, or workflow-only changes.

Each workflow still triggers on changes to its own workflow file.