### PR TITLE
Fix Coverity static analysis issues

### DIFF
--- a/src/am/build.c
+++ b/src/am/build.c
@@ -1108,7 +1108,8 @@ tp_insert(
 	tp_add_docid_to_pages(index, ht_ctid);
 
 	/* Recalculate IDF sum after insert */
-	tp_calculate_idf_sum(index_state);
+	if (index_state != NULL)
+		tp_calculate_idf_sum(index_state);
 
 	return true;
 }

--- a/src/am/scan.c
+++ b/src/am/scan.c
@@ -499,6 +499,9 @@ tp_rescan(
 	Assert(scan != NULL);
 	Assert(scan->opaque != NULL);
 
+	if (!so)
+		return;
+
 	/* Retrieve query LIMIT, if available */
 	{
 		int query_limit = tp_get_query_limit(scan->indexRelation);
@@ -690,6 +693,12 @@ tp_gettuple(IndexScanDesc scan, ScanDirection dir)
 	if (so->result_ctids == NULL && !so->eof_reached)
 	{
 		if (!tp_execute_scoring_query(scan))
+		{
+			so->eof_reached = true;
+			return false;
+		}
+		/* Scoring query must have allocated result_ctids on success */
+		if (so->result_ctids == NULL)
 		{
 			so->eof_reached = true;
 			return false;

--- a/src/memtable/scan.c
+++ b/src/memtable/scan.c
@@ -47,8 +47,11 @@ tp_memtable_search(
 	int			   entry_count;
 	char		  *ptr;
 
+	if (!so)
+		return false;
+
 	/* Use limit from scan state, fallback to GUC parameter */
-	if (so && so->limit > 0)
+	if (so->limit > 0)
 		max_results = so->limit;
 	else
 		max_results = tp_default_limit;

--- a/src/segment/scan.c
+++ b/src/segment/scan.c
@@ -41,11 +41,16 @@ tp_segment_posting_iterator_init(
 		TpSegmentReader			 *reader,
 		const char				 *term)
 {
-	TpSegmentHeader *header = reader->header;
+	TpSegmentHeader *header;
 	TpDictionary	 dict_header;
 	int				 left, right, mid;
 	char			*term_buffer = NULL;
 	uint32			 buffer_size = 0;
+
+	if (!reader || !reader->header)
+		return false;
+
+	header = reader->header;
 
 	iter->reader			  = reader;
 	iter->term				  = term;

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -964,10 +964,8 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 			continue;
 		}
 
-		/* Calculate number of blocks */
+		/* Calculate number of blocks (always >= 1 since doc_count > 0 here) */
 		num_blocks = (doc_count + TP_BLOCK_SIZE - 1) / TP_BLOCK_SIZE;
-		if (num_blocks == 0 && doc_count > 0)
-			num_blocks = 1;
 		term_blocks[i].block_count = (uint16)num_blocks;
 
 		/* Convert postings to block format */


### PR DESCRIPTION
## Summary
Fix all 11 Coverity static analysis issues reported in the initial scan.

## Issues Fixed

| CID | Severity | File | Issue | Fix |
|-----|----------|------|-------|-----|
| 640953, 640947 | High | merge.c | Uninitialized `dict_buf` | Initialize to `InvalidBuffer` |
| 640951 | Medium | build.c | NULL deref in `tp_insert` | Add NULL check |
| 640946 | Medium | am/scan.c | Deref before NULL check | Add early return |
| 640955 | Medium | am/scan.c | Deref after NULL check | Add post-query NULL check |
| 640949 | Medium | memtable/scan.c | Deref after NULL check | Add early return |
| 640952 | Medium | segment/scan.c | Deref before NULL check | Add NULL check for reader |
| 640954 | Medium | state.c | Dead code | Remove redundant NULL check |
| 640957 | Medium | state.c | Unexpected control flow | Use flag instead of continue in PG_CATCH |
| 640950 | Medium | merge.c | Explicit NULL deref | Add NULL check in allocation condition |
| 640956 | Medium | segment.c | Dead code | Remove unreachable num_blocks check |
| 640948 | Medium | merge.c | Dead code | Remove unreachable num_blocks check |

## Testing
- All 35 SQL regression tests pass
- All shell-based tests pass (concurrency, recovery, segment, stress)
