### PR TITLE
chore: symlink AGENTS.md to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Most non-Claude agentic coding tools look for AGENTS.md instead of CLAUDE.md. Create a symlink: AGENTS.md -> CLAUDE.md to support them as well.

Tested that it works locally.