### PR TITLE
fix: resolve implicit text <@> text in DML subqueries

### DIFF
--- a/test/expected/implicit.out
+++ b/test/expected/implicit.out
@@ -189,6 +189,67 @@ EXECUTE explicit_search('database');
 (2 rows)
 
 DEALLOCATE explicit_search;
+-- Test 11: Implicit text <@> text in DELETE subquery (issue #213)
+-- The implicit form should work inside subqueries of DML statements
+DELETE FROM implicit_docs WHERE id = (
+  SELECT id FROM implicit_docs ORDER BY content <@> 'database' LIMIT 1
+);
+-- Verify the top-scoring document for 'database' was deleted
+SELECT id, content
+FROM implicit_docs
+ORDER BY content <@> 'database'
+LIMIT 3;
+ id |       content        
+----+----------------------
+  3 | hello database world
+(1 row)
+
+-- Re-insert the deleted row for subsequent tests
+INSERT INTO implicit_docs (content) VALUES ('database system design');
+-- Test 12: Implicit text <@> text in UPDATE subquery
+UPDATE implicit_docs
+SET content = 'updated via subquery'
+WHERE id = (
+  SELECT id FROM implicit_docs ORDER BY content <@> 'hello' LIMIT 1
+);
+-- Verify the update happened to the top-scoring 'hello' document
+SELECT id, content FROM implicit_docs ORDER BY id;
+ id |        content         
+----+------------------------
+  1 | updated via subquery
+  3 | hello database world
+  4 | database system design
+(3 rows)
+
+-- Test 13: Implicit form in UPDATE SET subquery
+UPDATE implicit_docs
+SET content = (
+  SELECT content FROM implicit_docs
+  ORDER BY content <@> 'database' LIMIT 1
+)
+WHERE id = (SELECT max(id) FROM implicit_docs);
+SELECT id, content FROM implicit_docs ORDER BY id;
+ id |       content        
+----+----------------------
+  1 | updated via subquery
+  3 | hello database world
+  4 | hello database world
+(3 rows)
+
+-- Test 14: Nested subquery (exercises recursive SubLink handling)
+SELECT id, content FROM implicit_docs
+WHERE id IN (
+  SELECT id FROM implicit_docs
+  WHERE id = (
+    SELECT id FROM implicit_docs
+    ORDER BY content <@> 'database' LIMIT 1
+  )
+);
+ id |       content        
+----+----------------------
+  3 | hello database world
+(1 row)
+
 -- Cleanup
 DROP TABLE implicit_schema.schema_docs CASCADE;
 DROP SCHEMA implicit_schema CASCADE;


### PR DESCRIPTION
## Summary

- Fix implicit `text <@> text` resolution failing inside subqueries of DELETE and UPDATE statements
- The parse-analysis hook uses `expression_tree_mutator` which does not descend into `SubLink` subselects (they are `Query` nodes, not expression nodes). Added explicit `SubLink` handling in `resolve_index_mutator()` to recurse into subquery trees.

Fixes #213

## Testing

Added three test cases to `test/sql/implicit.sql`:
- Implicit form in DELETE WHERE subquery
- Implicit form in UPDATE WHERE subquery
- Implicit form in UPDATE SET subquery