### PR TITLE
refactor: use PageGetContents() for segment header access

### DIFF
--- a/src/am/build.c
+++ b/src/am/build.c
@@ -121,9 +121,8 @@ tp_auto_spill_if_needed(TpLocalIndexState *index_state, Relation index_rel)
 
 			seg_buf = ReadBuffer(index_rel, segment_root);
 			LockBuffer(seg_buf, BUFFER_LOCK_EXCLUSIVE);
-			seg_page				 = BufferGetPage(seg_buf);
-			seg_header				 = (TpSegmentHeader *)((char *)seg_page +
-											   SizeOfPageHeaderData);
+			seg_page   = BufferGetPage(seg_buf);
+			seg_header = (TpSegmentHeader *)PageGetContents(seg_page);
 			seg_header->next_segment = metap->level_heads[0];
 			MarkBufferDirty(seg_buf);
 			UnlockReleaseBuffer(seg_buf);
@@ -211,9 +210,8 @@ tp_spill_memtable(PG_FUNCTION_ARGS)
 
 			seg_buf = ReadBuffer(index_rel, segment_root);
 			LockBuffer(seg_buf, BUFFER_LOCK_EXCLUSIVE);
-			seg_page				 = BufferGetPage(seg_buf);
-			seg_header				 = (TpSegmentHeader *)((char *)seg_page +
-											   SizeOfPageHeaderData);
+			seg_page   = BufferGetPage(seg_buf);
+			seg_header = (TpSegmentHeader *)PageGetContents(seg_page);
 			seg_header->next_segment = metap->level_heads[0];
 			MarkBufferDirty(seg_buf);
 			UnlockReleaseBuffer(seg_buf);
@@ -944,8 +942,7 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 					seg_buf = ReadBuffer(index, segment_root);
 					LockBuffer(seg_buf, BUFFER_LOCK_EXCLUSIVE);
 					seg_page   = BufferGetPage(seg_buf);
-					seg_header = (TpSegmentHeader *)((char *)seg_page +
-													 SizeOfPageHeaderData);
+					seg_header = (TpSegmentHeader *)PageGetContents(seg_page);
 					seg_header->next_segment = metap->level_heads[0];
 					MarkBufferDirty(seg_buf);
 					UnlockReleaseBuffer(seg_buf);

