### PR TITLE
refactor: make text_config accept qualified names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ PG_CPPFLAGS = -I$(srcdir)/src -g -O2 -Wall -Wextra -Wunused-function -Wunused-va
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic binary_io bmw compression coverage deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed partitioned partitioned_many queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 segment segment_integrity strings unsupported updates vector unlogged_index wand
+REGRESS = aerodocs basic binary_io bmw compression coverage deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed partitioned partitioned_many queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 segment segment_integrity strings unsupported updates vector unlogged_index wand text_config
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -280,7 +280,8 @@ tp_build_extract_options(
 					(char *)options + options->text_config_offset);
 			/* Convert text config name to OID */
 			{
-				List *names = list_make1(makeString(*text_config_name));
+				List *names =
+						stringToQualifiedNameList(*text_config_name, NULL);
 
 				*text_config_oid = get_ts_config_oid(names, false);
 				list_free(names);
@@ -938,7 +939,8 @@ tp_buildempty(Relation index)
 			text_config_name = pstrdup(
 					(char *)options + options->text_config_offset);
 			{
-				List *names = list_make1(makeString(text_config_name));
+				List *names =
+						stringToQualifiedNameList(text_config_name, NULL);
 
 				text_config_oid = get_ts_config_oid(names, false);
 				list_free(names);

--- a/test/expected/text_config.out
+++ b/test/expected/text_config.out
@@ -1,0 +1,18 @@
+-- Test parameter "text_config" accepts qualified names
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+INFO:  pg_textsearch v0.5.0-dev installed
+-- Create table
+CREATE TABLE text_config_tbl (
+    id SERIAL PRIMARY KEY,
+    content TEXT
+);
+-- Verify that we can use qualified names when specifying "text_config"
+-- and the text configuration can be found by Postgres
+CREATE INDEX text_config_idx1 ON text_config_tbl USING bm25 (content) 
+    WITH (text_config = 'pg_catalog.english', k1=1.2, b=0.75);
+NOTICE:  BM25 index build started for relation text_config_idx1
+NOTICE:  Using text search configuration: pg_catalog.english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00, text_config='pg_catalog.english' (k1=1.20, b=0.75)
+DROP TABLE text_config_tbl;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/text_config.sql
+++ b/test/sql/text_config.sql
@@ -1,0 +1,16 @@
+-- Test parameter "text_config" accepts qualified names
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+-- Create table
+CREATE TABLE text_config_tbl (
+    id SERIAL PRIMARY KEY,
+    content TEXT
+);
+
+-- Verify that we can use qualified names when specifying "text_config"
+-- and the text configuration can be found by Postgres
+CREATE INDEX text_config_idx1 ON text_config_tbl USING bm25 (content) 
+    WITH (text_config = 'pg_catalog.english', k1=1.2, b=0.75);
+
+DROP TABLE text_config_tbl;
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
Previously, parameter `text_config` did not accept qualified names because we didn't split them before passing them to `get_ts_config_oid()`.

```sql
steve=# create index idx on test using bm25 (content) with (text_config = 'pg_catalog.english');
NOTICE:  BM25 index build started for relation idx
ERROR:  text search configuration "pg_catalog.english" does not exist
```

Fixes #156. Regression test added, see `test/sql/text_config.sql`.