### PR TITLE
fix: crash when creating BM25 index on temp table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ PG_CPPFLAGS += -Wno-unknown-warning-option -Wno-clobbered -Wno-packed-not-aligne
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic binary_io bmw bulk_load compression concurrent_build coverage deletion vacuum vacuum_extended dropped empty explicit_index force_merge implicit index inheritance limits lock manyterms memory merge mixed parallel_build parallel_bmw partitioned partitioned_many pgstats queries rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings unsupported updates vector unlogged_index wand text_config
+REGRESS = aerodocs basic binary_io bmw bulk_load compression concurrent_build coverage deletion vacuum vacuum_extended dropped empty explicit_index force_merge implicit index inheritance limits lock manyterms memory merge mixed parallel_build parallel_bmw partitioned partitioned_many pgstats queries rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table unsupported updates vector unlogged_index wand text_config
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -474,8 +474,14 @@ tp_build_init_metapage(
 
 	MarkBufferDirty(metabuf);
 
-	/* Flush metapage to disk immediately to ensure crash recovery works */
-	FlushOneBuffer(metabuf);
+	/*
+	 * Flush metapage to disk immediately to ensure crash recovery
+	 * works.  Skip for temp relations: local buffers cannot be
+	 * flushed via FlushOneBuffer, and temp data doesn't need
+	 * crash recovery anyway.
+	 */
+	if (!BufferIsLocal(metabuf))
+		FlushOneBuffer(metabuf);
 
 	UnlockReleaseBuffer(metabuf);
 }
@@ -1012,7 +1018,8 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 			metap->total_len  = total_len;
 
 			MarkBufferDirty(metabuf);
-			FlushOneBuffer(metabuf);
+			if (!BufferIsLocal(metabuf))
+				FlushOneBuffer(metabuf);
 			UnlockReleaseBuffer(metabuf);
 		}
 
@@ -1129,8 +1136,9 @@ tp_buildempty(Relation index)
 
 	MarkBufferDirty(metabuf);
 
-	/* Flush metapage to disk immediately to ensure crash recovery works */
-	FlushOneBuffer(metabuf);
+	/* Flush metapage to disk -- skip for temp relations */
+	if (!BufferIsLocal(metabuf))
+		FlushOneBuffer(metabuf);
 
 	UnlockReleaseBuffer(metabuf);
 }

--- a/src/state/metapage.c
+++ b/src/state/metapage.c
@@ -257,7 +257,8 @@ tp_add_docid_to_pages(Relation index, ItemPointer ctid)
 			metap->first_docid_page = target_page;
 
 			MarkBufferDirty(metabuf);
