### PR TITLE
docs: correct command to load Wikipedia test data

### DIFF
--- a/benchmarks/datasets/wikipedia/load.sql
+++ b/benchmarks/datasets/wikipedia/load.sql
@@ -2,7 +2,7 @@
 -- Loads Wikipedia articles and creates BM25 index
 --
 -- Usage:
---   psql -v data_dir="'/path/to/data'" -f load.sql
+--   DATA_DIR=/path/to/data psql -f load.sql
 
 \set ON_ERROR_STOP on
 \timing on


### PR DESCRIPTION
`benchmarks/datasets/wikipedia/load.sql` does not use the psql variable `data_dir`, it uses the environment variable `$DATA_DIR`