### PR TITLE
chore: correct comment of am->amusemaintenanceworkmem

### DIFF
--- a/src/am/handler.c
+++ b/src/am/handler.c
@@ -82,8 +82,9 @@ tp_handler(PG_FUNCTION_ARGS)
 	amroutine->ampredlocks		  = false; /* No predicate locking */
 	amroutine->amcanparallel	  = false; /* No parallel scan support yet */
 	amroutine->amcanbuildparallel = true;
-	amroutine->amcaninclude		  = false;		/* No INCLUDE columns */
-	amroutine->amusemaintenanceworkmem = false; /* Use work_mem for builds */
+	amroutine->amcaninclude		  = false; /* No INCLUDE columns */
+	amroutine->amusemaintenanceworkmem =
+			false; /* Vacuum does not use maintenance work mem */
 	amroutine->amsummarizing		   = false;
 	amroutine->amparallelvacuumoptions = VACUUM_OPTION_PARALLEL_BULKDEL;
 	amroutine->amkeytype			   = InvalidOid;


### PR DESCRIPTION
The current semantics of this field are not about whether maintenance_work_mem is used during index builds. Instead, it indicates whether the index needs a slice of the global maintenance memory budget when being vacuumed in parallel[1]

Given that, this commit corrects the code comment of amroutine->amusemaintenanceworkmem to reflect why we set it to false.

Comment-only change; no behavior is modified.

[1]: This is the only use of amusemaintenance in Postgres, https://github.com/postgres/postgres/blob/a9bdb63bba8a631cd4797393307eecf5fcde9167/src/backend/commands/vacuumparallel.c#L351