### PR TITLE
fix: resolve test failures on PG17 and /tmp environments

### DIFF
--- a/test/expected/binary_io.out
+++ b/test/expected/binary_io.out
@@ -27,10 +27,11 @@ SELECT id, q::text AS original_query FROM query_export ORDER BY id;
 (2 rows)
 
 -- Test COPY TO BINARY (exercises tpquery_send)
-COPY query_export TO '/tmp/query_export.bin' WITH (FORMAT binary);
+-- Use \copy (client-side) to avoid /tmp permission issues
+\copy query_export TO '/tmp/query_export.bin' WITH (FORMAT binary)
 -- Test COPY FROM BINARY (exercises tpquery_recv)
 CREATE TABLE query_import (id int, q bm25query);
-COPY query_import FROM '/tmp/query_export.bin' WITH (FORMAT binary);
+\copy query_import FROM '/tmp/query_export.bin' WITH (FORMAT binary)
 -- Verify data was imported correctly
 SELECT COUNT(*) AS imported_count FROM query_import;
  imported_count 
@@ -62,10 +63,10 @@ INSERT INTO vector_export (v) VALUES
     ('binary_io_idx:{hello:1,world:2}'::bm25vector),
     ('binary_io_idx:{database:3,search:1}'::bm25vector);
 -- Export via COPY BINARY (exercises bm25vector_send)
-COPY vector_export TO '/tmp/vector_export.bin' WITH (FORMAT binary);
+\copy vector_export TO '/tmp/vector_export.bin' WITH (FORMAT binary)
 -- Import via COPY BINARY (exercises bm25vector_recv)
 CREATE TABLE vector_import (id int, v bm25vector);
-COPY vector_import FROM '/tmp/vector_export.bin' WITH (FORMAT binary);
+\copy vector_import FROM '/tmp/vector_export.bin' WITH (FORMAT binary)
 -- Verify round-trip
 SELECT COUNT(*) AS vector_imported_count FROM vector_import;
  vector_imported_count 

--- a/test/expected/coverage.out
+++ b/test/expected/coverage.out
@@ -122,19 +122,21 @@ SELECT length(bm25_dump_index('coverage_idx')) > 0 AS dump_multi_segment;
 -- =============================================================================
 -- Test 6: Page visualization (exercises dump.c pageviz code)
 -- =============================================================================
+-- Create shared temp dir accessible by both server and test runner
+\! mkdir -p -m 777 /tmp/pg_textsearch_test
 -- bm25_debug_pageviz writes page layout to file
-SELECT bm25_debug_pageviz('coverage_idx', '/tmp/test_pageviz.txt');
-INFO:  Page visualization written to /tmp/test_pageviz.txt
-  bm25_debug_pageviz   
------------------------
- /tmp/test_pageviz.txt
+SELECT bm25_debug_pageviz('coverage_idx', '/tmp/pg_textsearch_test/pageviz.txt');
+INFO:  Page visualization written to /tmp/pg_textsearch_test/pageviz.txt
+         bm25_debug_pageviz          
+-------------------------------------
+ /tmp/pg_textsearch_test/pageviz.txt
 (1 row)
 
 -- Verify it wrote something
-\! test -s /tmp/test_pageviz.txt && echo 'pageviz file exists'
+\! test -s /tmp/pg_textsearch_test/pageviz.txt && echo 'pageviz file exists'
 pageviz file exists
 -- Clean up temp file
-\! rm -f /tmp/test_pageviz.txt
+\! rm -f /tmp/pg_textsearch_test/pageviz.txt
 -- =============================================================================
 -- Test 7: Score logging (exercises am/scan.c log_scores path)
 -- =============================================================================
@@ -213,17 +215,17 @@ DROP TABLE validate_test;
 -- =============================================================================
 -- Test 11: bm25_dump_index to file (exercises file output path)
 -- =============================================================================
-SELECT bm25_dump_index('coverage_idx', '/tmp/test_dump.txt') IS NOT NULL
-    AS dump_to_file;
-INFO:  Index dump written to /tmp/test_dump.txt
+SELECT bm25_dump_index('coverage_idx', '/tmp/pg_textsearch_test/dump.txt')
+    IS NOT NULL AS dump_to_file;
+INFO:  Index dump written to /tmp/pg_textsearch_test/dump.txt
  dump_to_file 
 --------------
  t
 (1 row)
 
-\! test -s /tmp/test_dump.txt && echo 'dump file exists'
+\! test -s /tmp/pg_textsearch_test/dump.txt && echo 'dump file exists'
 dump file exists
-\! rm -f /tmp/test_dump.txt
+\! rm -rf /tmp/pg_textsearch_test
 -- =============================================================================
 -- Test 12: Segment BMW seek (exercises segment/scan.c seek path)
 -- Uses ORDER BY ... LIMIT to trigger top-k BMW with segment data
