### PR TITLE
chore: drop directory prefix from the file identifiers

### DIFF
--- a/src/am/am.h
+++ b/src/am/am.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * am/am.h - BM25 access method shared definitions
+ * am.h - BM25 access method shared definitions
  */
 #pragma once
 

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * am/build.c - BM25 index build, insert, and spill operations
+ * build.c - BM25 index build, insert, and spill operations
  */
 #include <postgres.h>
 

--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * am/build_parallel.c - Parallel index build implementation
+ * build_parallel.c - Parallel index build implementation
  *
  * Architecture:
  * - Workers scan the heap and build memtables in shared DSA memory

--- a/src/am/build_parallel.h
+++ b/src/am/build_parallel.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * am/build_parallel.h - Parallel index build structures
+ * build_parallel.h - Parallel index build structures
  *
  * Architecture:
  * - Workers scan heap and build memtables in shared DSA memory

--- a/src/am/handler.c
+++ b/src/am/handler.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * am/handler.c - BM25 access method handler and options
+ * handler.c - BM25 access method handler and options
  */
 #include <postgres.h>
 

--- a/src/am/scan.c
+++ b/src/am/scan.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * am/scan.c - BM25 index scan operations
+ * scan.c - BM25 index scan operations
  */
 #include <postgres.h>
 

--- a/src/am/vacuum.c
+++ b/src/am/vacuum.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * am/vacuum.c - BM25 index vacuum and maintenance operations
+ * vacuum.c - BM25 index vacuum and maintenance operations
  */
 #include <postgres.h>
 

--- a/src/memtable/local_memtable.c
+++ b/src/memtable/local_memtable.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * memtable/local_memtable.c - Per-worker local memtable for parallel builds
+ * local_memtable.c - Per-worker local memtable for parallel builds
  */
 #include <postgres.h>
 

--- a/src/memtable/local_memtable.h
+++ b/src/memtable/local_memtable.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * memtable/local_memtable.h - Per-worker local memtable for parallel builds
+ * local_memtable.h - Per-worker local memtable for parallel builds
  *
  * Unlike the shared DSA-based memtable, a local memtable uses palloc'd memory
  * private to a single backend. This eliminates contention during parallel

--- a/src/memtable/posting_entry.h
+++ b/src/memtable/posting_entry.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * memtable/posting_entry.h - Common posting entry type
+ * posting_entry.h - Common posting entry type
  *
  * This type is shared between the DSA-based shared memtable and the
  * palloc-based local memtable used in parallel builds.

--- a/src/memtable/scan.c
+++ b/src/memtable/scan.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * memtable/scan.c - Memtable scan operations
+ * scan.c - Memtable scan operations
  *
  * This module provides the search interface for scanning the memtable
  * (and segments) during index scans.

--- a/src/memtable/scan.h
+++ b/src/memtable/scan.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * memtable/scan.h - Memtable scan operations
+ * scan.h - Memtable scan operations
  */
 #pragma once
 

--- a/src/memtable/source.c
+++ b/src/memtable/source.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * memtable/source.c - Memtable implementation of TpDataSource
+ * source.c - Memtable implementation of TpDataSource
  */
 #include <postgres.h>
 

--- a/src/memtable/source.h
+++ b/src/memtable/source.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * memtable/source.h - Memtable implementation of TpDataSource
+ * source.h - Memtable implementation of TpDataSource
  */
 #pragma once
 

--- a/src/planner/cost.c
+++ b/src/planner/cost.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * planner/cost.c - Cost estimation for BM25 index scans
+ * cost.c - Cost estimation for BM25 index scans
  */
 #include <postgres.h>
 

--- a/src/planner/cost.h
+++ b/src/planner/cost.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * planner/cost.h - Cost estimation for BM25 index scans
+ * cost.h - Cost estimation for BM25 index scans
  */
 #pragma once
 

--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * planner/hooks.c - Parse analysis and planner hooks
+ * hooks.c - Parse analysis and planner hooks
  *
  * When queries use the <@> operator without an explicit index, this hook
  * identifies the column being scored and finds a suitable BM25 index.

--- a/src/query/score.c
+++ b/src/query/score.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * query/score.c - BM25 scoring operators and document ranking
+ * score.c - BM25 scoring operators and document ranking
  */
 #include <postgres.h>
 

--- a/src/query/score.h
+++ b/src/query/score.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * query/score.h - BM25 scoring operator interface
+ * score.h - BM25 scoring operator interface
  */
 #pragma once
 

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * segment/merge.c - Segment merge for LSM-style compaction
+ * merge.c - Segment merge for LSM-style compaction
  */
 #include <postgres.h>
 

--- a/src/segment/merge.h
+++ b/src/segment/merge.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * segment_merge.h - Segment merge for LSM-style compaction
+ * merge.h - Segment merge for LSM-style compaction
  */
 #pragma once
 

--- a/src/segment/scan.c
+++ b/src/segment/scan.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * segment/scan.c - Zero-copy scan execution for segments
+ * scan.c - Zero-copy scan execution for segments
  */
 #include <postgres.h>
 


### PR DESCRIPTION
Drop directory prefix from the file identifiers so that we don't need to update them when moving files around.