### PR TITLE
Update copyright years to 2025-2026

### DIFF
--- a/src/am/am.h
+++ b/src/am/am.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * am/am.h - BM25 access method shared definitions

--- a/src/am/handler.c
+++ b/src/am/handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * am/handler.c - BM25 access method handler and options

--- a/src/am/scan.c
+++ b/src/am/scan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * am/scan.c - BM25 index scan operations

--- a/src/am/vacuum.c
+++ b/src/am/vacuum.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * am/vacuum.c - BM25 index vacuum and maintenance operations

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * constants.h - Shared constants and configuration

--- a/src/debug/dump.c
+++ b/src/debug/dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * dump.c - Index dump and debugging utilities

--- a/src/debug/dump.h
+++ b/src/debug/dump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * dump.h - Index dump and debugging utilities

--- a/src/memtable/memtable.c
+++ b/src/memtable/memtable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * memtable.c - In-memory inverted index implementation

--- a/src/memtable/memtable.h
+++ b/src/memtable/memtable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * memtable.h - In-memory inverted index structures

--- a/src/memtable/posting.c
+++ b/src/memtable/posting.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * posting.c - Posting list management for in-memory indexes

--- a/src/memtable/scan.c
+++ b/src/memtable/scan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * memtable/scan.c - Memtable scan operations

--- a/src/memtable/scan.h
+++ b/src/memtable/scan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * memtable/scan.h - Memtable scan operations

--- a/src/memtable/source.c
+++ b/src/memtable/source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * memtable/source.c - Memtable implementation of TpDataSource

--- a/src/memtable/source.h
+++ b/src/memtable/source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * memtable/source.h - Memtable implementation of TpDataSource

--- a/src/memtable/stringtable.c
+++ b/src/memtable/stringtable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * stringtable.c - String interning hash table using dshash

--- a/src/memtable/stringtable.h
+++ b/src/memtable/stringtable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * stringtable.h - String interning hash table using dshash

--- a/src/planner/cost.c
+++ b/src/planner/cost.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * planner/cost.c - Cost estimation for BM25 index scans

--- a/src/planner/cost.h
+++ b/src/planner/cost.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * planner/cost.h - Cost estimation for BM25 index scans

--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * planner/hooks.c - Parse analysis and planner hooks

--- a/src/planner/hooks.h
+++ b/src/planner/hooks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * planner/hooks.h - Planner hooks for BM25 query optimization

--- a/src/query/bmw.c
+++ b/src/query/bmw.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * bmw.c - Block-Max WAND query optimization implementation

--- a/src/query/bmw.h
+++ b/src/query/bmw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * bmw.h - Block-Max WAND query optimization

--- a/src/query/score.c
+++ b/src/query/score.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * query/score.c - BM25 scoring operators and document ranking

--- a/src/query/score.h
+++ b/src/query/score.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * query/score.h - BM25 scoring operator interface

--- a/src/segment/compression.c
+++ b/src/segment/compression.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * compression.c - Block compression for posting lists

--- a/src/segment/compression.h
+++ b/src/segment/compression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * compression.h - Block compression for posting lists

--- a/src/segment/dictionary.c
+++ b/src/segment/dictionary.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * dictionary.c - Term dictionary for disk segments

--- a/src/segment/dictionary.h
+++ b/src/segment/dictionary.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * dictionary.h - Term dictionary for disk segments

--- a/src/segment/docmap.c
+++ b/src/segment/docmap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * docmap.c - Document ID mapping implementation

--- a/src/segment/docmap.h
+++ b/src/segment/docmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * docmap.h - Document ID mapping for segment format

--- a/src/segment/fieldnorm.h
+++ b/src/segment/fieldnorm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * fieldnorm.h - Document length quantization for BM25 scoring

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * segment/merge.c - Segment merge for LSM-style compaction

--- a/src/segment/merge.h
+++ b/src/segment/merge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * segment_merge.h - Segment merge for LSM-style compaction

--- a/src/segment/pagemapper.h
+++ b/src/segment/pagemapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * pagemapper.h - Segment logical-to-physical address translation

--- a/src/segment/scan.c
+++ b/src/segment/scan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * segment/scan.c - Zero-copy scan execution for segments

--- a/src/source.c
+++ b/src/source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * source.c - Common helpers for data source interface

--- a/src/source.h
+++ b/src/source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * source.h - Abstract data source interface for posting lists

--- a/src/state/limit.c
+++ b/src/state/limit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * limit.c - Query LIMIT optimization

--- a/src/state/limit.h
+++ b/src/state/limit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * limit.h - Query LIMIT optimization interface

--- a/src/state/metapage.c
+++ b/src/state/metapage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * metapage.c - Index metapage operations

--- a/src/state/metapage.h
+++ b/src/state/metapage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * metapage.h - Index metapage structures and operations

--- a/src/state/registry.c
+++ b/src/state/registry.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * registry.c - Global registry mapping index OIDs to shared state

--- a/src/state/registry.h
+++ b/src/state/registry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * registry.h - Global registry for shared index states

--- a/src/state/state.h
+++ b/src/state/state.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * state.h - Index state management structures

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * query.c - bm25query data type implementation

--- a/src/types/query.h
+++ b/src/types/query.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * query.h - bm25query data type interface

--- a/src/types/vector.c
+++ b/src/types/vector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * vector.c - bm25vector data type implementation

--- a/src/types/vector.h
+++ b/src/types/vector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Tiger Data, Inc.
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
  * vector.h - bm25vector data type interface


### PR DESCRIPTION
## Summary
Updates copyright statements from 2025 to 2025-2026 in all source files as requested in issue #178.

## Changes
- Updated 48 files (.c, .h, .sql)
- Changed "Copyright (c) 2025 Tiger Data, Inc." to "Copyright (c) 2025-2026 Tiger Data, Inc."

## Issue
Closes #178

## Files Modified
All source files with copyright statements have been updated.