@@ -239,29 +241,35 @@ SELECT bm25_spill_index('coverage_idx');
 (1 row)
 
 -- ORDER BY score LIMIT triggers BMW seek path on segments
-SELECT id FROM coverage_docs
-WHERE content <@> to_bm25query('alpha', 'coverage_idx') < 0
-ORDER BY content <@> to_bm25query('alpha', 'coverage_idx')
-LIMIT 5;
+-- Wrap in outer query with id tiebreaker for deterministic ordering
+-- (adding secondary sort key to inner query would prevent index use)
+SELECT id FROM (
+    SELECT id FROM coverage_docs
+    WHERE content <@> to_bm25query('alpha', 'coverage_idx') < 0
+    ORDER BY content <@> to_bm25query('alpha', 'coverage_idx')
+    LIMIT 5
+) sub ORDER BY id;
  id  
 -----
+ 106
  107
  108
  109
  110
- 106
 (5 rows)
 
 -- Multi-term BMW seek with segment data
-SELECT id FROM coverage_docs
-WHERE content <@> to_bm25query('seek alpha', 'coverage_idx') < 0
-ORDER BY content <@> to_bm25query('seek alpha', 'coverage_idx')
-LIMIT 3;
+SELECT id FROM (
+    SELECT id FROM coverage_docs
+    WHERE content <@> to_bm25query('seek alpha', 'coverage_idx') < 0
+    ORDER BY content <@> to_bm25query('seek alpha', 'coverage_idx')
+    LIMIT 3
+) sub ORDER BY id;
  id  
 -----
+ 106
  107
  108
- 106
 (3 rows)
 
 -- =============================================================================
@@ -309,10 +317,12 @@ SET pg_textsearch.log_bmw_stats = false;
 -- =============================================================================
 SET enable_seqscan = off;
 -- The implicit text <@> text form in ORDER BY
-SELECT id FROM coverage_docs
-WHERE content <@> 'alpha'::text < 0
-ORDER BY content <@> 'alpha'::text
-LIMIT 3;
+SELECT id FROM (
+    SELECT id FROM coverage_docs
+    WHERE content <@> 'alpha'::text < 0
+    ORDER BY content <@> 'alpha'::text
+    LIMIT 3
+) sub ORDER BY id;
  id  
 -----
  106

--- a/test/sql/binary_io.sql
+++ b/test/sql/binary_io.sql
@@ -23,11 +23,12 @@ INSERT INTO query_export (q) VALUES
 SELECT id, q::text AS original_query FROM query_export ORDER BY id;
 
 -- Test COPY TO BINARY (exercises tpquery_send)
-COPY query_export TO '/tmp/query_export.bin' WITH (FORMAT binary);
+-- Use \copy (client-side) to avoid /tmp permission issues
+\copy query_export TO '/tmp/query_export.bin' WITH (FORMAT binary)
 
 -- Test COPY FROM BINARY (exercises tpquery_recv)
 CREATE TABLE query_import (id int, q bm25query);
-COPY query_import FROM '/tmp/query_export.bin' WITH (FORMAT binary);
+\copy query_import FROM '/tmp/query_export.bin' WITH (FORMAT binary)
 
 -- Verify data was imported correctly
 SELECT COUNT(*) AS imported_count FROM query_import;
@@ -53,11 +54,11 @@ INSERT INTO vector_export (v) VALUES
     ('binary_io_idx:{database:3,search:1}'::bm25vector);
 
 -- Export via COPY BINARY (exercises bm25vector_send)
-COPY vector_export TO '/tmp/vector_export.bin' WITH (FORMAT binary);
+\copy vector_export TO '/tmp/vector_export.bin' WITH (FORMAT binary)
 
 -- Import via COPY BINARY (exercises bm25vector_recv)
 CREATE TABLE vector_import (id int, v bm25vector);
-COPY vector_import FROM '/tmp/vector_export.bin' WITH (FORMAT binary);
+\copy vector_import FROM '/tmp/vector_export.bin' WITH (FORMAT binary)
 
 -- Verify round-trip
 SELECT COUNT(*) AS vector_imported_count FROM vector_import;


### PR DESCRIPTION
## Summary

- **binary_io**: Switch `COPY` to `\copy` (client-side) so temp files are owned by the test runner user, avoiding `/tmp` sticky-bit permission issues
- **coverage**: Use shared temp dir with 777 permissions for server-side file writes; add `id` tiebreaker to queries with tied BM25 scores for deterministic ordering
- **inheritance**: Extend `is_child_partition_index()` in `hooks.c` to handle regular table inheritance — PG17's planner may choose a child table's index over the parent's

## Test plan

- [x] All 47 SQL regression tests pass locally on PG17
- [x] `make format-check` passes
- [x] CI passes (PG17, PG18, sanitizer builds)
- [x] Verify inheritance test still passes on PG18 (planner behavior differs)