### PR TITLE
bench: add VACUUM step to ParadeDB benchmarks for segment compaction

### DIFF
--- a/benchmarks/datasets/msmarco-v2/systemx/load.sql
+++ b/benchmarks/datasets/msmarco-v2/systemx/load.sql
@@ -111,6 +111,10 @@ CREATE INDEX msmarco_v2_systemx_idx ON msmarco_v2_passages_systemx
         }'
     );
 
+-- Compact index segments (ParadeDB merges segments during VACUUM)
+\echo 'INDEX_VACUUM:'
+VACUUM msmarco_v2_passages_systemx;
+
 -- Report index and table sizes
 \echo ''
 \echo '=== Index Size Report ==='

--- a/benchmarks/datasets/msmarco/systemx/load.sql
+++ b/benchmarks/datasets/msmarco/systemx/load.sql
@@ -111,6 +111,10 @@ CREATE INDEX msmarco_systemx_idx ON msmarco_passages_systemx
         }'
     );
 
+-- Compact index segments (ParadeDB merges segments during VACUUM)
+\echo 'INDEX_VACUUM:'
+VACUUM msmarco_passages_systemx;
+
 -- Report index and table sizes
 \echo ''
 \echo '=== Index Size Report ==='

--- a/benchmarks/runner/extract_metrics.sh
+++ b/benchmarks/runner/extract_metrics.sh
@@ -46,6 +46,13 @@ num_or_null() {
 INDEX_BUILD_MS=$(grep -E "CREATE INDEX" "$LOG_FILE" -A 1 2>/dev/null | \
     grep -oE "Time: [0-9]+\.[0-9]+ ms" | head -1 | grep -oE "[0-9]+\.[0-9]+" || echo "")
 
+# Add post-build VACUUM time if present (ParadeDB segment compaction)
+INDEX_VACUUM_MS=$(grep -E "^INDEX_VACUUM:" "$LOG_FILE" -A 2 2>/dev/null | \
+    grep -oE "Time: [0-9]+\.[0-9]+ ms" | head -1 | grep -oE "[0-9]+\.[0-9]+" || echo "")
+if [ -n "$INDEX_VACUUM_MS" ] && [ -n "$INDEX_BUILD_MS" ]; then
+    INDEX_BUILD_MS=$(echo "$INDEX_BUILD_MS + $INDEX_VACUUM_MS" | bc)
+fi
+
 # Extract data load time (COPY statements)
 LOAD_TIME_MS=$(grep -E "^COPY [0-9]+" "$LOG_FILE" -A 1 2>/dev/null | \
     grep -oE "Time: [0-9]+\.[0-9]+ ms" | head -1 | grep -oE "[0-9]+\.[0-9]+" || echo "")


### PR DESCRIPTION
## Summary

- Add `VACUUM` after `CREATE INDEX` in ParadeDB (System X) MS MARCO v1 and v2 load scripts to trigger segment compaction
- Include VACUUM time in the reported `index_build_time_ms` metric via an `INDEX_VACUUM:` marker parsed by `extract_metrics.sh`

ParadeDB merges index segments during VACUUM, so without this step we may be benchmarking it in a suboptimal state with uncompacted segments.

## Testing

- Run MS MARCO v1 benchmark with ParadeDB and compare index size + query latency before/after this change
