### PR TITLE
Fix bm25query varlena detoasting for binary I/O and scoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ PG_CPPFLAGS = -I$(srcdir)/src -g -O2 -Wall -Wextra -Wunused-function -Wunused-va
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic bmw coverage deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed partitioned queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 segment segment_integrity strings unsupported updates vector unlogged_index wand
+REGRESS = aerodocs basic binary_io bmw coverage deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed partitioned queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 segment segment_integrity strings unsupported updates vector unlogged_index wand
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/test/expected/binary_io.out
+++ b/test/expected/binary_io.out
@@ -1,0 +1,62 @@
+-- Test binary I/O for bm25query type (COPY BINARY)
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+INFO:  pg_textsearch v0.3.0-dev: This is prerelease software and should not be used in production.
+INFO:  This release contains breaking changes in the bm25 index structure and will require existing indexes to be rebuilt.
+-- Create a table and index for testing
+CREATE TABLE binary_io_docs (id SERIAL PRIMARY KEY, content TEXT);
+INSERT INTO binary_io_docs (content) VALUES
+    ('hello world test'),
+    ('database search query');
+CREATE INDEX binary_io_idx ON binary_io_docs USING bm25(content)
+    WITH (text_config='english');
+NOTICE:  BM25 index build started for relation binary_io_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 2 documents, avg_length=3.00, text_config='english' (k1=1.20, b=0.75)
+-- Create a table with bm25query column
+CREATE TABLE query_export (id SERIAL, q bm25query);
+-- Insert some queries
+INSERT INTO query_export (q) VALUES
+    (to_bm25query('hello world', 'binary_io_idx')),
+    (to_bm25query('database search', 'binary_io_idx'));
+-- Show original data before COPY
+SELECT id, q::text AS original_query FROM query_export ORDER BY id;
+ id |        original_query         
+----+-------------------------------
+  1 | binary_io_idx:hello world
+  2 | binary_io_idx:database search
+(2 rows)
+
+-- Test COPY TO BINARY (exercises tpquery_send)
+COPY query_export TO '/tmp/query_export.bin' WITH (FORMAT binary);
+-- Test COPY FROM BINARY (exercises tpquery_recv)
+CREATE TABLE query_import (id int, q bm25query);
+COPY query_import FROM '/tmp/query_export.bin' WITH (FORMAT binary);
+-- Verify data was imported correctly
+SELECT COUNT(*) AS imported_count FROM query_import;
+ imported_count 
+----------------
+              2
+(1 row)
+
+-- Verify the queries are equivalent
+SELECT
+    e.id,
+    e.q::text AS exported,
+    i.q::text AS imported,
+    e.q = i.q AS queries_match
+FROM query_export e
+JOIN query_import i ON e.id = i.id
+ORDER BY e.id;
+ id |           exported            |           imported            | queries_match 
+----+-------------------------------+-------------------------------+---------------
+  1 | binary_io_idx:hello world     | binary_io_idx:hello world     | t
+  2 | binary_io_idx:database search | binary_io_idx:database search | t
+(2 rows)
+
+-- Clean up
+\! rm -f /tmp/query_export.bin
+DROP TABLE query_export;
+DROP TABLE query_import;
+DROP TABLE binary_io_docs CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/binary_io.sql
+++ b/test/sql/binary_io.sql
@@ -1,0 +1,50 @@
+-- Test binary I/O for bm25query type (COPY BINARY)
+
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+-- Create a table and index for testing
+CREATE TABLE binary_io_docs (id SERIAL PRIMARY KEY, content TEXT);
+INSERT INTO binary_io_docs (content) VALUES
+    ('hello world test'),
+    ('database search query');
+
+CREATE INDEX binary_io_idx ON binary_io_docs USING bm25(content)
+    WITH (text_config='english');
+
+-- Create a table with bm25query column
+CREATE TABLE query_export (id SERIAL, q bm25query);
+
+-- Insert some queries
+INSERT INTO query_export (q) VALUES
+    (to_bm25query('hello world', 'binary_io_idx')),
+    (to_bm25query('database search', 'binary_io_idx'));
+
+-- Show original data before COPY
+SELECT id, q::text AS original_query FROM query_export ORDER BY id;
+
+-- Test COPY TO BINARY (exercises tpquery_send)
+COPY query_export TO '/tmp/query_export.bin' WITH (FORMAT binary);
+
+-- Test COPY FROM BINARY (exercises tpquery_recv)
+CREATE TABLE query_import (id int, q bm25query);
+COPY query_import FROM '/tmp/query_export.bin' WITH (FORMAT binary);
+
+-- Verify data was imported correctly
+SELECT COUNT(*) AS imported_count FROM query_import;
+
+-- Verify the queries are equivalent
+SELECT
+    e.id,
+    e.q::text AS exported,
+    i.q::text AS imported,
+    e.q = i.q AS queries_match
+FROM query_export e
+JOIN query_import i ON e.id = i.id
+ORDER BY e.id;
+
+-- Clean up
+\! rm -f /tmp/query_export.bin
+DROP TABLE query_export;
+DROP TABLE query_import;
+DROP TABLE binary_io_docs CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Summary

- Fix data corruption in bm25query type when Postgres uses short (1-byte) varlena headers
- Functions `tpquery_out`, `tpquery_send`, `bm25_text_bm25query_score`, and `tpquery_eq` now properly detoast varlena arguments
- Fix `tpquery_send` to use `pq_begintypsend()` for proper binary protocol formatting
- Fix `tpquery_recv` to use `pq_getmsgbyte()` for version field

## Background

When Postgres stores small varlena values, it may use a 1-byte header instead of the standard 4-byte header. Functions using `PG_GETARG_POINTER` instead of `PG_DETOAST_DATUM` would access struct fields at incorrect offsets, causing data corruption.

This manifested as:
- Truncated query text in `tpquery_out`
- Wrong index OID values
- Binary I/O failures with COPY BINARY

## Testing

- Added `binary_io.sql` test that verifies COPY BINARY round-trip for bm25query type