### PR TITLE
fix: swap build/start order in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
+    - name: Build extension (optimized)
+      run: |
+        export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
+        make clean
+        # Build optimized version for release
+        CFLAGS="-O3 -DNDEBUG" make
+        sudo make install
+
     - name: Start PostgreSQL
       run: |
         export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
@@ -132,14 +140,6 @@ jobs:
         echo "unix_socket_directories = '$PWD/tmp_release_check'" >> tmp_release_check/data/postgresql.conf
         pg_ctl start -D tmp_release_check/data -l tmp_release_check/data/logfile -w
         createdb -h $PWD/tmp_release_check -p 55433 contrib_regression
-
-    - name: Build extension (optimized)
-      run: |
-        export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
-        make clean
-        # Build optimized version for release
-        CFLAGS="-O3 -DNDEBUG" make
-        sudo make install
 
     - name: Run full test suite
       run: |


### PR DESCRIPTION
## Summary
- Move build step before start step in release workflow's `build-and-test` job
- Postgres can't start with `shared_preload_libraries = 'pg_textsearch'`
  if the library isn't installed yet

Cherry-pick of #260 to main.

## Testing
- Workflow change only; verified in v0.6.0 release run