### PR TITLE
docs: clarify pre-existing test failures in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ consider a dedicated `pg_textsearch` schema for cleaner namespace management.
   before CREATE EXTENSION. A server restart is also required after updating
   the binary (e.g., after `make install` during development).
 
+- Do not ignore "pre-existing test failures".  They are almost never "pre-existing" as we keep CI green on main.
+
 ## Core Architecture
 
 ### Storage Architecture


### PR DESCRIPTION
## Summary

- Add note that apparent "pre-existing" test failures should not be ignored — CI is kept green on main so they are almost never actually pre-existing
