### PR TITLE
chore: standardize on clang-format v21.1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,9 +248,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install clang-format
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-format
+      run: pip install clang-format==21.1.8
 
     - name: Check formatting
       run: |

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -19,9 +19,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install clang-format
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-format
+      run: pip install clang-format==21.1.8
 
     - name: Check formatting
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,11 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v18.1.8'
+    rev: 'v21.1.8'
     hooks:
       - id: clang-format
         types: [c]
         files: ^src/.*\.(c|h)$
         args: [--style=file]
-
-  - repo: local
-    hooks:
-      - id: tapir-format-check
-        name: Tapir C Format Check
-        entry: clang-format
-        language: system
-        files: ^src/.*\.(c|h)$
-        args: [--dry-run, --Werror]
-        pass_filenames: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
## Summary

- Pre-commit: bump mirrors-clang-format from v18.1.8 to v21.1.8
- Pre-commit: remove redundant tapir-format-check hook (the two hooks used different clang-format versions, causing conflicts)
- CI: use `pip install clang-format==21.1.8` instead of `apt-get install clang-format` to pin exact version

No source files change — v18 and v21 produce identical output on the current codebase. The difference only matters for new code patterns (e.g., `errdetail()` line wrapping in deeply nested `ereport` calls).

## Testing

- `make format-check` passes locally with system clang-format 21.1.8