### PR TITLE
chore: improve wikipedia download script python 3.10 handling

### DIFF
--- a/benchmarks/datasets/wikipedia/download.sh
+++ b/benchmarks/datasets/wikipedia/download.sh
@@ -14,13 +14,16 @@ sys.exit(0 if (sys.version_info.major, sys.version_info.minor) == (3, 10) else 1
 EOF
 }
 
-if is_py310 python3.10; then
-    PYTHON_BIN=python3.10
-elif is_py310 python3; then
-    PYTHON_BIN=python3
-elif is_py310 python; then
-    PYTHON_BIN=python
-else
+PYTHON_BIN=""
+
+for candidate in python3.10 python3 python; do
+    if is_py310 "$candidate"; then
+        PYTHON_BIN="$candidate"
+        break
+    fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
     echo "Error: Python 3.10 is required. Install python3.10 and retry."
     exit 1
 fi


### PR DESCRIPTION
Summary:

- Added a strict Python 3.10 detector, inspecting python3.10, python3, or python, only use it if it is 3.10. Otherwise exit with an explicit error.
- We no longer invoke `pip` or `pip3` directly because:

  1. It won't work on externally managed environments. For example, macOS:

     ```sh 
     $ pip3 install xxx 
     error: externally-managed-environment
     ```

  2. It may not be the pip associated with Python 3.10