### PR TITLE
fix: widen TpDictEntry.block_count from uint16 to uint32

### DIFF
--- a/src/am/build_context.c
+++ b/src/am/build_context.c
@@ -270,7 +270,7 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	{
 		uint64 posting_offset;
 		uint32 skip_entry_start;
-		uint16 block_count;
+		uint32 block_count;
 		uint32 doc_freq;
 	} TermBlockInfo;
 
@@ -392,7 +392,7 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 		}
 
 		num_blocks = (doc_count + TP_BLOCK_SIZE - 1) / TP_BLOCK_SIZE;
-		term_blocks[i].block_count = (uint16)num_blocks;
+		term_blocks[i].block_count = num_blocks;
 
 		/* Initialize EXPULL reader for this term */
 		tp_expull_reader_init(&reader, ctx->arena, terms[i].expull);
@@ -548,7 +548,6 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 					((uint64)term_blocks[i].skip_entry_start *
 					 sizeof(TpSkipEntry));
 			entry.block_count = term_blocks[i].block_count;
-			entry.reserved	  = 0;
 			entry.doc_freq	  = term_blocks[i].doc_freq;
 
 			/* Locate this entry in the segment */
@@ -703,7 +702,7 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	{
 		uint64 posting_offset;
 		uint32 skip_entry_start;
-		uint16 block_count;
+		uint32 block_count;
 		uint32 doc_freq;
 	} TermBlockInfo;
 
@@ -821,7 +820,7 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 		}
 
 		num_blocks = (doc_count + TP_BLOCK_SIZE - 1) / TP_BLOCK_SIZE;
-		term_blocks[i].block_count = (uint16)num_blocks;
+		term_blocks[i].block_count = num_blocks;
 
 		tp_expull_reader_init(&reader, ctx->arena, terms[i].expull);
 
@@ -962,7 +961,6 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 					((uint64)term_blocks[i].skip_entry_start *
 					 sizeof(TpSkipEntry));
 			dict_entries[i].block_count = term_blocks[i].block_count;
-			dict_entries[i].reserved	= 0;
 			dict_entries[i].doc_freq	= term_blocks[i].doc_freq;
 		}
 

