### PR TITLE
Fix Coverity CID 640947: zero-initialize dict struct

### DIFF
--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -845,6 +845,7 @@ write_merged_segment(
 	header.dictionary_offset = writer.current_offset;
 
 	/* Write dictionary header */
+	memset(&dict, 0, sizeof(dict));
 	dict.num_terms = num_terms;
 	tp_segment_writer_write(
 			&writer, &dict, offsetof(TpDictionary, string_offsets));


### PR DESCRIPTION
## Summary

Fix Coverity static analysis issue CID 640947 (uninitialized scalar variable).

Coverity flagged that `dict.string_offsets` was uninitialized when passing
`&dict` to `tp_segment_writer_write()`. Although we only write up to
`offsetof(TpDictionary, string_offsets)` bytes (so the field isn't actually
used), Coverity cannot determine this statically.

Zero-initialize the struct at declaration to silence the warning.

## Testing

- All 39 SQL regression tests pass