### PR TITLE
Document Python 3.10 pin for wikiextractor

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -695,6 +695,7 @@ jobs:
         echo "After cleanup:"
         df -h /
 
+    # wikiextractor requires Python 3.10 (unmaintained, breaks on newer versions)
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
## Summary

- Add comment explaining why Python 3.10 is pinned in the comparative-benchmark job
- wikiextractor is unmaintained and breaks on Python 3.11+