-			FlushOneBuffer(metabuf);
+			if (!BufferIsLocal(metabuf))
+				FlushOneBuffer(metabuf);
 		}
 		else
 		{
@@ -323,7 +324,8 @@ tp_add_docid_to_pages(Relation index, ItemPointer ctid)
 		/* Link old page to new page */
 		docid_header->next_page = BufferGetBlockNumber(new_buf);
 		MarkBufferDirty(docid_buf);
-		FlushOneBuffer(docid_buf);
+		if (!BufferIsLocal(docid_buf))
+			FlushOneBuffer(docid_buf);
 
 		UnlockReleaseBuffer(docid_buf);
 
@@ -347,7 +349,7 @@ tp_add_docid_to_pages(Relation index, ItemPointer ctid)
 	 * Only flush when page is full. Individual docids are protected by the
 	 * dirty page - they'll be written during checkpoint or when full.
 	 */
-	if (docid_header->num_docids >= page_capacity)
+	if (docid_header->num_docids >= page_capacity && !BufferIsLocal(docid_buf))
 		FlushOneBuffer(docid_buf);
 
 	/* Update cache for next call */
@@ -385,7 +387,8 @@ tp_clear_docid_pages(Relation index)
 	metap->first_docid_page = InvalidBlockNumber;
 
 	MarkBufferDirty(metabuf);
-	FlushOneBuffer(metabuf);
+	if (!BufferIsLocal(metabuf))
+		FlushOneBuffer(metabuf);
 	UnlockReleaseBuffer(metabuf);
 
 	/* Invalidate the docid writer cache since pages are cleared */

--- a/test/expected/temp_table.out
+++ b/test/expected/temp_table.out
@@ -1,0 +1,100 @@
+--
+-- Tests for BM25 indexes on temporary tables.
+-- Regression test for GitHub issue #247: crash on rollback after
+-- scanning a BM25 index on a temp table.
+--
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+WARNING:  pg_textsearch v1.0.0-dev is a prerelease. Do not use in production.
+-- Basic: create, populate, query, drop
+CREATE TEMP TABLE t_basic (id serial, body text);
+INSERT INTO t_basic VALUES (DEFAULT, 'hello world'), (DEFAULT, 'foo bar baz');
+CREATE INDEX t_basic_idx ON t_basic USING bm25(body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation t_basic_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 2 documents, avg_length=2.50
+SELECT id, body <@> 'hello' AS score FROM t_basic ORDER BY score LIMIT 5;
+ id |       score        
+----+--------------------
+  1 | -0.754912793636322
+  2 |                  0
+(2 rows)
+
+DROP TABLE t_basic;
+-- Rollback to savepoint after scan (original crash from #247)
+BEGIN;
+CREATE TEMP TABLE t_sp (id serial, body text);
+INSERT INTO t_sp VALUES (DEFAULT, 'hello world'), (DEFAULT, 'foo bar baz');
+CREATE INDEX t_sp_idx ON t_sp USING bm25(body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation t_sp_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 2 documents, avg_length=2.50
+SAVEPOINT sp1;
+SELECT body <@> 'hello' FROM t_sp LIMIT 1;
+      ?column?      
+--------------------
+ -0.754912793636322
+(1 row)
+
+ROLLBACK TO SAVEPOINT sp1;
+-- Table and index should still be usable after savepoint rollback
+SELECT body <@> 'hello' FROM t_sp LIMIT 1;
+      ?column?      
+--------------------
+ -0.754912793636322
+(1 row)
+
+COMMIT;
+DROP TABLE t_sp;
+-- Full rollback after scan (second crash case from #247)
+BEGIN;
+CREATE TEMP TABLE t_rb (id serial, body text);
+INSERT INTO t_rb VALUES (DEFAULT, 'hello world');
+CREATE INDEX t_rb_idx ON t_rb USING bm25(body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation t_rb_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1 documents, avg_length=2.00
+SELECT body <@> 'hello' FROM t_rb LIMIT 1;
+       ?column?       
+----------------------
+ -0.28768208622932434
+(1 row)
+
+ROLLBACK;
+-- Rollback of CREATE INDEX itself
+BEGIN;
+CREATE TEMP TABLE t_rb2 (id serial, body text);
+INSERT INTO t_rb2 VALUES (DEFAULT, 'hello world');
+SAVEPOINT before_idx;
+CREATE INDEX t_rb2_idx ON t_rb2 USING bm25(body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation t_rb2_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1 documents, avg_length=2.00
+ROLLBACK TO SAVEPOINT before_idx;
+COMMIT;
+DROP TABLE t_rb2;
+-- ON COMMIT DROP temp table with index
+BEGIN;
+CREATE TEMP TABLE t_ocd (id serial, body text) ON COMMIT DROP;
+INSERT INTO t_ocd VALUES (DEFAULT, 'on commit drop test');
+CREATE INDEX t_ocd_idx ON t_ocd USING bm25(body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation t_ocd_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1 documents, avg_length=3.00
+SELECT body <@> 'test' FROM t_ocd LIMIT 1;
+       ?column?       
+----------------------
+ -0.28768208622932434
+(1 row)
+
+COMMIT;
+-- Table should be gone now
+SELECT * FROM t_ocd; -- expect error
+ERROR:  relation "t_ocd" does not exist
+LINE 1: SELECT * FROM t_ocd;
+                      ^
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/temp_table.sql
+++ b/test/sql/temp_table.sql
@@ -1,0 +1,56 @@
+--
+-- Tests for BM25 indexes on temporary tables.
+-- Regression test for GitHub issue #247: crash on rollback after
+-- scanning a BM25 index on a temp table.
+--
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+-- Basic: create, populate, query, drop
+CREATE TEMP TABLE t_basic (id serial, body text);
+INSERT INTO t_basic VALUES (DEFAULT, 'hello world'), (DEFAULT, 'foo bar baz');
+CREATE INDEX t_basic_idx ON t_basic USING bm25(body) WITH (text_config = 'english');
+SELECT id, body <@> 'hello' AS score FROM t_basic ORDER BY score LIMIT 5;
+DROP TABLE t_basic;
+
+-- Rollback to savepoint after scan (original crash from #247)
+BEGIN;
+CREATE TEMP TABLE t_sp (id serial, body text);
+INSERT INTO t_sp VALUES (DEFAULT, 'hello world'), (DEFAULT, 'foo bar baz');
+CREATE INDEX t_sp_idx ON t_sp USING bm25(body) WITH (text_config = 'english');
+SAVEPOINT sp1;
+SELECT body <@> 'hello' FROM t_sp LIMIT 1;
+ROLLBACK TO SAVEPOINT sp1;
+-- Table and index should still be usable after savepoint rollback
+SELECT body <@> 'hello' FROM t_sp LIMIT 1;
+COMMIT;
+DROP TABLE t_sp;
+
+-- Full rollback after scan (second crash case from #247)
+BEGIN;
+CREATE TEMP TABLE t_rb (id serial, body text);
+INSERT INTO t_rb VALUES (DEFAULT, 'hello world');
+CREATE INDEX t_rb_idx ON t_rb USING bm25(body) WITH (text_config = 'english');
+SELECT body <@> 'hello' FROM t_rb LIMIT 1;
+ROLLBACK;
+
+-- Rollback of CREATE INDEX itself
+BEGIN;
+CREATE TEMP TABLE t_rb2 (id serial, body text);
+INSERT INTO t_rb2 VALUES (DEFAULT, 'hello world');
+SAVEPOINT before_idx;
+CREATE INDEX t_rb2_idx ON t_rb2 USING bm25(body) WITH (text_config = 'english');
+ROLLBACK TO SAVEPOINT before_idx;
+COMMIT;
+DROP TABLE t_rb2;
+
+-- ON COMMIT DROP temp table with index
+BEGIN;
+CREATE TEMP TABLE t_ocd (id serial, body text) ON COMMIT DROP;
+INSERT INTO t_ocd VALUES (DEFAULT, 'on commit drop test');
+CREATE INDEX t_ocd_idx ON t_ocd USING bm25(body) WITH (text_config = 'english');
+SELECT body <@> 'test' FROM t_ocd LIMIT 1;
+COMMIT;
+-- Table should be gone now
+SELECT * FROM t_ocd; -- expect error
+
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
Fixes #247.

## Summary
- `FlushOneBuffer()` asserts `!BufferIsLocal(buffer)`, which fails for temporary tables whose buffers are backend-local
- Guard every `FlushOneBuffer` call with `!BufferIsLocal()` to skip the flush for temp relations
- This is safe because temp data is not WAL-logged and doesn't need crash-recovery durability

The fix covers 7 call sites across `src/am/build.c` (3) and `src/state/metapage.c` (4). `FlushRelationBuffers()` calls in the segment code already handle local buffers correctly.

## Testing
- New `temp_table` regression test covering:
  - Basic create/populate/query/drop on temp table
  - `ROLLBACK TO SAVEPOINT` after BM25 scan (original crash from #247)
  - Full `ROLLBACK` after BM25 scan (second crash case from #247)
  - Rollback of `CREATE INDEX` itself via savepoint
  - `ON COMMIT DROP` temp table with BM25 index
