### PR TITLE
feat: iterative index scan with exponential backoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ PG_CPPFLAGS = -I$(srcdir)/src -g -O2 -Wall -Wextra -Wunused-function -Wunused-va
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic binary_io bmw compression concurrent_build coverage deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed parallel_build partitioned partitioned_many queries schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings unsupported updates vector unlogged_index wand text_config
+REGRESS = aerodocs basic binary_io bmw compression concurrent_build coverage deletion vacuum dropped empty implicit index inheritance limits lock manyterms memory merge mixed parallel_build partitioned partitioned_many queries rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings unsupported updates vector unlogged_index wand text_config
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/src/am/am.h
+++ b/src/am/am.h
@@ -36,7 +36,8 @@ typedef struct TpScanOpaqueData
 	bool		eof_reached;   /* End of scan flag */
 
 	/* LIMIT optimization */
-	int limit; /* Query LIMIT value, -1 if none */
+	int limit;			  /* Query LIMIT value, -1 if none */
+	int max_results_used; /* Internal limit used for current batch */
 } TpScanOpaqueData;
 
 typedef TpScanOpaqueData *TpScanOpaque;

--- a/src/memtable/scan.c
+++ b/src/memtable/scan.c
@@ -110,8 +110,9 @@ tp_memtable_search(
 			so->result_ctids,
 			&so->result_scores);
 
-	so->result_count = result_count;
-	so->current_pos	 = 0;
+	so->result_count	 = result_count;
+	so->current_pos		 = 0;
+	so->max_results_used = max_results;
 
 	/* Free the query terms array and individual term strings */
 	for (int i = 0; i < entry_count; i++)

--- a/test/expected/limits.out
+++ b/test/expected/limits.out
@@ -148,6 +148,7 @@ NOTICE:  BM25 index scan: tid=(0,19), BM25_score=-1.3915
 NOTICE:  BM25 index scan: tid=(0,3), BM25_score=-1.1663
 NOTICE:  BM25 index scan: tid=(0,7), BM25_score=-0.9394
 NOTICE:  BM25 index scan: tid=(0,12), BM25_score=-0.9394
+NOTICE:  BM25 index scan: tid=(0,20), BM25_score=-0.9394
          title         |  score  
 -----------------------+---------
  Database Architecture | -2.3309
@@ -156,7 +157,8 @@ NOTICE:  BM25 index scan: tid=(0,12), BM25_score=-0.9394
  System Performance    | -1.3915
  Database Performance  | -0.9394
  Query Optimization    | -0.9394
-(6 rows)
+ Database Security     | -0.9394
+(7 rows)
 
 -- Test 4: No LIMIT (should use default behavior)
 -- Note: Query plan varies by PG version - not testing EXPLAIN here

--- a/test/expected/mixed.out
+++ b/test/expected/mixed.out
@@ -204,6 +204,7 @@ NOTICE:  BM25 index scan: tid=(0,6), BM25_score=-0.0631
 NOTICE:  BM25 index scan: tid=(0,7), BM25_score=-0.0631
 NOTICE:  BM25 index scan: tid=(0,20), BM25_score=-0.0563
 NOTICE:  BM25 index scan: tid=(0,38), BM25_score=-0.0563
+NOTICE:  BM25 index scan: tid=(0,16), BM25_score=-0.0563
  id |                            content                             |  score  
 ----+----------------------------------------------------------------+---------
   1 | updated database system with enhanced concurrent features      | -3.5477
@@ -215,7 +216,8 @@ NOTICE:  BM25 index scan: tid=(0,38), BM25_score=-0.0563
   7 | concurrent database operations need careful synchronization    | -0.0631
  20 | test document number 12 contains database and concurrent terms | -0.0563
  38 | test document number 30 contains database and concurrent terms | -0.0563
-(9 rows)
+ 16 | test document number 8 contains database and concurrent terms  | -0.0563
+(10 rows)
 
 -- Test 7: Delete operations
 \echo 'Test 7: Delete operations'

