### PR TITLE
perf: stack-allocate decode buffers in tp_decompress_block

### DIFF
--- a/src/segment/compression.c
+++ b/src/segment/compression.c
@@ -276,8 +276,8 @@ tp_decompress_block(
 		TpBlockPosting *out_postings)
 {
 	const TpCompressedBlockHeader *header;
-	uint32						  *doc_deltas;
-	uint32						  *frequencies;
+	uint32						   doc_deltas[TP_BLOCK_SIZE];
+	uint32						   frequencies[TP_BLOCK_SIZE];
 	uint32						   doc_id_bytes;
 	uint32						   freq_bytes;
 	uint32						   pos;
@@ -296,10 +296,6 @@ tp_decompress_block(
 	Assert(header->freq_bits >= 1 && header->freq_bits <= 16);
 
 	pos = sizeof(TpCompressedBlockHeader);
-
-	/* Allocate temporary arrays */
-	doc_deltas	= palloc(count * sizeof(uint32));
-	frequencies = palloc(count * sizeof(uint32));
 
 	/* Calculate sizes for seeking */
 	doc_id_bytes = (count * header->doc_id_bits + 7) / 8;
@@ -326,9 +322,6 @@ tp_decompress_block(
 
 		prev_doc = doc_id;
 	}
-
-	pfree(doc_deltas);
-	pfree(frequencies);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replace `palloc`/`pfree` of two temporary `uint32` arrays (`doc_deltas`, `frequencies`) in `tp_decompress_block` with fixed-size stack arrays of `TP_BLOCK_SIZE` (128) elements
- These 512-byte arrays (1 KiB total on stack) were being heap-allocated on every block decompression — a hot path at 6.5% of CPU in profiling
- `TP_BLOCK_SIZE` is a `#define` constant, so these are NOT VLAs

## Test plan
- [x] `make clean && make` compiles with zero new warnings
- [x] All 49 SQL regression tests pass (`make installcheck`)
- [x] `make format-check` passes
- [x] MS-MARCO v2 benchmark to measure latency improvement