### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/am/handler.c
+++ b/src/am/handler.c
@@ -103,9 +103,10 @@ tp_options(Datum reloptions, bool validate)
 	static const relopt_parse_elt tab[] =
 			{{"text_config",
 			  RELOPT_TYPE_STRING,
-			  offsetof(TpOptions, text_config_offset)},
-			 {"k1", RELOPT_TYPE_REAL, offsetof(TpOptions, k1)},
-			 {"b", RELOPT_TYPE_REAL, offsetof(TpOptions, b)}};
+			  offsetof(TpOptions, text_config_offset),
+			  0},
+			 {"k1", RELOPT_TYPE_REAL, offsetof(TpOptions, k1), 0},
+			 {"b", RELOPT_TYPE_REAL, offsetof(TpOptions, b), 0}};
 
 	return (bytea *)build_reloptions(
 			reloptions,

--- a/src/am/scan.c
+++ b/src/am/scan.c
@@ -689,6 +689,8 @@ tp_gettuple(IndexScanDesc scan, ScanDirection dir)
 	float4		 bm25_score;
 	BlockNumber	 blknum;
 
+	(void)dir; /* BM25 index only supports forward scan */
+
 	Assert(scan != NULL);
 	Assert(so != NULL);
 	Assert(so->query_text != NULL);

--- a/src/mod.c
+++ b/src/mod.c
@@ -24,6 +24,7 @@
 #include "memtable/memtable.h"
 #include "memtable/posting.h"
 #include "planner/hooks.h"
+#include "query/score.h"
 #include "state/registry.h"
 #include "state/state.h"
 

--- a/src/query/score.c
+++ b/src/query/score.c
@@ -22,10 +22,6 @@
 #include "state/metapage.h"
 #include "state/state.h"
 
-/* GUC variables from mod.c */
-extern bool tp_log_bmw_stats;
-extern bool tp_enable_bmw;
-
 /*
  * Centralized IDF calculation (basic version)
  * Calculates IDF using BM25 formula: log(1 + (N - df + 0.5) / (df + 0.5))

--- a/src/query/score.h
+++ b/src/query/score.h
@@ -39,6 +39,10 @@ extern int tp_score_documents(
 /* IDF calculation */
 extern float4 tp_calculate_idf(int32 doc_freq, int32 total_docs);
 
+/* GUC variables for BMW configuration - defined in mod.c */
+extern bool tp_log_bmw_stats;
+extern bool tp_enable_bmw;
+
 /*
  * Initialize HASHCTL for document score hash tables.
  * Uses ItemPointerData as key (CTID).


### PR DESCRIPTION
## Summary
- Add extern declarations for `tp_log_bmw_stats` and `tp_enable_bmw` in score.h to fix `-Wmissing-variable-declarations` warnings
- Add `isset_offset` field initializer to `relopt_parse_elt` structs in handler.c to fix `-Wmissing-field-initializers` warnings  
- Mark unused `dir` parameter in `tp_gettuple()` to fix `-Wunused-parameter` warning

The build now compiles cleanly with `CFLAGS="-Wall -Wextra -Werror"`.

## Testing
- All 33 regression tests pass