--- a/test/expected/rescan.out
+++ b/test/expected/rescan.out
@@ -1,0 +1,278 @@
+-- Test: iterative index scan (rescan with increasing limit)
+--
+-- Demonstrates and tests the interaction between LIMIT, WHERE clause
+-- post-filtering, and the index's internal result limit.
+--
+-- The core problem: the index computes top-k results in one shot.
+-- When a WHERE clause filters out rows, fewer than LIMIT rows may be
+-- returned even though qualifying rows exist in the table.
+--
+-- The fix: when the executor exhausts the index's result set without
+-- satisfying LIMIT, the index rescans with a larger internal limit
+-- (exponential backoff: 2x, 4x, ...) until enough rows are found.
+SET log_duration = off;
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+WARNING:  pg_textsearch v1.0.0-dev is a prerelease. Do not use in production.
+SET client_min_messages = NOTICE;
+SET enable_seqscan = false;
+------------------------------------------------------------------------
+-- Setup: table with two categories, deliberately skewed BM25 scores
+------------------------------------------------------------------------
+CREATE TABLE rescan_test (
+    id SERIAL PRIMARY KEY,
+    category TEXT,
+    content TEXT
+);
+-- 30 'common' rows: high BM25 score for 'database' (term appears 3x,
+-- short document)
+INSERT INTO rescan_test (category, content)
+SELECT 'common',
+       'database database database management optimization'
+FROM generate_series(1, 30);
+-- 20 'rare' rows: lower BM25 score for 'database' (term appears 1x,
+-- longer document, diluted by other terms)
+INSERT INTO rescan_test (category, content)
+SELECT 'rare',
+       'the modern application framework provides a database '
+       'connection pooling layer for enterprise deployments'
+FROM generate_series(1, 20);
+CREATE INDEX rescan_idx ON rescan_test
+USING bm25(content) WITH (text_config='english');
+NOTICE:  BM25 index build started for relation rescan_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 50 documents, avg_length=7.00, text_config='english' (k1=1.20, b=0.75)
+------------------------------------------------------------------------
+-- Baseline: without WHERE, LIMIT works correctly
+------------------------------------------------------------------------
+-- Should return exactly 5 rows
+SELECT COUNT(*) AS without_where
+FROM (
+    SELECT id FROM rescan_test
+    ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+    LIMIT 5
+) q;
+ without_where 
+---------------
+             5
+(1 row)
+
+------------------------------------------------------------------------
+-- Test 1: LIMIT + WHERE — complete miss
+--
+-- LIMIT 5 is pushed down to the index (no indexclauses to prevent it).
+-- The index returns top-5 results, all 'common' rows (higher score).
+-- WHERE category='rare' filters out all 5 — returns 0 rows.
+--
+-- After fix: index rescans with larger limit until 5 'rare' rows found.
+------------------------------------------------------------------------
+SELECT COUNT(*) AS with_where_complete_miss
+FROM (
+    SELECT id, category FROM rescan_test
+    WHERE category = 'rare'
+    ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+    LIMIT 5
+) q;
+ with_where_complete_miss 
+--------------------------
+                        5
+(1 row)
+
+------------------------------------------------------------------------
+-- Test 2: default_limit + WHERE — same problem without explicit LIMIT
+--
+-- When no LIMIT clause, the default_limit (set low here) controls
+-- how many results the index computes.  WHERE can still starve results.
+------------------------------------------------------------------------
+SET pg_textsearch.default_limit = 10;
+SELECT COUNT(*) AS default_limit_miss
+FROM (
+    SELECT id, category FROM rescan_test
+    WHERE category = 'rare'
+    ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+) q;
+ default_limit_miss 
+--------------------
+                 20
+(1 row)
+
+-- Reset to normal
+SET pg_textsearch.default_limit = 1000;
+------------------------------------------------------------------------
+-- Test 3: partial miss — some results pass, but fewer than LIMIT
+--
+-- Mix categories so that some top-k results pass the filter.
+------------------------------------------------------------------------
+INSERT INTO rescan_test (category, content) VALUES
+    ('mixed', 'database systems and database optimization techniques'),
+    ('mixed', 'database management in enterprise systems');
+-- Refresh index knowledge
+REINDEX INDEX rescan_idx;
+NOTICE:  BM25 index build started for relation rescan_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 52 documents, avg_length=6.90, text_config='english' (k1=1.20, b=0.75)
+-- Ask for 10 'mixed' rows but only 2 exist.  With a small internal
+-- limit, the index may not even find those 2 among the top-k results.
+SET pg_textsearch.default_limit = 5;
+SELECT COUNT(*) AS partial_miss
+FROM (
+    SELECT id, category FROM rescan_test
+    WHERE category = 'mixed'
+    ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+    LIMIT 10
+) q;
+ partial_miss 
+--------------
+            2
+(1 row)
+
+SET pg_textsearch.default_limit = 1000;
+------------------------------------------------------------------------
+-- Test 4: verify result ordering after rescan
+--
+-- Even when the index rescans with a larger limit, results must still
+-- be returned in correct BM25 score order.
+------------------------------------------------------------------------
+-- All 20 'rare' rows should be returned, in score order (they all
+-- have the same score, so order by id is acceptable as tiebreaker)
+SELECT id, category,
+       ROUND((content <@> to_bm25query('database', 'rescan_idx'))::numeric, 4) AS score
+FROM rescan_test
+WHERE category = 'rare'
+ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+LIMIT 5;
+ id | category |  score  
+----+----------+---------
+ 33 | rare     | -0.0080
+ 34 | rare     | -0.0080
+ 35 | rare     | -0.0080
+ 36 | rare     | -0.0080
+ 37 | rare     | -0.0080
+(5 rows)
+
+------------------------------------------------------------------------
+-- Test 5: large table with aggressive filtering
+--
+-- Scale up to make the problem more realistic.  With 500 total rows
+-- and only 10 matching the filter, the index needs multiple rescans.
+------------------------------------------------------------------------
+CREATE TABLE rescan_large (
+    id SERIAL PRIMARY KEY,
+    tag INT,
+    content TEXT
+);
+-- 490 rows with tag=0, high score for 'server'
+INSERT INTO rescan_large (tag, content)
+SELECT 0, 'server cluster server configuration server deployment'
+FROM generate_series(1, 490);
+-- 10 rows with tag=1, lower score for 'server'
+INSERT INTO rescan_large (tag, content)
+SELECT 1,
+       'the application connects to a server through a '
+       'load balanced proxy for high availability'
+FROM generate_series(1, 10);
+CREATE INDEX rescan_large_idx ON rescan_large
+USING bm25(content) WITH (text_config='english');
+NOTICE:  BM25 index build started for relation rescan_large_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 500 documents, avg_length=6.04, text_config='english' (k1=1.20, b=0.75)
+-- Ask for 8 rows with tag=1.  Only 10 exist out of 500 total.
+-- The index must scan deep enough to find them.
+SELECT COUNT(*) AS large_table_filter
+FROM (
+    SELECT id FROM rescan_large
+    WHERE tag = 1
+    ORDER BY content <@> to_bm25query('server', 'rescan_large_idx')
+    LIMIT 8
+) q;
+ large_table_filter 
+--------------------
+                  8
+(1 row)
+
+------------------------------------------------------------------------
+-- Test 6: WHERE on indexed column's table, not a separate column
+--
+-- Even when the WHERE references the same table, if it's not an
+-- index qual, the same problem applies.
+------------------------------------------------------------------------
+SELECT COUNT(*) AS where_on_id
+FROM (
+    SELECT id FROM rescan_large
+    WHERE id > 495
+    ORDER BY content <@> to_bm25query('server', 'rescan_large_idx')
+    LIMIT 3
+) q;
+ where_on_id 
+-------------
+           3
+(1 row)
+
+------------------------------------------------------------------------
+-- Test 7: LIMIT + OFFSET + WHERE
+--
+-- OFFSET makes this harder: we need to skip rows AND satisfy LIMIT,
+-- so the index needs even more candidates.
+------------------------------------------------------------------------
+SELECT COUNT(*) AS limit_offset_where
+FROM (
+    SELECT id FROM rescan_test
+    WHERE category = 'rare'
+    ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+    LIMIT 3 OFFSET 2
+) q;
+ limit_offset_where 
+--------------------
+                  3
+(1 row)
+
+------------------------------------------------------------------------
+-- Test 8: multiple backoffs required
+--
+-- With default_limit=5, finding 3 rows with tag=1 among 500 rows
+-- requires the limit to grow: 5 -> 10 -> 20 -> 40 -> 80 -> 160 ->
+-- 320 -> 640.  That's 7 doublings.  The NOTICE trace messages from
+-- the rescan code confirm each backoff step.
+------------------------------------------------------------------------
+SET pg_textsearch.default_limit = 5;
+SELECT COUNT(*) AS multi_backoff
+FROM (
+    SELECT id FROM rescan_large
+    WHERE tag = 1
+    ORDER BY content <@> to_bm25query('server', 'rescan_large_idx')
+    LIMIT 3
+) q;
+ multi_backoff 
+---------------
+             3
+(1 row)
+
+SET pg_textsearch.default_limit = 1000;
+------------------------------------------------------------------------
+-- Test 9: backoff terminates when all matching rows exhausted
+--
+-- Ask for 20 rows with tag=1, but only 10 exist.  The index should
+-- keep doubling until it has scanned all 500 docs, then stop.
+------------------------------------------------------------------------
+SET pg_textsearch.default_limit = 5;
+SELECT COUNT(*) AS exhausted_backoff
+FROM (
+    SELECT id FROM rescan_large
+    WHERE tag = 1
+    ORDER BY content <@> to_bm25query('server', 'rescan_large_idx')
+    LIMIT 20
+) q;
+ exhausted_backoff 
+-------------------
+                10
+(1 row)
+
+SET pg_textsearch.default_limit = 1000;
+------------------------------------------------------------------------
+-- Cleanup
+------------------------------------------------------------------------
+DROP TABLE rescan_test CASCADE;
+DROP TABLE rescan_large CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
Closes #143

## Summary

- When a WHERE clause post-filters BM25 index results, the one-shot top-k scan could return fewer rows than LIMIT requests (or zero rows), even when qualifying rows exist in the table
- Fix: `tp_gettuple` now doubles the internal limit and re-executes the scoring query when results are exhausted, skipping already-returned rows
- Terminates when `result_count < max_results_used` (all matching docs found) or the limit reaches `TP_MAX_QUERY_LIMIT`

## Testing

New `rescan.sql` regression test with 9 scenarios:
- Complete miss (all top-k filtered out by WHERE)
- Default limit + WHERE (no explicit LIMIT)
- Partial miss (some results pass filter)
- Result ordering preserved after rescan
- Large table with aggressive filtering (500 rows, 2% match rate)
- WHERE on non-indexed column
- LIMIT + OFFSET + WHERE
- Multiple backoffs required (8 doublings with default_limit=5)
- Backoff terminates when all matching rows exhausted

Updated expected output for `limits` and `mixed` tests which now correctly return additional rows that the rescan finds.