### PR TITLE
perf: shadow doc_id array and binary search in BMW inner loop

### DIFF
--- a/src/query/bmw.c
+++ b/src/query/bmw.c
@@ -1409,11 +1409,14 @@ score_segment_multi_term_bmw(
 		float4			 avg_doc_len,
 		TpBMWStats		*stats)
 {
-	int	   active_count;
-	uint32 doc_ids[64]; /* Shadow array - avoids pointer chasing */
-	int	   i;
+	int		active_count;
+	uint32	doc_ids_stack[64]; /* Shadow array - avoids pointer chasing */
+	uint32 *doc_ids;
+	int		i;
 
-	Assert(term_count <= 64);
+	/* Use stack array for typical queries, heap for exotic ones */
+	doc_ids = (term_count <= 64) ? doc_ids_stack
+								 : palloc(term_count * sizeof(uint32));
 
 	active_count = init_segment_term_states(
 			terms, term_count, reader, k1, b, avg_doc_len);
@@ -1421,6 +1424,8 @@ score_segment_multi_term_bmw(
 	if (active_count == 0)
 	{
 		cleanup_segment_term_states(terms, term_count);
+		if (doc_ids != doc_ids_stack)
+			pfree(doc_ids);
 		return;
 	}
 
@@ -1514,6 +1519,9 @@ score_segment_multi_term_bmw(
 	}
 
 	cleanup_segment_term_states(terms, term_count);
+
+	if (doc_ids != doc_ids_stack)
+		pfree(doc_ids);
 }
 
 /*


### PR DESCRIPTION
## Summary

Two optimizations targeting the hottest functions in the multi-term BMW query path, identified via `perf record` flamegraph profiling on MS-MARCO v2 (138M docs):

- **Shadow doc_id array** (targets `restore_ordering` at 19% of CPU): Maintains a contiguous `uint32[]` parallel to the `terms[]` pointer array. All doc_id reads in the WAND hot path now scan this cache-line-friendly array instead of chasing pointers through separately heap-allocated `TpTermState` structs. Affects `restore_ordering`, `find_wand_pivot`, `verify_pivot_alignment`, `seek_to_pivot`, `block_max_skip_advance`, and the main WAND loop.

- **Binary search within blocks** (targets `seek_term_to_doc` at 21% of CPU): Replaces linear scans over block postings with `block_lower_bound()` binary search. Blocks hold up to 128 `TpBlockPosting` entries (sorted by doc_id), so this reduces worst-case comparisons from 128 to 7.

## Test plan

- [x] All 50 regression tests pass
- [x] Code formatting check passes
- [ ] CI passes
- [ ] Benchmark on MS-MARCO v2 (138M docs) to measure latency improvement
- [ ] Ground truth validation passes (400 queries)