### PR TITLE
perf: skip empty memtable during query scoring

### DIFF
--- a/src/memtable/source.c
+++ b/src/memtable/source.c
@@ -127,7 +127,7 @@ tp_memtable_source_create(TpLocalIndexState *local_state)
 	Assert(local_state != NULL);
 
 	memtable = get_memtable(local_state);
-	if (!memtable)
+	if (!memtable || memtable->total_postings == 0)
 		return NULL;
 
 	ms			 = (TpMemtableSource *)palloc0(sizeof(TpMemtableSource));


### PR DESCRIPTION
## Summary
- One-line check: return NULL from `tp_memtable_source_create` when `memtable->total_postings == 0`
- Skips the entire memtable scoring path (dshash_attach x2, hash_create, per-term dshash_find, dshash_detach x2)
- Both single-term and multi-term BMW callers already handle NULL source gracefully

## Motivation
After `CREATE INDEX`, the memtable is empty -- all data lives in segments. But every query still attached to 2 dshash tables, created a doc accumulation hash table, and did per-term hash lookups that always returned NULL. Profiling on 138M MS-MARCO v2 showed this at 16% of CPU.

## Test plan
- [ ] All 49 regression tests pass
- [ ] CI passes
- [ ] Benchmark on MS-MARCO v2 to measure latency improvement