### PR TITLE
Run benchmark queries repeatedly for stable measurements

### DIFF
--- a/benchmarks/datasets/msmarco/queries.sql
+++ b/benchmarks/datasets/msmarco/queries.sql
@@ -21,68 +21,67 @@ ORDER BY passage_text <@> to_bm25query('example query', 'msmarco_bm25_idx')
 LIMIT 10;
 
 -- ============================================================
--- Benchmark 1: Single Query Latency (using BM25 index scan)
+-- Benchmark 1: Query Latency (10 iterations each, median reported)
 -- ============================================================
 \echo ''
-\echo '=== Benchmark 1: Single Query Latency (BM25 Index Scan) ==='
+\echo '=== Benchmark 1: Query Latency (10 iterations each) ==='
 \echo 'Running top-10 queries using the BM25 index'
 \echo ''
 
+-- Helper function to run a query multiple times and return median execution time
+CREATE OR REPLACE FUNCTION benchmark_query(query_text text, iterations int DEFAULT 10)
+RETURNS TABLE(median_ms numeric, min_ms numeric, max_ms numeric) AS $$
+DECLARE
+    i int;
+    start_ts timestamp;
+    end_ts timestamp;
+    times numeric[];
+    sorted_times numeric[];
+BEGIN
+    times := ARRAY[]::numeric[];
+    FOR i IN 1..iterations LOOP
+        start_ts := clock_timestamp();
+        EXECUTE 'SELECT passage_id FROM msmarco_passages
+                 WHERE passage_text <@> to_bm25query($1, ''msmarco_bm25_idx'') < 0
+                 ORDER BY passage_text <@> to_bm25query($1, ''msmarco_bm25_idx'')
+                 LIMIT 10' USING query_text;
+        end_ts := clock_timestamp();
+        times := array_append(times, EXTRACT(EPOCH FROM (end_ts - start_ts)) * 1000);
+    END LOOP;
+    SELECT array_agg(t ORDER BY t) INTO sorted_times FROM unnest(times) t;
+    median_ms := sorted_times[(iterations + 1) / 2];
+    min_ms := sorted_times[1];
+    max_ms := sorted_times[iterations];
+    RETURN NEXT;
+END;
+$$ LANGUAGE plpgsql;
+
 -- Short query (1 word)
 \echo 'Query 1: Short query (1 word) - "coffee"'
-EXPLAIN (ANALYZE, TIMING, FORMAT TEXT)
-SELECT passage_id,
-       passage_text <@> to_bm25query('coffee', 'msmarco_bm25_idx') as score
-FROM msmarco_passages
-WHERE passage_text <@> to_bm25query('coffee', 'msmarco_bm25_idx') < 0
-ORDER BY passage_text <@> to_bm25query('coffee', 'msmarco_bm25_idx')
-LIMIT 10;
+SELECT 'Execution Time: ' || round(median_ms, 3) || ' ms (min=' || round(min_ms, 3) || ', max=' || round(max_ms, 3) || ')' as result
+FROM benchmark_query('coffee');
 
 \echo ''
 \echo 'Query 2: Medium query (3 words) - "how to cook"'
-EXPLAIN (ANALYZE, TIMING, FORMAT TEXT)
-SELECT passage_id,
-       passage_text <@> to_bm25query('how to cook', 'msmarco_bm25_idx') as score
-FROM msmarco_passages
-WHERE passage_text <@> to_bm25query('how to cook', 'msmarco_bm25_idx') < 0
-ORDER BY passage_text <@> to_bm25query('how to cook', 'msmarco_bm25_idx')
-LIMIT 10;
+SELECT 'Execution Time: ' || round(median_ms, 3) || ' ms (min=' || round(min_ms, 3) || ', max=' || round(max_ms, 3) || ')' as result
+FROM benchmark_query('how to cook');
 
 \echo ''
 \echo 'Query 3: Long query (question) - "what is the capital of france"'
