### PR TITLE
Add pgspot CI workflow for SQL security checks

### DIFF
--- a/.github/workflows/pgspot.yml
+++ b/.github/workflows/pgspot.yml
@@ -1,0 +1,44 @@
+name: pgspot Security Check
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'sql/**'
+      - '.github/workflows/pgspot.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'sql/**'
+      - '.github/workflows/pgspot.yml'
+
+jobs:
+  pgspot:
+    name: Check Extension SQL
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install pgspot
+      run: pip install pgspot
+
+    - name: Run pgspot
+      run: |
+        # Check extension SQL files
+        # Ignore PS017 (unqualified object reference) - false positives for
+        # type/operator definitions that reference types being created
+        has_errors=0
+        for sql_file in sql/pg_textsearch--*.sql; do
+          echo "Checking $sql_file"
+          if ! pgspot --ignore PS017 "$sql_file"; then
+            has_errors=1
+          fi
+        done
+        exit $has_errors

--- a/sql/pg_textsearch--0.0.4--0.0.5.sql
+++ b/sql/pg_textsearch--0.0.4--0.0.5.sql
@@ -1,7 +1,7 @@
 -- Upgrade from 0.0.4 to 0.0.5
 
 -- Function to force segment write (spill memtable to disk)
-CREATE OR REPLACE FUNCTION bm25_spill_index(index_name text)
+CREATE FUNCTION bm25_spill_index(index_name text)
 RETURNS int4
 AS 'MODULE_PATHNAME', 'tp_spill_memtable'
 LANGUAGE C VOLATILE STRICT;

--- a/sql/pg_textsearch--0.3.0.sql
+++ b/sql/pg_textsearch--0.3.0.sql
@@ -186,7 +186,7 @@ END
 $$;
 
 -- Function to force segment write (spill memtable to disk)
-CREATE OR REPLACE FUNCTION bm25_spill_index(index_name text)
+CREATE FUNCTION bm25_spill_index(index_name text)
 RETURNS int4
 AS 'MODULE_PATHNAME', 'tp_spill_memtable'
 LANGUAGE C VOLATILE STRICT;

--- a/sql/pg_textsearch--0.4.0.sql
+++ b/sql/pg_textsearch--0.4.0.sql
@@ -186,7 +186,7 @@ END
 $$;
 
 -- Function to force segment write (spill memtable to disk)
-CREATE OR REPLACE FUNCTION bm25_spill_index(index_name text)
+CREATE FUNCTION bm25_spill_index(index_name text)
 RETURNS int4
 AS 'MODULE_PATHNAME', 'tp_spill_memtable'
 LANGUAGE C VOLATILE STRICT;


### PR DESCRIPTION
## Summary
- Add GitHub workflow to run pgspot on extension SQL files for security checks
- Fix PS002 warning by changing `CREATE OR REPLACE` to `CREATE` for `bm25_spill_index` function
- Ignore PS017 warnings (false positives for type/operator definitions within the extension)

## Testing
- All 37 regression tests pass
- pgspot runs clean on all SQL files with `--ignore PS017`