### PR TITLE
fix: add shared_preload_libraries to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         initdb -D tmp_bench/data --auth-local=trust --auth-host=trust
         echo "shared_buffers = 256MB" >> tmp_bench/data/postgresql.conf
         echo "max_connections = 20" >> tmp_bench/data/postgresql.conf
+        echo "shared_preload_libraries = 'pg_textsearch'" >> tmp_bench/data/postgresql.conf
         echo "unix_socket_directories = '$PWD/tmp_bench/socket'" >> tmp_bench/data/postgresql.conf
         pg_ctl start -D tmp_bench/data -l tmp_bench/postgres.log -w
         export PGHOST="$PWD/tmp_bench/socket"
@@ -127,6 +128,7 @@ jobs:
         echo "port = 55433" >> tmp_release_check/data/postgresql.conf
         echo "shared_buffers = 256MB" >> tmp_release_check/data/postgresql.conf
         echo "max_connections = 20" >> tmp_release_check/data/postgresql.conf
+        echo "shared_preload_libraries = 'pg_textsearch'" >> tmp_release_check/data/postgresql.conf
         echo "unix_socket_directories = '$PWD/tmp_release_check'" >> tmp_release_check/data/postgresql.conf
         pg_ctl start -D tmp_release_check/data -l tmp_release_check/data/logfile -w
         createdb -h $PWD/tmp_release_check -p 55433 contrib_regression


### PR DESCRIPTION
## Summary
- The benchmark-gate and build-and-test jobs in `release.yml` were missing
  `shared_preload_libraries = 'pg_textsearch'` in postgresql.conf, causing
  `CREATE EXTENSION` to fail during the v0.6.0 release run

## Testing
- Workflow change only; verified by inspecting the release run failure logs