### PR TITLE
docs: update benchmark comparison with March 3 results

### DIFF
--- a/benchmarks/gh-pages/comparison.html
+++ b/benchmarks/gh-pages/comparison.html
@@ -125,14 +125,14 @@
     <div class="content">
         <div class="snapshot-notice">
             <strong>Snapshot in time:</strong> This comparison reflects pg_textsearch as of
-            February 9, 2026. The project is under active development with performance improvements
+            March 3, 2026. The project is under active development with performance improvements
             shipping regularly. Check the <a href="./">benchmark dashboard</a> for the latest numbers.
         </div>
 
         <p class="meta">
             <strong>Dataset:</strong> MS MARCO 8.8M passages |
-            <strong>Date:</strong> 2026-02-09 |
-            <strong>Commit:</strong> <a href="https://github.com/timescale/pg_textsearch/commit/74d725b">74d725b</a> |
+            <strong>Date:</strong> 2026-03-03 |
+            <strong>Commit:</strong> <a href="https://github.com/timescale/pg_textsearch/commit/1b09cc9">1b09cc9</a> |
             <strong>System X:</strong> v0.21.6
         </p>
 
@@ -142,7 +142,7 @@
             <div class="summary-card">
                 <h4>pg_textsearch today</h4>
                 <ul>
-                    <li><strong>2.8x faster</strong> overall query throughput</li>
+                    <li><strong>3.2x faster</strong> overall query throughput</li>
                     <li>Faster on all query lengths (1-8+ tokens)</li>
                     <li>Smaller index (no positions stored)*</li>
                     <li>Parallel index build (4 workers)</li>
@@ -152,7 +152,7 @@
             <div class="summary-card systemx">
                 <h4>System X v0.21.6</h4>
                 <ul>
-                    <li>Faster index build (2x)</li>
+                    <li>Faster index build (1.6x)</li>
                     <li>Phrase queries supported</li>
                     <li>Larger feature set (facets, etc.)</li>
                 </ul>
@@ -162,12 +162,16 @@
         <div class="roadmap">
             <h3>Recent Improvements</h3>
             <ul>