--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -151,9 +151,8 @@ tp_worker_spill_memtable(
 
 		tail_buf = ReadBuffer(index, my_info->segment_tail);
 		LockBuffer(tail_buf, BUFFER_LOCK_EXCLUSIVE);
-		tail_page				  = BufferGetPage(tail_buf);
-		tail_header				  = (TpSegmentHeader *)((char *)tail_page +
-											SizeOfPageHeaderData);
+		tail_page	= BufferGetPage(tail_buf);
+		tail_header = (TpSegmentHeader *)PageGetContents(tail_page);
 		tail_header->next_segment = seg_block;
 		MarkBufferDirty(tail_buf);
 		UnlockReleaseBuffer(tail_buf);
@@ -1021,7 +1020,7 @@ write_final_header(
 {
 	Buffer buf = ReadBuffer(index, header_block);
 	LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
-	memcpy((char *)BufferGetPage(buf) + SizeOfPageHeaderData,
+	memcpy(PageGetContents(BufferGetPage(buf)),
 		   header,
 		   sizeof(TpSegmentHeader));
 	MarkBufferDirty(buf);
@@ -1249,9 +1248,8 @@ tp_link_all_worker_segments(TpParallelBuildShared *shared, Relation index)
 
 			tail_buf = ReadBuffer(index, chain_tail);
 			LockBuffer(tail_buf, BUFFER_LOCK_EXCLUSIVE);
-			tail_page				  = BufferGetPage(tail_buf);
-			tail_header				  = (TpSegmentHeader *)((char *)tail_page +
-												SizeOfPageHeaderData);
+			tail_page	= BufferGetPage(tail_buf);
+			tail_header = (TpSegmentHeader *)PageGetContents(tail_page);
 			tail_header->next_segment = worker_info[i].segment_head;
 			MarkBufferDirty(tail_buf);
 			UnlockReleaseBuffer(tail_buf);

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -1180,8 +1180,7 @@ write_merged_segment(
 	header_buf = ReadBuffer(index, header_block);
 	LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
 	header_page		= BufferGetPage(header_buf);
-	existing_header = (TpSegmentHeader *)((char *)header_page +
-										  SizeOfPageHeaderData);
+	existing_header = (TpSegmentHeader *)PageGetContents(header_page);
 
 	existing_header->dictionary_offset	 = header.dictionary_offset;
 	existing_header->strings_offset		 = header.strings_offset;
@@ -1494,9 +1493,8 @@ tp_merge_level_segments(Relation index, uint32 level)
 
 		seg_buf = ReadBuffer(index, new_segment);
 		LockBuffer(seg_buf, BUFFER_LOCK_EXCLUSIVE);
-		seg_page				 = BufferGetPage(seg_buf);
-		seg_header				 = (TpSegmentHeader *)((char *)seg_page +
-										   SizeOfPageHeaderData);
+		seg_page   = BufferGetPage(seg_buf);
+		seg_header = (TpSegmentHeader *)PageGetContents(seg_page);
 		seg_header->next_segment = metap->level_heads[level + 1];
 		MarkBufferDirty(seg_buf);
 		UnlockReleaseBuffer(seg_buf);

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -173,7 +173,7 @@ tp_segment_open_ex(Relation index, BlockNumber root_block, bool load_ctids)
 	/* Copy header to reader structure */
 	reader->header = palloc(sizeof(TpSegmentHeader));
 	memcpy(reader->header,
-		   (char *)header_page + SizeOfPageHeaderData,
+		   PageGetContents(header_page),
 		   sizeof(TpSegmentHeader));
 
 	header = reader->header;
@@ -1386,10 +1386,9 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
 	header_page = BufferGetPage(header_buf);
 
-	existing_header					= (TpSegmentHeader *)((char *)header_page +
-										  SizeOfPageHeaderData);
-	existing_header->strings_offset = header.strings_offset;
-	existing_header->entries_offset = header.entries_offset;
+	existing_header = (TpSegmentHeader *)PageGetContents(header_page);
+	existing_header->strings_offset		 = header.strings_offset;
+	existing_header->entries_offset		 = header.entries_offset;
 	existing_header->postings_offset	 = header.postings_offset;
 	existing_header->skip_index_offset	 = header.skip_index_offset;
 	existing_header->fieldnorm_offset	 = header.fieldnorm_offset;

--- a/src/state/state.c
+++ b/src/state/state.c
@@ -1305,8 +1305,7 @@ tp_bulk_load_spill_check(void)
 				seg_buf = ReadBuffer(index_rel, segment_root);
 				LockBuffer(seg_buf, BUFFER_LOCK_EXCLUSIVE);
 				seg_page   = BufferGetPage(seg_buf);
-				seg_header = (TpSegmentHeader *)((char *)seg_page +
-												 SizeOfPageHeaderData);
+				seg_header = (TpSegmentHeader *)PageGetContents(seg_page);
 				seg_header->next_segment = metap->level_heads[0];
 				MarkBufferDirty(seg_buf);
 				UnlockReleaseBuffer(seg_buf);


### PR DESCRIPTION
## Summary

Replace direct `(char *)page + SizeOfPageHeaderData` with `PageGetContents(page)` for `TpSegmentHeader` access.

## Motivation

Per [code review feedback](https://github.com/timescale/pg_textsearch/pull/114#pullrequestreview-3721245324), using `PageGetContents()` is more idiomatic Postgres code. While `SizeOfPageHeaderData` (24 bytes) is typically already MAXALIGN'd and produces identical results, `PageGetContents()` is:

- More idiomatic Postgres API usage
- Future-proof if `SizeOfPageHeaderData` ever changes
- Consistent with how we access other page content types (e.g., `TpIndexMetaPage`, `TpDocidPageHeader`)

## Changes

Updated all `TpSegmentHeader` access patterns in:
- `src/am/build.c` (3 occurrences)
- `src/am/build_parallel.c` (3 occurrences)
- `src/segment/merge.c` (2 occurrences)
- `src/segment/segment.c` (2 occurrences)
- `src/state/state.c` (1 occurrence)

No functional change - purely a style/consistency improvement.

## Testing

- `make installcheck` passes