### PR TITLE
Add segment integrity tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ PG_CPPFLAGS = -I$(srcdir)/src -g -O2 -Wall -Wextra -Wunused-function -Wunused-va
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic bmw deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed partitioned queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 segment strings unsupported updates vector unlogged_index wand
+REGRESS = aerodocs basic bmw deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed partitioned queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 segment segment_integrity strings unsupported updates vector unlogged_index wand
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/test/expected/segment_integrity.out
+++ b/test/expected/segment_integrity.out
@@ -1,0 +1,391 @@
+-- Test case: segment_integrity
+-- Verifies that segment operations preserve exact document scores.
+--
+-- Key insight: BM25 scores legitimately change when documents are added
+-- (IDF and avgdl change). This test captures scores IMMEDIATELY before
+-- an operation and verifies they are IDENTICAL after. This catches:
+-- - Data loss during spill/merge
+-- - Corruption of posting lists
+-- - Document length encoding errors
+-- - Term frequency encoding errors
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+INFO:  pg_textsearch v0.3.0-dev: This is prerelease software and should not be used in production.
+INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
+SET pg_textsearch.log_scores = false;
+SET enable_seqscan = off;
+-- Create table with enough documents to be meaningful
+CREATE TABLE integrity_test (
+    id SERIAL PRIMARY KEY,
+    content TEXT
+);
+CREATE INDEX integrity_test_idx ON integrity_test USING bm25(content)
+  WITH (text_config='english', k1=1.2, b=0.75);
+NOTICE:  BM25 index build started for relation integrity_test_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00, text_config='english' (k1=1.20, b=0.75)
+-- Insert a variety of documents with different term frequencies and lengths
+INSERT INTO integrity_test (content) VALUES
+    ('hello world'),
+    ('hello hello world'),
+    ('hello hello hello world world'),
+    ('goodbye cruel world'),
+    ('goodbye goodbye'),
+    ('the quick brown fox jumps over the lazy dog'),
+    ('fox fox fox hunting'),
+    ('lazy dog sleeps'),
+    ('world peace and harmony'),
+    ('database indexing and search'),
+    ('full text search with ranking'),
+    ('search search search query'),
+    ('query optimization techniques'),
+    ('hello world database search'),
+    ('unique document here'),
+    ('another unique entry'),
+    ('fox and dog are friends'),
+    ('peace in the world'),
+    ('cruel cruel world'),
+    ('harmony and peace forever');
+--------------------------------------------------------------------------------
+-- Test 1: Spill integrity (memtable -> segment)
+--------------------------------------------------------------------------------
+-- Capture scores IMMEDIATELY before spill
+CREATE TEMP TABLE pre_spill_scores AS
+SELECT
+    id,
+    content,
+    query,
+    score
+FROM (
+    SELECT id, content, 'hello'::text AS query,
+           (content <@> to_bm25query('hello', 'integrity_test_idx'))::numeric AS score
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'world'::text,
+           (content <@> to_bm25query('world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'fox'::text,
+           (content <@> to_bm25query('fox', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'search'::text,
+           (content <@> to_bm25query('search', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'hello world'::text,
+           (content <@> to_bm25query('hello world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'peace harmony'::text,
+           (content <@> to_bm25query('peace harmony', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+) sub;
+SELECT 'Test 1: Spill integrity' AS test,
+       COUNT(DISTINCT id) AS docs,
+       COUNT(DISTINCT query) AS queries
+FROM pre_spill_scores;
+          test           | docs | queries 
+-------------------------+------+---------
+ Test 1: Spill integrity |   20 |       6
+(1 row)
+
+-- Spill to segment
+SELECT bm25_spill_index('integrity_test_idx') IS NOT NULL AS spill_ok;
+ spill_ok 
+----------
+ t
+(1 row)
+
+-- Verify ALL scores match after spill
+SELECT
+    CASE
+        WHEN COUNT(*) = (SELECT COUNT(*) FROM pre_spill_scores)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS spill_integrity,
+    COUNT(*) AS matching,
+    (SELECT COUNT(*) FROM pre_spill_scores) AS expected
+FROM pre_spill_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      <= 0.0001;
+ spill_integrity | matching | expected 
+-----------------+----------+----------
+ PASS            |      120 |      120
+(1 row)
+
+-- Show any mismatches (should be empty)
+SELECT 'Spill mismatches:' AS label;
+       label       
+-------------------
+ Spill mismatches:
+(1 row)
+
+SELECT p.id, p.query,
+       ROUND(p.score, 6) AS before,
+       ROUND((p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric, 6)
+           AS after
+FROM pre_spill_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      > 0.0001
+LIMIT 5;
+ id | query | before | after 
+----+-------+--------+-------
+(0 rows)
+
+DROP TABLE pre_spill_scores;
+--------------------------------------------------------------------------------
+-- Test 2: Second spill integrity (add docs, then spill again)
+--------------------------------------------------------------------------------
+-- Add more documents
+INSERT INTO integrity_test (content) VALUES
+    ('new document after first spill'),
+    ('hello from the other side'),
+    ('world domination plans'),
+    ('search and rescue mission'),
+    ('fox news network');
+-- Capture scores IMMEDIATELY before second spill
+CREATE TEMP TABLE pre_spill2_scores AS
+SELECT
+    id,
+    content,
+    query,
+    score
+FROM (
+    SELECT id, content, 'hello'::text AS query,
+           (content <@> to_bm25query('hello', 'integrity_test_idx'))::numeric AS score
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'world'::text,
+           (content <@> to_bm25query('world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'search'::text,
+           (content <@> to_bm25query('search', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+) sub;
+SELECT 'Test 2: Second spill integrity' AS test,
+       COUNT(DISTINCT id) AS docs
+FROM pre_spill2_scores;
+              test              | docs 
+--------------------------------+------
+ Test 2: Second spill integrity |   25
+(1 row)
+
+-- Second spill
+SELECT bm25_spill_index('integrity_test_idx') IS NOT NULL AS spill2_ok;
+ spill2_ok 
+-----------
+ t
+(1 row)
+
+-- Verify scores match
+SELECT
+    CASE
+        WHEN COUNT(*) = (SELECT COUNT(*) FROM pre_spill2_scores)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS spill2_integrity,
+    COUNT(*) AS matching,
+    (SELECT COUNT(*) FROM pre_spill2_scores) AS expected
+FROM pre_spill2_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      <= 0.0001;
+ spill2_integrity | matching | expected 
+------------------+----------+----------
+ PASS             |       75 |       75
+(1 row)
+
+DROP TABLE pre_spill2_scores;
+--------------------------------------------------------------------------------
+-- Test 3: Merge integrity
+--------------------------------------------------------------------------------
+-- Configure for merge (2 segments triggers merge)
+SET pg_textsearch.segments_per_level = 2;
+-- Add more docs and spill to trigger merge
+INSERT INTO integrity_test (content) VALUES
+    ('merge test document one'),
+    ('merge test hello world'),
+    ('merge fox and dog'),
+    ('search merge optimization');
+-- Capture scores IMMEDIATELY before merge-triggering spill
+CREATE TEMP TABLE pre_merge_scores AS
+SELECT
+    id,
+    content,
+    query,
+    score
+FROM (
+    SELECT id, content, 'hello'::text AS query,
+           (content <@> to_bm25query('hello', 'integrity_test_idx'))::numeric AS score
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'world'::text,
+           (content <@> to_bm25query('world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'merge'::text,
+           (content <@> to_bm25query('merge', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'search'::text,
+           (content <@> to_bm25query('search', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+) sub;
+SELECT 'Test 3: Merge integrity' AS test,
+       COUNT(DISTINCT id) AS docs
+FROM pre_merge_scores;
+          test           | docs 
+-------------------------+------
+ Test 3: Merge integrity |   29
+(1 row)
+
+-- This spill triggers merge
+SELECT bm25_spill_index('integrity_test_idx') IS NOT NULL AS merge_spill_ok;
+ merge_spill_ok 
+----------------
+ t
+(1 row)
+
+-- Verify all scores match after merge
+SELECT
+    CASE
+        WHEN COUNT(*) = (SELECT COUNT(*) FROM pre_merge_scores)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS merge_integrity,
+    COUNT(*) AS matching,
+    (SELECT COUNT(*) FROM pre_merge_scores) AS expected
+FROM pre_merge_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      <= 0.0001;
+ merge_integrity | matching | expected 
+-----------------+----------+----------
+ PASS            |      116 |      116
+(1 row)
+
+-- Show any mismatches (should be empty)
+SELECT 'Merge mismatches:' AS label;
+       label       
+-------------------
+ Merge mismatches:
+(1 row)
+
+SELECT p.id, p.query,
+       ROUND(p.score, 6) AS before,
+       ROUND((p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric, 6)
+           AS after
+FROM pre_merge_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      > 0.0001
+LIMIT 5;
+ id | query | before | after 
+----+-------+--------+-------
+(0 rows)
+
+DROP TABLE pre_merge_scores;
+--------------------------------------------------------------------------------
+-- Test 4: Document reachability
+-- Verify documents with matching terms are returned by index scan.
+-- Note: Documents without any queried terms correctly return score=0
+-- and may not appear in ORDER BY results - this is expected behavior.
+--------------------------------------------------------------------------------
+SELECT 'Test 4: Document reachability' AS test;
+             test              
+-------------------------------
+ Test 4: Document reachability
+(1 row)
+
+-- Test that documents with 'hello' are found when searching for 'hello'
+-- Count docs containing 'hello' in table vs docs returned by index
+SELECT
+    'hello' AS term,
+    (SELECT COUNT(*) FROM integrity_test
+     WHERE to_tsvector('english', content) @@ to_tsquery('english', 'hello'))
+        AS expected,
+    (SELECT COUNT(*) FROM (
+        SELECT id FROM integrity_test
+        WHERE (content <@> to_bm25query('hello', 'integrity_test_idx')) < 0
+    ) t) AS found,
+    CASE
+        WHEN (SELECT COUNT(*) FROM integrity_test
+              WHERE to_tsvector('english', content) @@ to_tsquery('english', 'hello'))
+           = (SELECT COUNT(*) FROM (
+                SELECT id FROM integrity_test
+                WHERE (content <@> to_bm25query('hello', 'integrity_test_idx')) < 0
+              ) t)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS hello_reachable;
+ term  | expected | found | hello_reachable 
+-------+----------+-------+-----------------
+ hello |        6 |     6 | PASS
+(1 row)
+
+SELECT
+    'world' AS term,
+    (SELECT COUNT(*) FROM integrity_test
+     WHERE to_tsvector('english', content) @@ to_tsquery('english', 'world'))
+        AS expected,
+    (SELECT COUNT(*) FROM (
+        SELECT id FROM integrity_test
+        WHERE (content <@> to_bm25query('world', 'integrity_test_idx')) < 0
+    ) t) AS found,
+    CASE
+        WHEN (SELECT COUNT(*) FROM integrity_test
+              WHERE to_tsvector('english', content) @@ to_tsquery('english', 'world'))
+           = (SELECT COUNT(*) FROM (
+                SELECT id FROM integrity_test
+                WHERE (content <@> to_bm25query('world', 'integrity_test_idx')) < 0
+              ) t)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS world_reachable;
+ term  | expected | found | world_reachable 
+-------+----------+-------+-----------------
+ world |       10 |    10 | PASS
+(1 row)
+
+SELECT
+    'search' AS term,
+    (SELECT COUNT(*) FROM integrity_test
+     WHERE to_tsvector('english', content) @@ to_tsquery('english', 'search'))
+        AS expected,
+    (SELECT COUNT(*) FROM (
+        SELECT id FROM integrity_test
+        WHERE (content <@> to_bm25query('search', 'integrity_test_idx')) < 0
+    ) t) AS found,
+    CASE
+        WHEN (SELECT COUNT(*) FROM integrity_test
+              WHERE to_tsvector('english', content) @@ to_tsquery('english', 'search'))
+           = (SELECT COUNT(*) FROM (
+                SELECT id FROM integrity_test
+                WHERE (content <@> to_bm25query('search', 'integrity_test_idx')) < 0
+              ) t)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS search_reachable;
+  term  | expected | found | search_reachable 
+--------+----------+-------+------------------
+ search |        6 |     6 | PASS
+(1 row)
+
+--------------------------------------------------------------------------------
+-- Summary
+--------------------------------------------------------------------------------
+SELECT 'SUMMARY' AS section,
+       COUNT(*) AS total_documents
+FROM integrity_test;
+ section | total_documents 
+---------+-----------------
+ SUMMARY |              29
+(1 row)
+
+-- Cleanup
+DROP TABLE integrity_test CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/segment_integrity.sql
+++ b/test/sql/segment_integrity.sql
@@ -1,0 +1,333 @@
+-- Test case: segment_integrity
+-- Verifies that segment operations preserve exact document scores.
+--
+-- Key insight: BM25 scores legitimately change when documents are added
+-- (IDF and avgdl change). This test captures scores IMMEDIATELY before
+-- an operation and verifies they are IDENTICAL after. This catches:
+-- - Data loss during spill/merge
+-- - Corruption of posting lists
+-- - Document length encoding errors
+-- - Term frequency encoding errors
+
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+SET pg_textsearch.log_scores = false;
+SET enable_seqscan = off;
+
+-- Create table with enough documents to be meaningful
+CREATE TABLE integrity_test (
+    id SERIAL PRIMARY KEY,
+    content TEXT
+);
+
+CREATE INDEX integrity_test_idx ON integrity_test USING bm25(content)
+  WITH (text_config='english', k1=1.2, b=0.75);
+
+-- Insert a variety of documents with different term frequencies and lengths
+INSERT INTO integrity_test (content) VALUES
+    ('hello world'),
+    ('hello hello world'),
+    ('hello hello hello world world'),
+    ('goodbye cruel world'),
+    ('goodbye goodbye'),
+    ('the quick brown fox jumps over the lazy dog'),
+    ('fox fox fox hunting'),
+    ('lazy dog sleeps'),
+    ('world peace and harmony'),
+    ('database indexing and search'),
+    ('full text search with ranking'),
+    ('search search search query'),
+    ('query optimization techniques'),
+    ('hello world database search'),
+    ('unique document here'),
+    ('another unique entry'),
+    ('fox and dog are friends'),
+    ('peace in the world'),
+    ('cruel cruel world'),
+    ('harmony and peace forever');
+
+--------------------------------------------------------------------------------
+-- Test 1: Spill integrity (memtable -> segment)
+--------------------------------------------------------------------------------
+
+-- Capture scores IMMEDIATELY before spill
+CREATE TEMP TABLE pre_spill_scores AS
+SELECT
+    id,
+    content,
+    query,
+    score
+FROM (
+    SELECT id, content, 'hello'::text AS query,
+           (content <@> to_bm25query('hello', 'integrity_test_idx'))::numeric AS score
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'world'::text,
+           (content <@> to_bm25query('world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'fox'::text,
+           (content <@> to_bm25query('fox', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'search'::text,
+           (content <@> to_bm25query('search', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'hello world'::text,
+           (content <@> to_bm25query('hello world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'peace harmony'::text,
+           (content <@> to_bm25query('peace harmony', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+) sub;
+
+SELECT 'Test 1: Spill integrity' AS test,
+       COUNT(DISTINCT id) AS docs,
+       COUNT(DISTINCT query) AS queries
+FROM pre_spill_scores;
+
+-- Spill to segment
+SELECT bm25_spill_index('integrity_test_idx') IS NOT NULL AS spill_ok;
+
+-- Verify ALL scores match after spill
+SELECT
+    CASE
+        WHEN COUNT(*) = (SELECT COUNT(*) FROM pre_spill_scores)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS spill_integrity,
+    COUNT(*) AS matching,
+    (SELECT COUNT(*) FROM pre_spill_scores) AS expected
+FROM pre_spill_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      <= 0.0001;
+
+-- Show any mismatches (should be empty)
+SELECT 'Spill mismatches:' AS label;
+SELECT p.id, p.query,
+       ROUND(p.score, 6) AS before,
+       ROUND((p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric, 6)
+           AS after
+FROM pre_spill_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      > 0.0001
+LIMIT 5;
+
+DROP TABLE pre_spill_scores;
+
+--------------------------------------------------------------------------------
+-- Test 2: Second spill integrity (add docs, then spill again)
+--------------------------------------------------------------------------------
+
+-- Add more documents
+INSERT INTO integrity_test (content) VALUES
+    ('new document after first spill'),
+    ('hello from the other side'),
+    ('world domination plans'),
+    ('search and rescue mission'),
+    ('fox news network');
+
+-- Capture scores IMMEDIATELY before second spill
+CREATE TEMP TABLE pre_spill2_scores AS
+SELECT
+    id,
+    content,
+    query,
+    score
+FROM (
+    SELECT id, content, 'hello'::text AS query,
+           (content <@> to_bm25query('hello', 'integrity_test_idx'))::numeric AS score
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'world'::text,
+           (content <@> to_bm25query('world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'search'::text,
+           (content <@> to_bm25query('search', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+) sub;
+
+SELECT 'Test 2: Second spill integrity' AS test,
+       COUNT(DISTINCT id) AS docs
+FROM pre_spill2_scores;
+
+-- Second spill
+SELECT bm25_spill_index('integrity_test_idx') IS NOT NULL AS spill2_ok;
+
+-- Verify scores match
+SELECT
+    CASE
+        WHEN COUNT(*) = (SELECT COUNT(*) FROM pre_spill2_scores)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS spill2_integrity,
+    COUNT(*) AS matching,
+    (SELECT COUNT(*) FROM pre_spill2_scores) AS expected
+FROM pre_spill2_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      <= 0.0001;
+
+DROP TABLE pre_spill2_scores;
+
+--------------------------------------------------------------------------------
+-- Test 3: Merge integrity
+--------------------------------------------------------------------------------
+
+-- Configure for merge (2 segments triggers merge)
+SET pg_textsearch.segments_per_level = 2;
+
+-- Add more docs and spill to trigger merge
+INSERT INTO integrity_test (content) VALUES
+    ('merge test document one'),
+    ('merge test hello world'),
+    ('merge fox and dog'),
+    ('search merge optimization');
+
+-- Capture scores IMMEDIATELY before merge-triggering spill
+CREATE TEMP TABLE pre_merge_scores AS
+SELECT
+    id,
+    content,
+    query,
+    score
+FROM (
+    SELECT id, content, 'hello'::text AS query,
+           (content <@> to_bm25query('hello', 'integrity_test_idx'))::numeric AS score
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'world'::text,
+           (content <@> to_bm25query('world', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'merge'::text,
+           (content <@> to_bm25query('merge', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+    UNION ALL
+    SELECT id, content, 'search'::text,
+           (content <@> to_bm25query('search', 'integrity_test_idx'))::numeric
+    FROM integrity_test
+) sub;
+
+SELECT 'Test 3: Merge integrity' AS test,
+       COUNT(DISTINCT id) AS docs
+FROM pre_merge_scores;
+
+-- This spill triggers merge
+SELECT bm25_spill_index('integrity_test_idx') IS NOT NULL AS merge_spill_ok;
+
+-- Verify all scores match after merge
+SELECT
+    CASE
+        WHEN COUNT(*) = (SELECT COUNT(*) FROM pre_merge_scores)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS merge_integrity,
+    COUNT(*) AS matching,
+    (SELECT COUNT(*) FROM pre_merge_scores) AS expected
+FROM pre_merge_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      <= 0.0001;
+
+-- Show any mismatches (should be empty)
+SELECT 'Merge mismatches:' AS label;
+SELECT p.id, p.query,
+       ROUND(p.score, 6) AS before,
+       ROUND((p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric, 6)
+           AS after
+FROM pre_merge_scores p
+WHERE ABS(p.score -
+          (p.content <@> to_bm25query(p.query, 'integrity_test_idx'))::numeric)
+      > 0.0001
+LIMIT 5;
+
+DROP TABLE pre_merge_scores;
+
+--------------------------------------------------------------------------------
+-- Test 4: Document reachability
+-- Verify documents with matching terms are returned by index scan.
+-- Note: Documents without any queried terms correctly return score=0
+-- and may not appear in ORDER BY results - this is expected behavior.
+--------------------------------------------------------------------------------
+
+SELECT 'Test 4: Document reachability' AS test;
+
+-- Test that documents with 'hello' are found when searching for 'hello'
+-- Count docs containing 'hello' in table vs docs returned by index
+SELECT
+    'hello' AS term,
+    (SELECT COUNT(*) FROM integrity_test
+     WHERE to_tsvector('english', content) @@ to_tsquery('english', 'hello'))
+        AS expected,
+    (SELECT COUNT(*) FROM (
+        SELECT id FROM integrity_test
+        WHERE (content <@> to_bm25query('hello', 'integrity_test_idx')) < 0
+    ) t) AS found,
+    CASE
+        WHEN (SELECT COUNT(*) FROM integrity_test
+              WHERE to_tsvector('english', content) @@ to_tsquery('english', 'hello'))
+           = (SELECT COUNT(*) FROM (
+                SELECT id FROM integrity_test
+                WHERE (content <@> to_bm25query('hello', 'integrity_test_idx')) < 0
+              ) t)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS hello_reachable;
+
+SELECT
+    'world' AS term,
+    (SELECT COUNT(*) FROM integrity_test
+     WHERE to_tsvector('english', content) @@ to_tsquery('english', 'world'))
+        AS expected,
+    (SELECT COUNT(*) FROM (
+        SELECT id FROM integrity_test
+        WHERE (content <@> to_bm25query('world', 'integrity_test_idx')) < 0
+    ) t) AS found,
+    CASE
+        WHEN (SELECT COUNT(*) FROM integrity_test
+              WHERE to_tsvector('english', content) @@ to_tsquery('english', 'world'))
+           = (SELECT COUNT(*) FROM (
+                SELECT id FROM integrity_test
+                WHERE (content <@> to_bm25query('world', 'integrity_test_idx')) < 0
+              ) t)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS world_reachable;
+
+SELECT
+    'search' AS term,
+    (SELECT COUNT(*) FROM integrity_test
+     WHERE to_tsvector('english', content) @@ to_tsquery('english', 'search'))
+        AS expected,
+    (SELECT COUNT(*) FROM (
+        SELECT id FROM integrity_test
+        WHERE (content <@> to_bm25query('search', 'integrity_test_idx')) < 0
+    ) t) AS found,
+    CASE
+        WHEN (SELECT COUNT(*) FROM integrity_test
+              WHERE to_tsvector('english', content) @@ to_tsquery('english', 'search'))
+           = (SELECT COUNT(*) FROM (
+                SELECT id FROM integrity_test
+                WHERE (content <@> to_bm25query('search', 'integrity_test_idx')) < 0
+              ) t)
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS search_reachable;
+
+--------------------------------------------------------------------------------
+-- Summary
+--------------------------------------------------------------------------------
+
+SELECT 'SUMMARY' AS section,
+       COUNT(*) AS total_documents
+FROM integrity_test;
+
+-- Cleanup
+DROP TABLE integrity_test CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Summary

Adds `test/sql/segment_integrity.sql` which verifies that segment operations preserve exact document scores across:
- Spill (memtable → segment)
- Second spill (mixed sources → two segments)  
- Merge (triggered by segments_per_level threshold)

## Approach

The test captures BM25 scores **immediately before** each operation and verifies they are **identical after**. This is important because:

- BM25 scores legitimately change when documents are added (IDF and avgdl change)
- We need to isolate the effect of the segment operation itself
- Comparing scores across document insertions would give false failures

## What This Catches

- Data loss during spill/merge
- Corruption of posting lists
- Document length encoding errors
- Term frequency encoding errors
- Segment merge correctness (all documents survive with correct scores)

## Test Structure

1. **Test 1: Spill integrity** - 20 docs, 6 queries, 120 score comparisons
2. **Test 2: Second spill** - 25 docs after adding 5 more
3. **Test 3: Merge integrity** - 29 docs, triggered by `segments_per_level=2`
4. **Test 4: Document reachability** - Verifies docs with term X are found when searching for X

## Testing

```
make test REGRESS=segment_integrity  # passes
make test                            # all 33 tests pass
```