--- a/src/query/bmw.c
+++ b/src/query/bmw.c
@@ -476,9 +476,9 @@ score_segment_single_term_bmw(
 	TpSegmentPostingIterator iter;
 	TpSegmentPosting		*posting;
 	TpDictEntry				*dict_entry;
-	uint16					 block_count;
+	uint32					 block_count;
 	float4					*block_max_scores;
-	uint16					 i;
+	uint32					 i;
 
 	/* Initialize iterator for this term */
 	if (!tp_segment_posting_iterator_init(&iter, reader, term))
@@ -800,9 +800,9 @@ advance_term_iterator(TpTermState *ts)
 static bool
 seek_term_to_doc(TpTermState *ts, uint32 target_doc_id)
 {
-	uint16 block_count;
+	uint32 block_count;
 	int	   left, right, mid;
-	uint16 target_block;
+	uint32 target_block;
 
 	if (!ts->found || ts->iter.finished)
 		return false;
@@ -929,8 +929,8 @@ init_segment_term_states(
 		/* Pre-load skip entries for BMW threshold checks and fast seeking */
 		if (ts->iter.dict_entry.block_count > 0)
 		{
-			uint16 block_idx;
-			uint16 block_count = ts->iter.dict_entry.block_count;
+			uint32 block_idx;
+			uint32 block_count = ts->iter.dict_entry.block_count;
 
 			ts->block_max_scores   = palloc(block_count * sizeof(float4));
 			ts->block_last_doc_ids = palloc(block_count * sizeof(uint32));
@@ -1107,7 +1107,7 @@ compute_block_max_at_pivot(TpTermState **terms, int pivot_len)
 	for (i = 0; i < pivot_len; i++)
 	{
 		TpTermState *ts = terms[i];
-		uint16		 block;
+		uint32		 block;
 
 		if (!ts->found || ts->iter.finished)
 			continue;
@@ -1151,7 +1151,7 @@ block_max_skip_advance(
 	{
 		TpTermState *ts = terms[i];
 		uint32		 doc_id;
-		uint16		 block;
+		uint32		 block;
 		uint32		 block_last;
 
 		doc_id = term_current_doc_id(ts);

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -1219,7 +1219,7 @@ write_merged_segment_to_sink(
 			FLUSH_BLOCK(block_buf, block_count, num_blocks);
 
 		term_blocks[i].doc_freq	   = doc_count;
-		term_blocks[i].block_count = (uint16)num_blocks;
+		term_blocks[i].block_count = num_blocks;
 
 		free_term_posting_sources(psources, num_psources);
 
@@ -1300,7 +1300,6 @@ write_merged_segment_to_sink(
 					((uint64)term_blocks[i].skip_entry_start *
 					 sizeof(TpSkipEntry));
 			dict_entries[i].block_count = term_blocks[i].block_count;
-			dict_entries[i].reserved	= 0;
 			dict_entries[i].doc_freq	= term_blocks[i].doc_freq;
 		}
 

--- a/src/segment/merge_internal.h
+++ b/src/segment/merge_internal.h
@@ -76,7 +76,7 @@ typedef struct TpPostingMergeSource
 
 	/* block iteration state */
 	uint64			skip_index_offset; /* Offset to skip entries */
-	uint16			block_count;	   /* Total blocks */
+	uint32			block_count;	   /* Total blocks */
 	uint32			current_block;	   /* Current block index */
 	uint32			current_in_block;  /* Position within current block */
 	TpSkipEntry		skip_entry;		   /* Current block's skip entry */
@@ -99,7 +99,7 @@ typedef struct TpMergeDocMapping
 typedef struct MergeTermBlockInfo
 {
 	uint64 posting_offset;	 /* Offset where postings were written */
-	uint16 block_count;		 /* Number of blocks for this term */
+	uint32 block_count;		 /* Number of blocks for this term */
 	uint32 doc_freq;		 /* Document frequency */
 	uint32 skip_entry_start; /* Index into skip entries array */
 } MergeTermBlockInfo;

--- a/src/segment/scan.c
+++ b/src/segment/scan.c
@@ -23,7 +23,7 @@ void
 tp_segment_read_skip_entry(
 		TpSegmentReader *reader,
 		uint64			 skip_index_offset,
-		uint16			 block_idx,
+		uint32			 block_idx,
 		TpSkipEntry		*skip)
 {
 	uint64 skip_offset;
@@ -436,9 +436,9 @@ tp_segment_posting_iterator_seek(
 		uint32					  target_doc_id,
 		TpSegmentPosting		**posting)
 {
-	uint16		block_count;
+	uint32		block_count;
 	int			left, right, mid;
-	uint16		target_block;
+	uint32		target_block;
 	TpSkipEntry skip;
 
 	if (!iter->initialized || iter->finished)

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -112,7 +112,6 @@ tp_segment_read_dict_entry(
 		/* Widen V3 fields to V4 */
 		entry->skip_index_offset = (uint64)v3.skip_index_offset;
 		entry->block_count		 = v3.block_count;
-		entry->reserved			 = v3.reserved;
 		entry->doc_freq			 = v3.doc_freq;
 	}
 	else
@@ -962,7 +961,7 @@ build_docmap_from_memtable(TpLocalIndexState *state)
 typedef struct TermBlockInfo
 {
 	uint64 posting_offset;	 /* Absolute offset where postings were written */
-	uint16 block_count;		 /* Number of blocks for this term */
+	uint32 block_count;		 /* Number of blocks for this term */
 	uint32 doc_freq;		 /* Document frequency */
 	uint32 skip_entry_start; /* Index into accumulated skip entries array */
 } TermBlockInfo;
@@ -1138,7 +1137,7 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 
 		/* Calculate number of blocks (always >= 1 since doc_count > 0 here) */
 		num_blocks = (doc_count + TP_BLOCK_SIZE - 1) / TP_BLOCK_SIZE;
-		term_blocks[i].block_count = (uint16)num_blocks;
+		term_blocks[i].block_count = num_blocks;
 
 		/* Convert postings to block format */
 		block_postings = palloc(doc_count * sizeof(TpBlockPosting));
@@ -1316,7 +1315,6 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 					((uint64)term_blocks[i].skip_entry_start *
 					 sizeof(TpSkipEntry));
 			entry.block_count = term_blocks[i].block_count;
-			entry.reserved	  = 0;
 			entry.doc_freq	  = term_blocks[i].doc_freq;
 
 			/* Calculate where this entry is in the segment */

--- a/src/segment/segment.h
+++ b/src/segment/segment.h
@@ -182,12 +182,17 @@ typedef struct TpDictEntryV3
  * Points to skip index instead of raw postings. The skip index
  * contains block_count TpSkipEntry structures, each pointing to
  * a block of up to TP_BLOCK_SIZE postings.
+ *
+ * block_count was widened from uint16 to uint32 without a format
+ * version bump.  The old layout had uint16 block_count + uint16
+ * reserved (always 0) at bytes 8-11.  On little-endian platforms
+ * (x86-64, ARM64) these four bytes read identically as a uint32,
+ * so existing V4 segments are binary-compatible.
  */
 typedef struct TpDictEntry
 {
 	uint64 skip_index_offset; /* Offset to TpSkipEntry array for this term */
-	uint16 block_count;		  /* Number of blocks (and skip entries) */
-	uint16 reserved;		  /* Padding */
+	uint32 block_count;		  /* Number of blocks (and skip entries) */
 	uint32 doc_freq;		  /* Document frequency for IDF */
 } __attribute__((aligned(8))) TpDictEntry;
 

--- a/src/segment/segment_io.h
+++ b/src/segment/segment_io.h
@@ -189,7 +189,7 @@ extern void tp_segment_posting_iterator_free(TpSegmentPostingIterator *iter);
 extern void tp_segment_read_skip_entry(
 		TpSegmentReader *reader,
 		uint64			 skip_index_offset,
-		uint16			 block_idx,
+		uint32			 block_idx,
 		TpSkipEntry		*skip);
 
 /* Seek iterator to target doc ID (for WAND algorithm) */


### PR DESCRIPTION
## Summary

- **Fixes #144**: `TpDictEntry.block_count` was `uint16`, capping each term at 65,535 blocks (~8.4M postings). For corpora >50M docs, common terms in a compacted segment exceed this limit and the silent `(uint16)` cast wraps to 0, corrupting query results.
- Widens `block_count` from `uint16` to `uint32` and removes the adjacent `reserved` field, keeping `TpDictEntry` at exactly 16 bytes.
- **Binary-compatible**: old V4 segments stored `uint16` at bytes 8-9 with `reserved=0` at bytes 10-11. On little-endian platforms (x86-64, ARM64) this reads identically as `uint32`. No format version bump; existing indexes work without rebuild.
- V3 segments (`TpDictEntryV3`) are unchanged — their `uint32` offset limit makes it impossible for a single term to reach the 65K block cap.

## Changes across 8 files

| File | Change |
|------|--------|
| `segment.h` | `TpDictEntry`: `uint16 block_count` + `uint16 reserved` → `uint32 block_count` |
| `segment.c` | Widen `TermBlockInfo.block_count`, remove `(uint16)` cast, remove `reserved` assignments |
| `merge_internal.h` | Widen `MergeTermBlockInfo.block_count` and `TpPostingMergeSource.block_count` |
| `merge.c` | Remove `(uint16)` cast, remove `reserved` assignment |
| `build_context.c` | Widen both `TermBlockInfo` structs, remove casts and `reserved` assignments |
| `bmw.c` | Widen `block_count`/`block_idx`/`block`/`target_block` locals (6 variables, 4 functions) |
| `scan.c` | Widen `block_count`/`target_block` locals, widen `block_idx` parameter |
| `segment_io.h` | Widen `tp_segment_read_skip_entry` `block_idx` parameter |

## Test plan

- [x] `sizeof(TpDictEntry) == 16` confirmed (struct size unchanged)
- [x] `make clean && make` — zero new warnings
- [x] `make installcheck` — all 49 regression tests pass
- [x] `make format-check` — formatting clean
- [ ] CI: PG17 + PG18 regression tests
- [ ] CI: Address sanitizer build
- [ ] CI: Formatting check