### PR TITLE
fix: prevent ResourceOwnerEnlarge crash during transaction abort

### DIFF
--- a/src/state/registry.c
+++ b/src/state/registry.c
@@ -154,6 +154,22 @@ tp_registry_shmem_startup(void)
 }
 
 /*
+ * Return the DSA area only if already attached in this backend.
+ * Unlike tp_registry_get_dsa(), this will NOT lazily create or attach
+ * to the DSA. This is safe to call during transaction abort cleanup
+ * where ResourceOwnerEnlarge would fail.
+ *
+ * Returns NULL if this backend has not yet attached to the DSA.
+ *
+ * See: https://github.com/timescale/pg_textsearch/issues/247
+ */
+dsa_area *
+tp_registry_get_dsa_if_attached(void)
+{
+	return tapir_dsa;
+}
+
+/*
  * Get or create the shared DSA area
  *
  * This function is called by any backend that needs access to the DSA.
@@ -328,8 +344,13 @@ tp_registry_lookup_dsa(Oid index_oid)
 	TpRegistryEntry *entry;
 	dsa_pointer		 result = InvalidDsaPointer;
 
-	/* Ensure DSA is initialized */
-	tp_registry_get_dsa();
+	/*
+	 * Do not lazily initialize DSA here — this function may be called
+	 * during transaction abort via tp_cleanup_build_mode_on_abort().
+	 * See: https://github.com/timescale/pg_textsearch/issues/247
+	 */
+	if (!tapir_dsa)
+		return InvalidDsaPointer;
 
 	if (!tapir_registry ||
 		tapir_registry->registry_handle == DSHASH_HANDLE_INVALID)
@@ -376,8 +397,19 @@ tp_registry_is_registered(Oid index_oid)
 	if (tapir_registry->registry_handle == DSHASH_HANDLE_INVALID)
 		return false;
 
-	/* Ensure DSA is attached */
-	tp_registry_get_dsa();
+	/*
+	 * If DSA is not yet attached for this backend, return false instead of
+	 * lazily initializing. Lazy DSA initialization (via dsa_attach /
+	 * dsa_create) calls ResourceOwnerEnlarge, which will fail with
+	 * "ResourceOwnerEnlarge called after release started" if called during
+	 * transaction abort cleanup (e.g., from object_access_hook processing
+	 * OAT_DROP events for objects created in the aborting transaction).
+	 *
+	 * If this backend has never attached to the DSA, it has never
+	 * interacted with any BM25 indexes, so no cleanup is needed.
+	 *
+	 * See: https://github.com/timescale/pg_textsearch/issues/247
+	 */
 	if (!tapir_dsa)
 		return false;
 
@@ -414,8 +446,14 @@ tp_registry_unregister(Oid index_oid)
 		return;
 	}
 
-	/* Ensure DSA is attached */
-	tp_registry_get_dsa();
+	/*
+	 * Do not lazily initialize DSA here — this function may be called
+	 * during transaction abort (from tp_cleanup_build_mode_on_abort via
+	 * object_access_hook). Lazy initialization would call
+	 * ResourceOwnerEnlarge which fails during abort on PG17+.
+	 *
+	 * See: https://github.com/timescale/pg_textsearch/issues/247
+	 */
 	if (!tapir_dsa)
 		return;
 

--- a/src/state/registry.h
+++ b/src/state/registry.h
@@ -54,6 +54,7 @@ extern void tp_registry_shmem_startup(void);
 
 /* DSA management */
 extern dsa_area *tp_registry_get_dsa(void);
+extern dsa_area *tp_registry_get_dsa_if_attached(void);
 
 /* Registry operations */
 extern bool tp_registry_register(

--- a/src/state/state.c
+++ b/src/state/state.c
@@ -558,7 +558,19 @@ tp_cleanup_build_mode_on_abort(void)
 	if (local_state_cache == NULL)
 		return;
 
-	global_dsa = tp_registry_get_dsa();
+	/*
+	 * Use the already-attached DSA if available, but do NOT lazily
+	 * initialize it. During transaction abort, calling tp_registry_get_dsa()
+	 * may trigger dsa_attach() which calls ResourceOwnerEnlarge — this will
+	 * fail with "ResourceOwnerEnlarge called after release started" on
+	 * PostgreSQL 17+ where the ResourceOwner releasing guard is enforced.
+	 *
+	 * If the DSA was never attached in this backend, there can be no
+	 * build-mode indexes to clean up.
+	 *
+	 * See: https://github.com/timescale/pg_textsearch/issues/247
+	 */
+	global_dsa = tp_registry_get_dsa_if_attached();
 
 	hash_seq_init(&status, local_state_cache);
 	while ((entry = hash_seq_search(&status)) != NULL)
@@ -638,8 +650,20 @@ tp_cleanup_index_shared_memory(Oid index_oid)
 		return; /* Nothing to clean up */
 	}
 
-	/* Get the shared DSA area */
-	dsa = tp_registry_get_dsa();
+	/*
+	 * Get the shared DSA area. Use the non-lazy version since this may be
+	 * called during transaction abort via the object_access_hook.
+	 * If tp_registry_lookup_dsa returned a valid pointer above, DSA must
+	 * already be attached, so this is just a safety check.
+	 *
+	 * See: https://github.com/timescale/pg_textsearch/issues/247
+	 */
+	dsa = tp_registry_get_dsa_if_attached();
+	if (dsa == NULL)
+	{
+		tp_registry_unregister(index_oid);
+		return;
+	}
 
 	/* Get shared state to access memtable */
 	shared_state = (TpSharedIndexState *)dsa_get_address(dsa, shared_dp);


### PR DESCRIPTION
When pg_textsearch is loaded via shared_preload_libraries, any transaction that creates database objects via DDL, encounters an error, and then attempts ROLLBACK will fail with:

  ERROR: ResourceOwnerEnlarge called after release started

This occurs because pg_textsearch's object_access_hook and transaction abort callbacks lazily initialize the DSA area (via dsa_attach/dsa_create), which calls ResourceOwnerEnlarge. On PostgreSQL 17+, calling ResourceOwnerEnlarge after the ResourceOwner has started releasing resources triggers a guard check that throws this error.

The fix:
- In tp_registry_is_registered(): check tapir_dsa directly instead of calling tp_registry_get_dsa(). If DSA was never attached in this backend, no BM25 indexes can need cleanup.
- In tp_registry_lookup_dsa() and tp_registry_unregister(): same guard - do not lazily initialize DSA since these may be called during abort.
- In tp_cleanup_build_mode_on_abort(): use new tp_registry_get_dsa_if_attached() which returns the already-attached DSA or NULL without lazy init.
- In tp_cleanup_index_shared_memory(): use tp_registry_get_dsa_if_attached() since this is called from the object_access_hook during abort.
- Add tp_registry_get_dsa_if_attached() function and declaration.

Ref: https://github.com/timescale/pg_textsearch/issues/247