### PR TITLE
Fix Coverity static analysis issues

### DIFF
--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -877,12 +877,9 @@ write_term_postings(
 		/* Calculate block stats */
 		for (j = block_start; j < block_end; j++)
 		{
-			if (block_postings[j].doc_id > last_doc_id)
-				last_doc_id = block_postings[j].doc_id;
-			if (block_postings[j].frequency > max_tf)
-				max_tf = block_postings[j].frequency;
-			if (block_postings[j].fieldnorm > max_norm)
-				max_norm = block_postings[j].fieldnorm;
+			last_doc_id = Max(last_doc_id, block_postings[j].doc_id);
+			max_tf		= Max(max_tf, block_postings[j].frequency);
+			max_norm	= Max(max_norm, block_postings[j].fieldnorm);
 		}
 
 		/* Build skip entry */

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -812,8 +812,8 @@ write_merged_segment(
 
 	/* Accumulated skip entries for all terms */
 	TpSkipEntry *all_skip_entries;
-	uint32		 skip_entries_count;
-	uint32		 skip_entries_capacity;
+	uint32		 skip_entries_count	   = 0;
+	uint32		 skip_entries_capacity = 0;
 
 	if (num_terms == 0)
 		return InvalidBlockNumber;

--- a/src/segment/scan.c
+++ b/src/segment/scan.c
@@ -48,10 +48,12 @@ tp_segment_posting_iterator_init(
 	char			*term_buffer = NULL;
 	uint32			 buffer_size = 0;
 
-	if (!reader || !reader->header)
+	if (reader == NULL)
 		return false;
 
 	header = reader->header;
+	if (header == NULL)
+		return false;
 
 	iter->reader			  = reader;
 	iter->term				  = term;


### PR DESCRIPTION
## Summary

Address three Coverity static analysis issues:

- **CID 640947** (merge.c): Initialize `skip_entries_count` and
  `skip_entries_capacity` at declaration to fix uninitialized scalar
  variable warning

- **CID 640952** (scan.c): Split null check into two separate statements
  in `tp_segment_posting_iterator_init()` to clarify control flow for
  Coverity's dereference-before-null-check analysis

- **CID 642865** (build_parallel.c): Use `Max()` macro instead of
  conditional assignments in `write_term_postings()` to eliminate
  logically dead code warning

## Testing

- All 39 SQL regression tests pass
- `make format-check` passes