### PR TITLE
fix: use min fieldnorm for BMW skip entries in parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ PG_CPPFLAGS = -I$(srcdir)/src -g -O2 -Wall -Wextra -Wunused-function -Wunused-va
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic binary_io bmw bulk_load compression concurrent_build coverage deletion vacuum vacuum_extended dropped empty explicit_index implicit index inheritance limits lock manyterms memory merge mixed parallel_build partitioned partitioned_many pgstats queries rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings unsupported updates vector unlogged_index wand text_config
+REGRESS = aerodocs basic binary_io bmw bulk_load compression concurrent_build coverage deletion vacuum vacuum_extended dropped empty explicit_index implicit index inheritance limits lock manyterms memory merge mixed parallel_build parallel_bmw partitioned partitioned_many pgstats queries rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings unsupported updates vector unlogged_index wand text_config
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -863,7 +863,7 @@ write_posting_blocks(
 		uint32		bstart	   = bidx * TP_BLOCK_SIZE;
 		uint32		bend	   = Min(bstart + TP_BLOCK_SIZE, bp_count);
 		uint16		max_tf	   = 0;
-		uint8		max_norm   = 0;
+		uint8		min_norm   = 255;
 		uint32		last_docid = 0;
 		uint32		k;
 
@@ -873,14 +873,14 @@ write_posting_blocks(
 				last_docid = bp_array[k].doc_id;
 			if (bp_array[k].frequency > max_tf)
 				max_tf = bp_array[k].frequency;
-			if (bp_array[k].fieldnorm > max_norm)
-				max_norm = bp_array[k].fieldnorm;
+			if (bp_array[k].fieldnorm < min_norm)
+				min_norm = bp_array[k].fieldnorm;
 		}
 
 		skip.last_doc_id	= last_docid;
 		skip.doc_count		= (uint8)(bend - bstart);
 		skip.block_max_tf	= max_tf;
-		skip.block_max_norm = max_norm;
+		skip.block_max_norm = min_norm;
 		skip.posting_offset = writer->current_offset;
 		memset(skip.reserved, 0, sizeof(skip.reserved));
 

--- a/test/expected/parallel_bmw.out
+++ b/test/expected/parallel_bmw.out
@@ -1,0 +1,100 @@
+-- Test case: parallel_bmw
+-- Validates that parallel index build computes correct block_max_norm
+-- (MIN fieldnorm) for BMW skip entries, matching the serial build path.
+--
+-- The bug: build_parallel.c computed MAX fieldnorm instead of MIN,
+-- causing BMW to underestimate block score upper bounds and incorrectly
+-- skip blocks containing high-scoring short documents.
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+WARNING:  pg_textsearch v1.0.0-dev is a prerelease. Do not use in production.
+SET enable_seqscan = off;
+SET min_parallel_table_scan_size = 0;
+SET maintenance_work_mem = '256MB';
+--------------------------------------------------------------------------------
+-- Setup: 3-tier document design to expose block_max_norm bug
+--------------------------------------------------------------------------------
+-- The posting list for "target" is ordered by CTID (insertion order):
+--
+--   Rows 1-5000:      MEDIUM docs (50 words with "target") -> set threshold
+--   Rows 5001-7000:   SHORT + LONG docs (alternating, both with "target")
+--   Rows 7001-150000: FILLER docs (no "target", for parallel build sizing)
+--
+-- BMW processes blocks sequentially. Medium-doc blocks are processed first,
+-- establishing a threshold. Then mixed short+long blocks follow:
+--
+--   Correct (MIN fieldnorm): upper bound from short doc -> above threshold
+--   Buggy   (MAX fieldnorm): upper bound from long doc  -> below threshold
+--
+-- With the bug, BMW skips the mixed blocks entirely, missing the short
+-- docs that should rank highest in top-k results.
+SET max_parallel_maintenance_workers = 2;
+CREATE TABLE parallel_bmw_test (
+    id SERIAL PRIMARY KEY,
+    content TEXT
+);
+INSERT INTO parallel_bmw_test (content)
+SELECT CASE
+    -- Medium docs: "target" + 49 filler words = 50 total
+    WHEN i <= 5000 THEN
+        'target ' || repeat('alpha ', 49)
+    -- Short docs (odd): just "target" = 1 word
+    WHEN i <= 7000 AND i % 2 = 1 THEN
+        'target'
+    -- Long docs (even): "target" + 199 filler words = 200 total
+    WHEN i <= 7000 THEN
+        'target ' || repeat('beta ', 199)
+    -- Filler: no "target" term
+    ELSE
+        'gamma delta'
+END
+FROM generate_series(1, 150000) AS i;
+ANALYZE parallel_bmw_test;
+CREATE INDEX parallel_bmw_test_idx ON parallel_bmw_test
+    USING bm25(content) WITH (text_config='english');
+NOTICE:  BM25 index build started for relation parallel_bmw_test_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  parallel index build: launched 2 of 2 requested workers
+--------------------------------------------------------------------------------
+-- Test 1: BMW top-k must find short docs despite them being in later blocks
+--------------------------------------------------------------------------------
+-- Short docs (1 word) score highest due to BM25 length normalization.
+-- With the bug, their blocks are skipped because the upper bound is
+-- computed from the long docs (200 words) sharing those blocks, and that
+-- upper bound falls below the threshold set by medium docs (50 words).
+SELECT COUNT(*) AS short_docs_in_top10
+FROM (
+    SELECT content
+    FROM parallel_bmw_test
+    ORDER BY content <@> to_bm25query('target', 'parallel_bmw_test_idx')
+    LIMIT 10
+) sub
+WHERE content = 'target';
+ short_docs_in_top10 
+---------------------
+                  10
+(1 row)
+
+--------------------------------------------------------------------------------
+-- Test 2: Baseline without BMW confirms correct results
+--------------------------------------------------------------------------------
+SET pg_textsearch.enable_bmw = false;
+SELECT COUNT(*) AS short_docs_in_top10_no_bmw
+FROM (
+    SELECT content
+    FROM parallel_bmw_test
+    ORDER BY content <@> to_bm25query('target', 'parallel_bmw_test_idx')
+    LIMIT 10
+) sub
+WHERE content = 'target';
+ short_docs_in_top10_no_bmw 
+----------------------------
+                         10
+(1 row)
+
+SET pg_textsearch.enable_bmw = true;
+--------------------------------------------------------------------------------
+-- Cleanup
+--------------------------------------------------------------------------------
+DROP TABLE parallel_bmw_test CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Summary
- Fix `write_posting_blocks()` in parallel build to compute MIN fieldnorm (shortest doc) instead of MAX (longest doc) per block
- The `block_max_norm` skip entry field must store the minimum fieldnorm so BMW computes valid score upper bounds; using maximum caused BMW to incorrectly skip blocks containing high-scoring short documents
- The serial build (`segment.c`) and merge (`merge.c`) paths already used `min_norm` correctly — this aligns the parallel build path
- Add `parallel_bmw` regression test that deterministically reproduces the bug: medium-length docs set the BMW threshold in early blocks, then mixed short+long doc blocks follow where the wrong upper bound causes BMW to skip them

## Test plan
- [x] `parallel_bmw` test fails deterministically without fix (0 short docs in top-10), passes with fix (10 short docs)
- [x] Verified 5/5 stable passes for `bmw` + `parallel_build` tests
- [x] Full regression suite passes (only pre-existing `binary_io` failure)
- [x] `make format-check` passes