### PR TITLE
chore: bump System X benchmark version to 0.21.6

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ permissions:
 
 env:
   # System X (competitive baseline) version for benchmarking
-  SYSTEM_X_VERSION: "0.20.6"
+  SYSTEM_X_VERSION: "0.21.6"
 
 on:
   # Nightly benchmark


### PR DESCRIPTION
## Summary

Update the ParadeDB (System X) version used in competitive benchmarks from 0.20.6 to 0.21.6.

## Testing

The next benchmark run will use the new version.