### PR TITLE
ci: use standard runners for benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -120,13 +120,13 @@ jobs:
         mkdir -p tmp_bench/socket
         initdb -D tmp_bench/data --auth-local=trust --auth-host=trust
 
-        # Parallel build requires maintenance_work_mem >= 32MB * (workers + 1)
-        # 1GB allows up to 31 workers
+        # Parallel build requires maintenance_work_mem >= 64MB
+        # (ubuntu-latest: 2-4 vCPUs, ~7GB RAM)
         NCPUS=$(nproc)
         cat >> tmp_bench/data/postgresql.conf << EOF
         unix_socket_directories = '$PWD/tmp_bench/socket'
-        shared_buffers = 4GB
-        maintenance_work_mem = 1GB
+        shared_buffers = 1GB
+        maintenance_work_mem = 512MB
         max_parallel_maintenance_workers = $NCPUS
         EOF
 
@@ -580,16 +580,17 @@ jobs:
         initdb -D tmp_bench/data --auth-local=trust --auth-host=trust
 
         # Use identical configuration to pg_textsearch benchmark
+        # (ubuntu-latest: 2-4 vCPUs, ~7GB RAM)
         NCPUS=$(nproc)
         cat >> tmp_bench/data/postgresql.conf << EOF
         unix_socket_directories = '$PWD/tmp_bench/socket'
-        shared_buffers = 4GB
-        effective_cache_size = 12GB
-        maintenance_work_mem = 1GB
-        work_mem = 128MB
+        shared_buffers = 1GB
+        effective_cache_size = 4GB
+        maintenance_work_mem = 512MB
+        work_mem = 64MB
         max_connections = 20
         checkpoint_completion_target = 0.9
-        wal_buffers = 64MB
+        wal_buffers = 16MB
         random_page_cost = 1.1
         effective_io_concurrency = 200
         max_parallel_maintenance_workers = $NCPUS
@@ -751,7 +752,7 @@ jobs:
 
   # Full benchmark suite
   full-benchmark:
-    runs-on: ubuntu-latest-16-cores  # 16 vCPUs, 64 GB RAM for parallel scaling tests
+    runs-on: ubuntu-latest  # Standard runner (2-4 vCPUs)
     timeout-minutes: 360  # 6 hours max for full Wikipedia
 
     steps:
@@ -806,19 +807,18 @@ jobs:
         mkdir -p tmp_bench/socket
         initdb -D tmp_bench/data --auth-local=trust --auth-host=trust
 
-        # Tune for benchmarking (ubuntu-latest: 4 vCPUs, 16GB RAM)
-        # Parallel build requires maintenance_work_mem >= 32MB * (workers + 1)
-        # 1GB allows up to 31 workers
+        # Tune for benchmarking (ubuntu-latest: 2-4 vCPUs, ~7GB RAM)
+        # Parallel build requires maintenance_work_mem >= 64MB
         NCPUS=$(nproc)
         cat >> tmp_bench/data/postgresql.conf << EOF
         unix_socket_directories = '$PWD/tmp_bench/socket'
-        shared_buffers = 4GB
-        effective_cache_size = 12GB
-        maintenance_work_mem = 1GB
-        work_mem = 128MB
+        shared_buffers = 1GB
+        effective_cache_size = 4GB
+        maintenance_work_mem = 512MB
+        work_mem = 64MB
         max_connections = 20
         checkpoint_completion_target = 0.9
-        wal_buffers = 64MB
+        wal_buffers = 16MB
         random_page_cost = 1.1
         effective_io_concurrency = 200
         max_parallel_maintenance_workers = $NCPUS


### PR DESCRIPTION
## Summary
- Reverts benchmark workflow from `ubuntu-latest-16-cores` to standard `ubuntu-latest` runners
- Adjusts PostgreSQL memory settings to fit within ~7GB RAM limit
- Fixes jobs that were queueing indefinitely due to unavailable 16-core runners

## Changes
| Setting | Before | After |
|---------|--------|-------|
| Runner | ubuntu-latest-16-cores | ubuntu-latest |
| shared_buffers | 4GB | 1GB |
| effective_cache_size | 12GB | 4GB |
| maintenance_work_mem | 1GB | 512MB |
| work_mem | 128MB | 64MB |
| wal_buffers | 64MB | 16MB |

The 512MB maintenance_work_mem is still well above the 64MB minimum required for parallel index builds.

## Testing
Manually triggered workflow succeeded and results look reasonable.