-EXPLAIN (ANALYZE, TIMING, FORMAT TEXT)
-SELECT passage_id,
-       passage_text <@> to_bm25query('what is the capital of france',
-                                     'msmarco_bm25_idx') as score
-FROM msmarco_passages
-WHERE passage_text <@> to_bm25query('what is the capital of france',
-                                    'msmarco_bm25_idx') < 0
-ORDER BY passage_text <@> to_bm25query('what is the capital of france',
-                                       'msmarco_bm25_idx')
-LIMIT 10;
+SELECT 'Execution Time: ' || round(median_ms, 3) || ' ms (min=' || round(min_ms, 3) || ', max=' || round(max_ms, 3) || ')' as result
+FROM benchmark_query('what is the capital of france');
 
 \echo ''
 \echo 'Query 4: Common term - "the"'
-EXPLAIN (ANALYZE, TIMING, FORMAT TEXT)
-SELECT passage_id,
-       passage_text <@> to_bm25query('the', 'msmarco_bm25_idx') as score
-FROM msmarco_passages
-WHERE passage_text <@> to_bm25query('the', 'msmarco_bm25_idx') < 0
-ORDER BY passage_text <@> to_bm25query('the', 'msmarco_bm25_idx')
-LIMIT 10;
+SELECT 'Execution Time: ' || round(median_ms, 3) || ' ms (min=' || round(min_ms, 3) || ', max=' || round(max_ms, 3) || ')' as result
+FROM benchmark_query('the');
 
 \echo ''
 \echo 'Query 5: Rare term - "cryptocurrency blockchain"'
-EXPLAIN (ANALYZE, TIMING, FORMAT TEXT)
-SELECT passage_id,
-       passage_text <@> to_bm25query('cryptocurrency blockchain',
-                                     'msmarco_bm25_idx') as score
-FROM msmarco_passages
-WHERE passage_text <@> to_bm25query('cryptocurrency blockchain',
-                                    'msmarco_bm25_idx') < 0
-ORDER BY passage_text <@> to_bm25query('cryptocurrency blockchain',
-                                       'msmarco_bm25_idx')
-LIMIT 10;
+SELECT 'Execution Time: ' || round(median_ms, 3) || ' ms (min=' || round(min_ms, 3) || ', max=' || round(max_ms, 3) || ')' as result
+FROM benchmark_query('cryptocurrency blockchain');
+
+DROP FUNCTION benchmark_query;
 
 -- ============================================================
 -- Benchmark 2: Query Throughput (batch of queries)

--- a/benchmarks/runner/extract_metrics.sh
+++ b/benchmarks/runner/extract_metrics.sh
@@ -35,10 +35,11 @@ LOAD_TIME_MS=$(grep -E "^COPY [0-9]+" "$LOG_FILE" -A 1 2>/dev/null | \
 NUM_DOCUMENTS=$(grep -E "BM25 index build completed:" "$LOG_FILE" 2>/dev/null | \
     grep -oE "[0-9]+ documents" | grep -oE "[0-9]+" || echo "")
 
-# Extract Execution Time from EXPLAIN ANALYZE outputs
-# Format: "Execution Time: 123.456 ms"
+# Extract Execution Time from benchmark query outputs
+# Format: "Execution Time: 123.456 ms (min=..., max=...)"
+# We extract only the first number (median) from each line
 mapfile -t EXEC_TIMES < <(grep -E "Execution Time:" "$LOG_FILE" 2>/dev/null | \
-    grep -oE "[0-9]+\.[0-9]+" || true)
+    sed -E 's/.*Execution Time: ([0-9]+\.[0-9]+).*/\1/' || true)
 
 # Extract throughput result
 THROUGHPUT_LINE=$(grep -E "THROUGHPUT_RESULT:" "$LOG_FILE" 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- Each benchmark query now runs 10 times, reporting median/min/max times
- Reduces variance from cache warming and system noise
- Updated extract_metrics.sh to parse median from new output format

## Testing
Manually verified query function works locally. Benchmark results will be validated on next nightly run.