### PR TITLE
Fix Coverity static analysis issues

### DIFF
--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -842,10 +842,9 @@ write_term_postings(
 		return 0;
 	}
 
-	/* Calculate number of blocks */
-	num_blocks = (doc_count + TP_BLOCK_SIZE - 1) / TP_BLOCK_SIZE;
-	if (num_blocks == 0 && doc_count > 0)
-		num_blocks = 1;
+	/* Calculate number of blocks (ceiling division, always >= 1 for doc_count
+	 * > 0) */
+	num_blocks			   = (doc_count + TP_BLOCK_SIZE - 1) / TP_BLOCK_SIZE;
 	term_info->block_count = (uint16)num_blocks;
 
 	/* Convert postings to block format */

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -903,7 +903,7 @@ write_merged_segment(
 	for (i = 0; i < num_terms; i++)
 	{
 		CollectedPosting *postings;
-		uint32			  doc_count;
+		uint32			  doc_count = 0;
 		uint32			  j;
 		uint32			  block_idx;
 		uint32			  num_blocks;

--- a/src/segment/scan.c
+++ b/src/segment/scan.c
@@ -134,8 +134,7 @@ tp_segment_posting_iterator_init(
 			iter->initialized	 = true;
 			iter->finished		 = (iter->dict_entry.block_count == 0);
 
-			if (term_buffer)
-				pfree(term_buffer);
+			pfree(term_buffer);
 			return true;
 		}
 		else if (cmp < 0)
@@ -148,8 +147,7 @@ tp_segment_posting_iterator_init(
 		}
 	}
 
-	if (term_buffer)
-		pfree(term_buffer);
+	pfree(term_buffer);
 	return false;
 }
 


### PR DESCRIPTION
## Summary

- Remove dead code in `write_term_postings()` where a condition can never be true
- Remove redundant null checks before `pfree()` in `tp_segment_posting_iterator_init()`
- Initialize `doc_count` variable to satisfy Coverity's inter-procedural analysis

## Testing

- All SQL regression tests pass
- Concurrency, recovery, and segment shell tests pass