### PR TITLE
Improve benchmark dashboard: dataset sizes and compact layout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -378,6 +378,26 @@ jobs:
         comment-on-alert: true
         fail-on-alert: false
 
+    - name: Update benchmark dashboard
+      if: always()
+      run: |
+        # Save the new index.html before switching branches
+        cp benchmarks/gh-pages/index.html /tmp/new_index.html
+
+        # Update index.html on gh-pages branch
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git fetch origin gh-pages
+        git checkout gh-pages
+        cp /tmp/new_index.html benchmarks/index.html
+        git add benchmarks/index.html
+        if ! git diff --cached --quiet; then
+          git commit -m "Update benchmark dashboard layout"
+          git push origin gh-pages
+        fi
+        # Return to original branch
+        git checkout -
+
     - name: Cleanup
       if: always()
       run: |

--- a/benchmarks/gh-pages/index.html
+++ b/benchmarks/gh-pages/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>pg_textsearch Benchmarks</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@2.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 1600px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        h1 { color: #333; margin-bottom: 10px; }
+        h2 { color: #555; margin-top: 30px; margin-bottom: 15px; }
+        .description {
+            color: #666;
+            margin-bottom: 20px;
+        }
+        .charts-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 15px;
+        }
+        @media (max-width: 1200px) {
+            .charts-grid {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+        @media (max-width: 800px) {
+            .charts-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+        .chart-container {
+            background: white;
+            border-radius: 8px;
+            padding: 15px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        canvas { max-height: 250px; }
+        .dataset-section {
+            margin-bottom: 40px;
+        }
+    </style>
+</head>
+<body>
+    <h1>pg_textsearch Benchmarks</h1>
+    <p class="description">
+        Performance tracking for <a href="https://github.com/timescale/pg_textsearch">pg_textsearch</a>.
+        Click any data point to view the commit.
+    </p>
+    <div id="charts"></div>
+
+    <script src="./data.js"></script>
+    <script>
+        const colors = [
+            'rgb(54, 162, 235)',
+            'rgb(255, 99, 132)',
+            'rgb(75, 192, 192)',
+            'rgb(255, 159, 64)',
+            'rgb(153, 102, 255)',
+            'rgb(255, 205, 86)',
+            'rgb(201, 203, 207)',
+            'rgb(255, 99, 71)',
+        ];
+
+        function formatDate(timestamp) {
+            const d = new Date(timestamp);
+            return d.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: '2-digit'
+            });
+        }
+
+        function formatCommit(hash) {
+            return hash ? hash.substring(0, 7) : '';
+        }
+
+        function getUnit(metricName, defaultUnit) {
+            if (metricName.includes('Index Size')) return 'MB';
+            return defaultUnit || 'ms';
+        }
+
+        function createChart(container, metricName, data, colorIdx) {
+            const div = document.createElement('div');
+            div.className = 'chart-container';
+
+            const canvas = document.createElement('canvas');
+            div.appendChild(canvas);
+            container.appendChild(div);
+
+            const unit = getUnit(metricName, data[0]?.unit || 'ms');
+
+            new Chart(canvas, {
+                type: 'line',
+                data: {
+                    datasets: [{
+                        label: metricName,
+                        data: data,
+                        borderColor: colors[colorIdx % colors.length],
+                        backgroundColor: colors[colorIdx % colors.length] + '33',
+                        fill: true,
+                        tension: 0.1,
+                        pointRadius: 3,
+                        pointHoverRadius: 6
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: {
+                        title: {
+                            display: true,
+                            text: metricName,
+                            font: { size: 13, weight: 'bold' }
+                        },
+                        legend: {
+                            display: false
+                        },
+                        tooltip: {
+                            callbacks: {
+                                title: (items) => {
+                                    const item = items[0];
+                                    const date = formatDate(item.raw.date);
+                                    const commit = formatCommit(item.raw.commit);
+                                    return `${date} (${commit})`;
+                                },
+                                label: (item) => {
+                                    return `${item.raw.y.toFixed(2)} ${unit}`;
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            type: 'time',
+                            time: {
+                                unit: 'day',
+                                displayFormats: {
+                                    day: 'MMM d'
+                                }
+                            },
+                            title: {
+                                display: false
+                            },
+                            ticks: {
+                                font: { size: 10 }
+                            }
+                        },
+                        y: {
+                            beginAtZero: true,
+                            title: {
+                                display: true,
+                                text: unit,
+                                font: { size: 10 }
+                            },
+                            ticks: {
+                                font: { size: 10 }
+                            }
+                        }
+                    },
+                    onClick: (event, elements) => {
+                        if (elements.length > 0) {
+                            const idx = elements[0].index;
+                            const commit = data[idx].commit;
+                            if (commit) {
+                                window.open(
+                                    `https://github.com/timescale/pg_textsearch/commit/${commit}`,
+                                    '_blank'
+                                );
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        // Render charts for each benchmark suite
+        if (typeof window.BENCHMARK_DATA !== 'undefined') {
+            const container = document.getElementById('charts');
+
+            Object.entries(window.BENCHMARK_DATA.entries).forEach(([suiteName, suiteData]) => {
+                // Create section for this benchmark suite
+                const section = document.createElement('div');
+                section.className = 'dataset-section';
+
+                const header = document.createElement('h2');
+                header.textContent = suiteName;
+                section.appendChild(header);
+
+                const grid = document.createElement('div');
+                grid.className = 'charts-grid';
+                section.appendChild(grid);
+
+                // Group data by metric name
+                const metrics = {};
+                suiteData.forEach(run => {
+                    run.benches.forEach(bench => {
+                        if (!metrics[bench.name]) {
+                            metrics[bench.name] = [];
+                        }
+                        metrics[bench.name].push({
+                            x: run.date,
+                            y: bench.value,
+                            unit: bench.unit,
+                            commit: run.commit.id,
+                            date: run.date
+                        });
+                    });
+                });
+
+                // Create a chart for each metric
+                Object.entries(metrics).forEach(([metricName, data], idx) => {
+                    createChart(grid, metricName, data, idx);
+                });
+
+                container.appendChild(section);
+            });
+        } else {
+            document.getElementById('charts').innerHTML =
+                '<p>No benchmark data available yet. Run a benchmark workflow to generate data.</p>';
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Include document count in benchmark metric names (e.g., "msmarco (8.8M docs) - Index Build Time")
- Create 3-column responsive grid layout for benchmark dashboard (responsive down to 1 column on mobile)
- Auto-deploy updated index.html to gh-pages after benchmarks run

## Changes

**format_for_action.sh**: Format document counts (1.4K, 8.8M, etc.) and include in metric names

**benchmarks/gh-pages/index.html**: New compact layout with:
- 3-column grid (responsive)
- Smaller chart sizes
- Cleaner styling
- Dataset sections with headers

**benchmark.yml**: Add step to deploy updated index.html to gh-pages
