### PR TITLE
Add missing math.h include in build.c

### DIFF
--- a/src/am/build.c
+++ b/src/am/build.c
@@ -10,6 +10,7 @@
 #include <catalog/namespace.h>
 #include <commands/progress.h>
 #include <executor/spi.h>
+#include <math.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
 #include <nodes/value.h>


### PR DESCRIPTION
gcc 14.2.0 reports an error about implicit declaration of 'log' function in build.c. Adding the math.h include resolves this issue.