### PR TITLE
Replace fixed-size registry with dshash for unlimited indexes

### DIFF
--- a/test/expected/dropped.out
+++ b/test/expected/dropped.out
@@ -44,6 +44,92 @@ SELECT COUNT(*) AS nonexistent
 FROM dropped_idx_test
 WHERE content <@> to_bm25query('test', 'totally_fake_index') < -0.001;
 ERROR:  index "totally_fake_index" does not exist
+-- Test registry slot cleanup (issue #83)
+-- Create multiple indexes, drop them, then create new ones
+-- This verifies that registry slots are properly freed on drop
+-- Create 5 indexes
+CREATE INDEX dropped_idx_1 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_1
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_2 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_2
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_3 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_3
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_4 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_4
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_5 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_5
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+-- Drop all 5
+DROP INDEX dropped_idx_1;
+DROP INDEX dropped_idx_2;
+DROP INDEX dropped_idx_3;
+DROP INDEX dropped_idx_4;
+DROP INDEX dropped_idx_5;
+-- Create 5 more indexes (should succeed if slots were freed)
+CREATE INDEX dropped_idx_6 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_6
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_7 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_7
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_8 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_8
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_9 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_9
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+CREATE INDEX dropped_idx_10 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_10
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+-- Test that the new indexes work
+SELECT COUNT(*) AS recycled_slots_work
+FROM dropped_idx_test
+WHERE content <@> to_bm25query('test', 'dropped_idx_6') < -0.001;
+ recycled_slots_work 
+---------------------
+                   5
+(1 row)
+
+-- Also test CASCADE drop (table drop should clean up index slots)
+CREATE TABLE cascade_test (id SERIAL, content TEXT);
+INSERT INTO cascade_test (content) VALUES ('cascade test doc');
+CREATE INDEX cascade_idx ON cascade_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation cascade_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+-- Drop table should cascade to drop index and free its registry slot
+DROP TABLE cascade_test CASCADE;
+-- Create another index to verify the cascade-dropped slot was freed
+CREATE INDEX dropped_idx_11 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation dropped_idx_11
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
 -- Clean up
 DROP TABLE dropped_idx_test;
 DROP EXTENSION pg_textsearch;

--- a/test/sql/dropped.sql
+++ b/test/sql/dropped.sql
@@ -40,6 +40,47 @@ SELECT COUNT(*) AS nonexistent
 FROM dropped_idx_test
 WHERE content <@> to_bm25query('test', 'totally_fake_index') < -0.001;
 
+-- Test registry slot cleanup (issue #83)
+-- Create multiple indexes, drop them, then create new ones
+-- This verifies that registry slots are properly freed on drop
+
+-- Create 5 indexes
+CREATE INDEX dropped_idx_1 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_2 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_3 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_4 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_5 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+
+-- Drop all 5
+DROP INDEX dropped_idx_1;
+DROP INDEX dropped_idx_2;
+DROP INDEX dropped_idx_3;
+DROP INDEX dropped_idx_4;
+DROP INDEX dropped_idx_5;
+
+-- Create 5 more indexes (should succeed if slots were freed)
+CREATE INDEX dropped_idx_6 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_7 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_8 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_9 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+CREATE INDEX dropped_idx_10 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+
+-- Test that the new indexes work
+SELECT COUNT(*) AS recycled_slots_work
+FROM dropped_idx_test
+WHERE content <@> to_bm25query('test', 'dropped_idx_6') < -0.001;
+
+-- Also test CASCADE drop (table drop should clean up index slots)
+CREATE TABLE cascade_test (id SERIAL, content TEXT);
+INSERT INTO cascade_test (content) VALUES ('cascade test doc');
+CREATE INDEX cascade_idx ON cascade_test USING bm25 (content) WITH (text_config = 'english');
+
+-- Drop table should cascade to drop index and free its registry slot
+DROP TABLE cascade_test CASCADE;
+
+-- Create another index to verify the cascade-dropped slot was freed
+CREATE INDEX dropped_idx_11 ON dropped_idx_test USING bm25 (content) WITH (text_config = 'english');
+
 -- Clean up
 DROP TABLE dropped_idx_test;
 DROP EXTENSION pg_textsearch;


### PR DESCRIPTION
## Summary
- Replaces fixed-size registry array (64 slots) with dshash for unlimited index tracking
- Fixes registry slot leak on cascade drops (DROP TABLE)
- Resolves #83 "registry slots not freed when bm25 indexes are dropped"

## Details
The registry previously used `TP_MAX_INDEXES=64` fixed array. This caused "registry full" errors with many indexes, especially partitioned tables.

The new dshash implementation:
- No fixed limit (bounded only by available memory)
- O(1) lookup performance  
- Uses existing DSA infrastructure

Also fixes the object access hook which was skipping cleanup for `PERFORM_DELETION_INTERNAL` drops, causing registry entries to leak on cascade operations.

## Testing
- All 10 SQL regression tests pass
- Verified 100 create/drop cycles work (beyond old 64-slot limit)
- Extended dropped.sql tests for create-drop-recreate cycles