### PR TITLE
chore: fix make test and override pgxs installcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 # SQL regression tests
-test: install
+test:
 	@echo "Running SQL regression tests..."
 	@$(pg_regress_installcheck) $(REGRESS_OPTS) $(REGRESS)
 
@@ -94,7 +94,7 @@ test-all: test test-shell
 	@echo "All tests (SQL regression + shell scripts) completed successfully"
 
 # Override installcheck to run all tests (SQL regression + shell scripts)
-installcheck: install
+installcheck:
 	@$(MAKE) test
 	@$(MAKE) test-shell
 


### PR DESCRIPTION
This commit:

1. Adds the missing `test` target. It is mentioned in `make help` but has not been defined, when I run it locally, I see this:
   ```sh
   $ make test
   make: Nothing to be done for `test'.
   ```
   
2. Makes the `installcheck` target override the one defined by pgxs. Previously, we were not overriding it but appending new commands to it