-                <li><strong>WAND pivot selection</strong> - Improved multi-term query optimization
-                    (<a href="https://github.com/timescale/pg_textsearch/pull/210">PR #210</a>),
-                    30-43% faster on 5-8+ token queries</li>
-                <li><strong>Parallel index build</strong> - Uses 4 workers, cutting build time in half
-                    (<a href="https://github.com/timescale/pg_textsearch/pull/188">PR #188</a>)</li>
-                <li><strong>Overall throughput</strong> - pg_textsearch now 2.8x faster than System X</li>
+                <li><strong>SIMD-accelerated decoding</strong> - Bitpack decoding with SIMD intrinsics
+                    (<a href="https://github.com/timescale/pg_textsearch/pull/250">PR #250</a>)</li>
+                <li><strong>Stack-allocated decode buffers</strong> - Reduced allocation overhead
+                    (<a href="https://github.com/timescale/pg_textsearch/pull/253">PR #253</a>)</li>
+                <li><strong>BMW term state optimization</strong> - Pointer indirection for ordering
+                    (<a href="https://github.com/timescale/pg_textsearch/pull/249">PR #249</a>)</li>
+                <li><strong>Arena allocator</strong> - Rewritten index build with parallel page pool
+                    (<a href="https://github.com/timescale/pg_textsearch/pull/231">PR #231</a>)</li>
+                <li><strong>Overall throughput</strong> - pg_textsearch now 3.2x faster than System X
+                    (up from 2.8x in February)</li>
             </ul>
         </div>
 
@@ -182,15 +186,15 @@
             </tr>
             <tr>
                 <td>Index Size</td>
-                <td class="winner">1,189 MB</td>
-                <td>1,503 MB</td>
-                <td><span class="better">-21%</span></td>
+                <td class="winner">1,215 MB</td>
+                <td>1,499 MB</td>
+                <td><span class="better">-19%</span></td>
             </tr>
             <tr>
                 <td>Build Time</td>
-                <td>269.5 sec</td>
-                <td class="winner">137.9 sec</td>
-                <td><span class="worse">+95%</span></td>
+                <td>234.4 sec</td>
+                <td class="winner">150.6 sec</td>
+                <td><span class="worse">+56%</span></td>
             </tr>
             <tr>
                 <td>Documents</td>
@@ -208,10 +212,12 @@
         </div>
 
         <div class="note progress">
-            <strong>Build time improvement:</strong> With parallel index build
-            (<a href="https://github.com/timescale/pg_textsearch/pull/188">PR #188</a>),
-            build time dropped from 518s to 270s. The gap with System X
-            narrowed from 3.8x to 2.0x.
+            <strong>Build time improvement:</strong> With the arena allocator rewrite
+            (<a href="https://github.com/timescale/pg_textsearch/pull/231">PR #231</a>) and
+            leader-only merge
+            (<a href="https://github.com/timescale/pg_textsearch/pull/244">PR #244</a>),
+            build time dropped from 270s to 234s. The gap with System X
+            narrowed from 2.0x to 1.6x.
         </div>
 
         <h2>Query Latency (p50)</h2>
@@ -226,51 +232,51 @@
             </tr>
             <tr>
                 <td>1 token</td>
-                <td class="winner">1.51 ms</td>
-                <td>17.29 ms</td>
-                <td><span class="better">-91%</span></td>
+                <td class="winner">0.69 ms</td>
+                <td>19.34 ms</td>
+                <td><span class="better">-96%</span></td>
             </tr>
             <tr>
                 <td>2 tokens</td>
-                <td class="winner">2.24 ms</td>
-                <td>17.23 ms</td>
-                <td><span class="better">-87%</span></td>
+                <td class="winner">1.49 ms</td>
+                <td>19.23 ms</td>
+                <td><span class="better">-92%</span></td>
             </tr>
             <tr>
                 <td>3 tokens</td>
-                <td class="winner">3.85 ms</td>
-                <td>22.53 ms</td>
-                <td><span class="better">-83%</span></td>
+                <td class="winner">2.98 ms</td>
+                <td>25.76 ms</td>
+                <td><span class="better">-88%</span></td>
             </tr>
             <tr>
                 <td>4 tokens</td>
-                <td class="winner">5.54 ms</td>
-                <td>24.31 ms</td>
-                <td><span class="better">-77%</span></td>
+                <td class="winner">4.51 ms</td>
+                <td>27.68 ms</td>
+                <td><span class="better">-84%</span></td>
             </tr>
             <tr>
                 <td>5 tokens</td>
-                <td class="winner">8.41 ms</td>
-                <td>26.81 ms</td>
-                <td><span class="better">-69%</span></td>
+                <td class="winner">7.46 ms</td>
+                <td>29.63 ms</td>
+                <td><span class="better">-75%</span></td>
             </tr>
             <tr>
                 <td>6 tokens</td>
-                <td class="winner">12.98 ms</td>
-                <td>33.65 ms</td>
-                <td><span class="better">-61%</span></td>
+                <td class="winner">10.63 ms</td>
+                <td>36.13 ms</td>
+                <td><span class="better">-71%</span></td>
             </tr>
             <tr>
                 <td>7 tokens</td>
-                <td class="winner">18.02 ms</td>
-                <td>33.98 ms</td>
-                <td><span class="better">-47%</span></td>
+                <td class="winner">16.29 ms</td>
+                <td>37.16 ms</td>
+                <td><span class="better">-56%</span></td>
             </tr>
             <tr>
                 <td>8+ tokens</td>
-                <td class="winner">27.95 ms</td>
-                <td>41.23 ms</td>
-                <td><span class="better">-32%</span></td>
+                <td class="winner">25.48 ms</td>
+                <td>45.21 ms</td>
+                <td><span class="better">-44%</span></td>
             </tr>
         </table>
 
@@ -286,51 +292,51 @@
             </tr>
             <tr>
                 <td>1 token</td>
-                <td class="winner">2.10 ms</td>
-                <td>22.60 ms</td>
-                <td><span class="better">-91%</span></td>
+                <td class="winner">1.64 ms</td>
+                <td>25.10 ms</td>
+                <td><span class="better">-93%</span></td>
             </tr>
             <tr>
                 <td>2 tokens</td>
-                <td class="winner">4.92 ms</td>
-                <td>28.76 ms</td>
-                <td><span class="better">-83%</span></td>
+                <td class="winner">4.69 ms</td>
+                <td>31.55 ms</td>
+                <td><span class="better">-85%</span></td>
             </tr>
             <tr>
                 <td>3 tokens</td>
-                <td class="winner">10.26 ms</td>
-                <td>33.37 ms</td>
-                <td><span class="better">-69%</span></td>
+                <td class="winner">9.19 ms</td>
+                <td>38.17 ms</td>
+                <td><span class="better">-76%</span></td>
             </tr>
             <tr>
                 <td>4 tokens</td>
-                <td class="winner">17.37 ms</td>
-                <td>33.94 ms</td>
-                <td><span class="better">-49%</span></td>
+                <td class="winner">13.84 ms</td>
+                <td>38.56 ms</td>
+                <td><span class="better">-64%</span></td>
             </tr>
             <tr>
                 <td>5 tokens</td>
-                <td class="winner">26.03 ms</td>
-                <td>36.19 ms</td>
-                <td><span class="better">-28%</span></td>
+                <td class="winner">23.07 ms</td>
+                <td>39.38 ms</td>
+                <td><span class="better">-41%</span></td>
             </tr>
             <tr>
                 <td>6 tokens</td>
-                <td class="winner">29.20 ms</td>
-                <td>55.70 ms</td>
-                <td><span class="better">-48%</span></td>
+                <td class="winner">26.68 ms</td>
+                <td>57.61 ms</td>
+                <td><span class="better">-54%</span></td>
             </tr>
             <tr>
                 <td>7 tokens</td>
-                <td class="winner">47.63 ms</td>
-                <td>61.52 ms</td>
-                <td><span class="better">-23%</span></td>
+                <td class="winner">41.71 ms</td>
+                <td>67.31 ms</td>
+                <td><span class="better">-38%</span></td>
             </tr>
             <tr>
                 <td>8+ tokens</td>
-                <td class="winner">60.42 ms</td>
-                <td>67.77 ms</td>
-                <td><span class="better">-11%</span></td>
+                <td class="winner">56.31 ms</td>
+                <td>70.05 ms</td>
+                <td><span class="better">-20%</span></td>
             </tr>
         </table>
 
@@ -346,15 +352,15 @@
             </tr>
             <tr>
                 <td>Total time</td>
-                <td class="winner">8.39 sec</td>
-                <td>23.34 sec</td>
-                <td><span class="better">-64%</span></td>
+                <td class="winner">7.91 sec</td>
+                <td>25.57 sec</td>
+                <td><span class="better">-69%</span></td>
             </tr>
             <tr>
                 <td>Avg ms/query</td>
-                <td class="winner">10.48 ms</td>
-                <td>29.18 ms</td>
-                <td><span class="better">-64%</span></td>
+                <td class="winner">9.89 ms</td>
+                <td>31.97 ms</td>
+                <td><span class="better">-69%</span></td>
             </tr>
         </table>
 
@@ -362,27 +368,33 @@
 
         <h3>Query latency: pg_textsearch faster across all token counts</h3>
         <p>
-            pg_textsearch is faster on all 8 token buckets at p50, ranging from 11x faster
-            on single-token queries to 1.5x faster on 8+ token queries. The Block-Max WAND
-            implementation with WAND pivot selection
-            (<a href="https://github.com/timescale/pg_textsearch/pull/210">PR #210</a>)
-            improved multi-token performance by 30-43% compared to the previous release,
-            closing what had been a gap on longer queries.
+            pg_textsearch is faster on all 8 token buckets at p50, ranging from 28x faster
+            on single-token queries to 1.8x faster on 8+ token queries. SIMD-accelerated
+            bitpack decoding
+            (<a href="https://github.com/timescale/pg_textsearch/pull/250">PR #250</a>)
+            and stack-allocated decode buffers
+            (<a href="https://github.com/timescale/pg_textsearch/pull/253">PR #253</a>)
+            improved segment read performance, while BMW term state pointer indirection
+            (<a href="https://github.com/timescale/pg_textsearch/pull/249">PR #249</a>)
+            reduced overhead in the query scoring path.
         </p>
 
-        <h3>Overall throughput: pg_textsearch 2.8x faster</h3>
+        <h3>Overall throughput: pg_textsearch 3.2x faster</h3>
         <p>
-            pg_textsearch completes 800 queries in 8.4s vs 23.3s for System X, a
-            <strong>2.8x throughput advantage</strong>. This is up from 1.8x in the
-            February 6 comparison, driven by the WAND pivot selection improvements
-            on multi-token queries.
+            pg_textsearch completes 800 queries in 7.9s vs 25.6s for System X, a
+            <strong>3.2x throughput advantage</strong>. This is up from 2.8x in the
+            February 9 comparison, driven by segment decoding and scoring path
+            optimizations.
         </p>
 
-        <h3>Index build: System X still faster</h3>
+        <h3>Index build: gap narrowing</h3>
         <p>
-            System X builds its index in 138s vs 270s for pg_textsearch (2.0x faster).
-            pg_textsearch uses parallel build with 4 workers, which cut build time
-            roughly in half from the single-threaded baseline.
+            System X builds its index in 151s vs 234s for pg_textsearch (1.6x faster).
+            The arena allocator rewrite
+            (<a href="https://github.com/timescale/pg_textsearch/pull/231">PR #231</a>)
+            and leader-only merge
+            (<a href="https://github.com/timescale/pg_textsearch/pull/244">PR #244</a>)
+            cut build time from 270s to 234s, narrowing the gap from 2.0x to 1.6x.
         </p>
 
         <h2>Methodology</h2>


### PR DESCRIPTION
## Summary
- Update comparison page with results from benchmark run [22642807624](https://github.com/timescale/pg_textsearch/actions/runs/22642807624)
- Overall throughput improved from 2.8x to 3.2x faster than System X
- Build time gap narrowed from 2.0x to 1.6x (270s → 234s)
- Key improvements since Feb 9: SIMD bitpack decoding (#250), stack-allocated decode buffers (#253), BMW term state pointer indirection (#249), arena allocator rewrite (#231), leader-only merge (#244)

## Testing
- Numbers extracted from benchmark run on commit 1b09cc9
- gh-pages branch also needs updating (will push after merge)