### PR TITLE
fix: add coverage gate to block PRs on coverage reduction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,6 +594,63 @@ jobs:
         # Show summary
         lcov --list coverage.info
 
+    - name: Restore coverage baseline
+      if: github.event_name == 'pull_request'
+      uses: actions/cache/restore@v4
+      with:
+        path: coverage-baseline.txt
+        key: coverage-baseline-never-matches
+        restore-keys: |
+          coverage-baseline-
+
+    - name: Coverage gate
+      id: coverage-gate
+      run: |
+        # Read old baseline if available (before we overwrite it)
+        BASELINE=""
+        if [ -f coverage-baseline.txt ]; then
+          BASELINE=$(cat coverage-baseline.txt)
+        fi
+
+        # Extract current line coverage percentage
+        CURRENT=$(lcov --summary coverage.info 2>&1 \
+          | grep "lines" | sed 's/.*: \([0-9.]*\)%.*/\1/')
+        echo "Current line coverage: ${CURRENT}%"
+        echo "line_coverage=$CURRENT" >> "$GITHUB_OUTPUT"
+
+        # Save current value as baseline for future runs
+        echo "$CURRENT" > coverage-baseline.txt
+
+        # Enforce minimum coverage threshold
+        MIN_COVERAGE=85
+        if (( $(echo "$CURRENT < $MIN_COVERAGE" | bc -l) )); then
+          echo "::error::Line coverage ${CURRENT}% is below" \
+               "minimum ${MIN_COVERAGE}%"
+          exit 1
+        fi
+        echo "Coverage ${CURRENT}% meets minimum ${MIN_COVERAGE}%"
+
+        # Check for coverage reduction on PRs
+        if [ -n "$BASELINE" ]; then
+          DIFF=$(echo "$CURRENT - $BASELINE" | bc -l)
+          echo "Baseline: ${BASELINE}%, Change: ${DIFF}%"
+          if (( $(echo "$DIFF < -1.0" | bc -l) )); then
+            echo "::error::Coverage decreased by more than 1%:" \
+                 "${BASELINE}% -> ${CURRENT}% (change: ${DIFF}%)"
+            exit 1
+          fi
+          echo "Coverage change (${DIFF}%) within threshold"
+        else
+          echo "No baseline found, skipping reduction check"
+        fi
+
+    - name: Save coverage baseline
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v4
+      with:
+        path: coverage-baseline.txt
+        key: coverage-baseline-${{ github.sha }}
+
     - name: Generate HTML report
       run: |
         genhtml coverage.info \
@@ -607,7 +664,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.info
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Upload HTML coverage report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -138,6 +138,63 @@ jobs:
         # Show summary
         lcov --list coverage.info --rc branch_coverage=1
 
+    - name: Restore coverage baseline
+      if: github.event_name == 'pull_request'
+      uses: actions/cache/restore@v4
+      with:
+        path: coverage-baseline.txt
+        key: coverage-baseline-never-matches
+        restore-keys: |
+          coverage-baseline-
+
+    - name: Coverage gate
+      id: coverage-gate
+      run: |
+        # Read old baseline if available (before we overwrite it)
+        BASELINE=""
+        if [ -f coverage-baseline.txt ]; then
+          BASELINE=$(cat coverage-baseline.txt)
+        fi
+
+        # Extract current line coverage percentage
+        CURRENT=$(lcov --summary coverage.info 2>&1 \
+          | grep "lines" | sed 's/.*: \([0-9.]*\)%.*/\1/')
+        echo "Current line coverage: ${CURRENT}%"
+        echo "line_coverage=$CURRENT" >> "$GITHUB_OUTPUT"
+
+        # Save current value as baseline for future runs
+        echo "$CURRENT" > coverage-baseline.txt
+
+        # Enforce minimum coverage threshold
+        MIN_COVERAGE=85
+        if (( $(echo "$CURRENT < $MIN_COVERAGE" | bc -l) )); then
+          echo "::error::Line coverage ${CURRENT}% is below" \
+               "minimum ${MIN_COVERAGE}%"
+          exit 1
+        fi
+        echo "Coverage ${CURRENT}% meets minimum ${MIN_COVERAGE}%"
+
+        # Check for coverage reduction on PRs
+        if [ -n "$BASELINE" ]; then
+          DIFF=$(echo "$CURRENT - $BASELINE" | bc -l)
+          echo "Baseline: ${BASELINE}%, Change: ${DIFF}%"
+          if (( $(echo "$DIFF < -1.0" | bc -l) )); then
+            echo "::error::Coverage decreased by more than 1%:" \
+                 "${BASELINE}% -> ${CURRENT}% (change: ${DIFF}%)"
+            exit 1
+          fi
+          echo "Coverage change (${DIFF}%) within threshold"
+        else
+          echo "No baseline found, skipping reduction check"
+        fi
+
+    - name: Save coverage baseline
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v4
+      with:
+        path: coverage-baseline.txt
+        key: coverage-baseline-${{ github.sha }}
+
     - name: Generate HTML report
       run: |
         genhtml coverage.info \
@@ -152,7 +209,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.info
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Upload HTML coverage report


### PR DESCRIPTION
## Summary
- The coverage job collected data and uploaded to Codecov but never enforced
  thresholds — it always succeeded regardless of coverage values
- Codecov status checks (`codecov/project`, `codecov/patch`) weren't appearing
  on PRs, likely due to a missing/invalid `CODECOV_TOKEN`, and
  `fail_ci_if_error` was `false` so the upload failure was silent
- Branch protection had an empty required checks list (`all-tests-passed` was
  not listed), so CI failures couldn't block merges — now fixed

### Changes
- Add in-workflow coverage gate to both `ci.yml` and `coverage.yml` that:
  - Enforces a minimum 85% line coverage threshold
  - Caches the main branch baseline via `actions/cache`
  - Compares PR coverage against baseline, fails if it drops by more than 1%
- Change `fail_ci_if_error` from `false` to `true` on Codecov upload
- Added `all-tests-passed` to branch protection required status checks

### How the baseline works
- On pushes to `main`, the coverage percentage is saved to GitHub Actions
  cache with key `coverage-baseline-<sha>`
- On PRs, the most recent main branch cache is restored and compared against
  the PR's coverage
- First run after this merges will skip the reduction check (no baseline yet)
  and establish the initial baseline

## Testing
- CI on this PR validates the gate runs (no baseline exists yet, so the
  reduction check was skipped, but the minimum threshold check ran and passed)
- After merging, the next PR that reduces coverage by >1% will fail
