### PR TITLE
fix: crash on ROLLBACK after error in transaction block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ PG_CPPFLAGS += -Wno-unknown-warning-option -Wno-clobbered -Wno-packed-not-aligne
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = aerodocs basic binary_io bmw bulk_load compression concurrent_build coverage deletion vacuum vacuum_extended vacuum_rebuild dropped empty explicit_index force_merge implicit index inheritance limits lock manyterms memory merge mixed parallel_build parallel_bmw partitioned partitioned_many pgstats queries rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table unsupported updates vector unlogged_index wand text_config
+REGRESS = abort aerodocs basic binary_io bmw bulk_load compression concurrent_build coverage deletion vacuum vacuum_extended vacuum_rebuild dropped empty explicit_index force_merge implicit index inheritance limits lock manyterms memory merge mixed parallel_build parallel_bmw partitioned partitioned_many pgstats queries rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table unsupported updates vector unlogged_index wand text_config
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -13,6 +13,7 @@
 #include <access/genam.h>
 #include <access/htup_details.h>
 #include <access/table.h>
+#include <access/xact.h>
 #include <catalog/indexing.h>
 #include <catalog/namespace.h>
 #include <catalog/pg_am.h>
@@ -717,7 +718,14 @@ tp_post_parse_analyze_hook(
 	/* Reset flag for this query - will be set if BM25 operators found */
 	query_has_bm25_operators = false;
 
-	resolve_indexes_in_query(query);
+	/*
+	 * Skip index resolution if we're not in a valid transaction state.
+	 * This happens when a statement is parsed after an error in a
+	 * transaction block (e.g., ROLLBACK after a failed query). In that
+	 * state, catalog lookups are forbidden.
+	 */
+	if (IsTransactionState())
+		resolve_indexes_in_query(query);
 
 	if (prev_post_parse_analyze_hook)
 		prev_post_parse_analyze_hook(pstate, query, jstate);

--- a/test/expected/abort.out
+++ b/test/expected/abort.out
@@ -1,0 +1,136 @@
+--
+-- Test transaction abort scenarios
+--
+-- Verify that pg_textsearch hooks handle aborted transactions gracefully.
+-- The post_parse_analyze_hook fires on every SQL statement including
+-- ROLLBACK. When a transaction is in an aborted state, catalog lookups
+-- are forbidden, so the hook must skip its work.
+--
+CREATE EXTENSION pg_textsearch;
+WARNING:  pg_textsearch v1.0.0-dev is a prerelease. Do not use in production.
+-- Scenario 1: Basic abort with no pg_textsearch objects
+-- This is the original bug report (#247): ROLLBACK after an error in a
+-- transaction that has nothing to do with BM25 should not crash.
+BEGIN;
+CREATE TABLE abort_test1 (id serial PRIMARY KEY);
+SELECT 1/0;
+ERROR:  division by zero
+ROLLBACK;
+-- Scenario 2: Abort with a BM25 index present (created before the xact)
+CREATE TABLE abort_test2 (id serial PRIMARY KEY, body text);
+CREATE INDEX abort_test2_idx ON abort_test2
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation abort_test2_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+BEGIN;
+INSERT INTO abort_test2 (body) VALUES ('hello world');
+SELECT 1/0;
+ERROR:  division by zero
+ROLLBACK;
+-- Verify the index is still usable after the abort
+INSERT INTO abort_test2 (body) VALUES ('hello world');
+SELECT id, ROUND((body <@> to_bm25query('hello', 'abort_test2_idx'))::numeric, 4) AS score
+    FROM abort_test2
+    ORDER BY body <@> to_bm25query('hello', 'abort_test2_idx')
+    LIMIT 5;
+ id |  score  
+----+---------
+  2 | -0.1823
+(1 row)
+
+-- Scenario 3: Abort during CREATE INDEX
+BEGIN;
+CREATE TABLE abort_test3 (id serial PRIMARY KEY, body text);
+INSERT INTO abort_test3 (body) VALUES ('test document');
+CREATE INDEX ON abort_test3
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation abort_test3_body_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1 documents, avg_length=2.00
+SELECT 1/0;
+ERROR:  division by zero
+ROLLBACK;
+-- Table and index should not exist after rollback
+SELECT count(*) FROM pg_class WHERE relname = 'abort_test3';
+ count 
+-------
+     0
+(1 row)
+
+-- Scenario 4: Abort with DDL (DROP TABLE that has a BM25 index)
+CREATE TABLE abort_test4 (id serial PRIMARY KEY, body text);
+CREATE INDEX abort_test4_idx ON abort_test4
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation abort_test4_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+INSERT INTO abort_test4 (body) VALUES ('still here');
+BEGIN;
+DROP TABLE abort_test4;
+SELECT 1/0;
+ERROR:  division by zero
+ROLLBACK;
+-- Table should still exist after the aborted DROP
+SET client_min_messages = warning;
+SELECT count(*) FROM abort_test4;
+ count 
+-------
+     1
+(1 row)
+
+RESET client_min_messages;
+-- Scenario 5: Multiple errors in sequence
+BEGIN;
+SELECT 1/0;
+ERROR:  division by zero
+SELECT 2/0;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+-- Scenario 6: SAVEPOINT and error within subtransaction
+BEGIN;
+INSERT INTO abort_test2 (body) VALUES ('before savepoint');
+SAVEPOINT sp1;
+SELECT 1/0;
+ERROR:  division by zero
+ROLLBACK TO sp1;
+INSERT INTO abort_test2 (body)
+    VALUES ('after rollback to savepoint');
+COMMIT;
+SELECT id, body FROM abort_test2
+    WHERE body <@> to_bm25query('savepoint', 'abort_test2_idx') < 0
+    ORDER BY body <@> to_bm25query('savepoint', 'abort_test2_idx');
+ id |            body             
+----+-----------------------------
+  3 | before savepoint
+  4 | after rollback to savepoint
+(2 rows)
+
+-- Scenario 7: Error in a BM25 query
+BEGIN;
+INSERT INTO abort_test2 (body) VALUES ('scenario seven');
+-- Force an error via division by zero in the same statement
+SELECT (body <@> to_bm25query('scenario', 'abort_test2_idx'))::int / 0
+    FROM abort_test2;
+ERROR:  division by zero
+ROLLBACK;
+-- Scenario 8: Abort after BM25 query succeeds, then later stmt fails
+BEGIN;
+SELECT id FROM abort_test2
+    ORDER BY body <@> to_bm25query('hello', 'abort_test2_idx')
+    LIMIT 3;
+ id 
+----
+  2
+(1 row)
+
+SELECT 1/0;
+ERROR:  division by zero
+ROLLBACK;
+-- Cleanup
+DROP TABLE abort_test2;
+DROP TABLE abort_test4;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/abort.sql
+++ b/test/sql/abort.sql
@@ -1,0 +1,98 @@
+--
+-- Test transaction abort scenarios
+--
+-- Verify that pg_textsearch hooks handle aborted transactions gracefully.
+-- The post_parse_analyze_hook fires on every SQL statement including
+-- ROLLBACK. When a transaction is in an aborted state, catalog lookups
+-- are forbidden, so the hook must skip its work.
+--
+
+CREATE EXTENSION pg_textsearch;
+
+-- Scenario 1: Basic abort with no pg_textsearch objects
+-- This is the original bug report (#247): ROLLBACK after an error in a
+-- transaction that has nothing to do with BM25 should not crash.
+BEGIN;
+CREATE TABLE abort_test1 (id serial PRIMARY KEY);
+SELECT 1/0;
+ROLLBACK;
+
+-- Scenario 2: Abort with a BM25 index present (created before the xact)
+CREATE TABLE abort_test2 (id serial PRIMARY KEY, body text);
+CREATE INDEX abort_test2_idx ON abort_test2
+    USING bm25 (body) WITH (text_config = 'english');
+BEGIN;
+INSERT INTO abort_test2 (body) VALUES ('hello world');
+SELECT 1/0;
+ROLLBACK;
+-- Verify the index is still usable after the abort
+INSERT INTO abort_test2 (body) VALUES ('hello world');
+SELECT id, ROUND((body <@> to_bm25query('hello', 'abort_test2_idx'))::numeric, 4) AS score
+    FROM abort_test2
+    ORDER BY body <@> to_bm25query('hello', 'abort_test2_idx')
+    LIMIT 5;
+
+-- Scenario 3: Abort during CREATE INDEX
+BEGIN;
+CREATE TABLE abort_test3 (id serial PRIMARY KEY, body text);
+INSERT INTO abort_test3 (body) VALUES ('test document');
+CREATE INDEX ON abort_test3
+    USING bm25 (body) WITH (text_config = 'english');
+SELECT 1/0;
+ROLLBACK;
+-- Table and index should not exist after rollback
+SELECT count(*) FROM pg_class WHERE relname = 'abort_test3';
+
+-- Scenario 4: Abort with DDL (DROP TABLE that has a BM25 index)
+CREATE TABLE abort_test4 (id serial PRIMARY KEY, body text);
+CREATE INDEX abort_test4_idx ON abort_test4
+    USING bm25 (body) WITH (text_config = 'english');
+INSERT INTO abort_test4 (body) VALUES ('still here');
+BEGIN;
+DROP TABLE abort_test4;
+SELECT 1/0;
+ROLLBACK;
+-- Table should still exist after the aborted DROP
+SET client_min_messages = warning;
+SELECT count(*) FROM abort_test4;
+RESET client_min_messages;
+
+-- Scenario 5: Multiple errors in sequence
+BEGIN;
+SELECT 1/0;
+SELECT 2/0;
+ROLLBACK;
+
+-- Scenario 6: SAVEPOINT and error within subtransaction
+BEGIN;
+INSERT INTO abort_test2 (body) VALUES ('before savepoint');
+SAVEPOINT sp1;
+SELECT 1/0;
+ROLLBACK TO sp1;
+INSERT INTO abort_test2 (body)
+    VALUES ('after rollback to savepoint');
+COMMIT;
+SELECT id, body FROM abort_test2
+    WHERE body <@> to_bm25query('savepoint', 'abort_test2_idx') < 0
+    ORDER BY body <@> to_bm25query('savepoint', 'abort_test2_idx');
+
+-- Scenario 7: Error in a BM25 query
+BEGIN;
+INSERT INTO abort_test2 (body) VALUES ('scenario seven');
+-- Force an error via division by zero in the same statement
+SELECT (body <@> to_bm25query('scenario', 'abort_test2_idx'))::int / 0
+    FROM abort_test2;
+ROLLBACK;
+
+-- Scenario 8: Abort after BM25 query succeeds, then later stmt fails
+BEGIN;
+SELECT id FROM abort_test2
+    ORDER BY body <@> to_bm25query('hello', 'abort_test2_idx')
+    LIMIT 3;
+SELECT 1/0;
+ROLLBACK;
+
+-- Cleanup
+DROP TABLE abort_test2;
+DROP TABLE abort_test4;
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
Fixes #247.

## Summary

- The `post_parse_analyze_hook` fires on every SQL statement, including `ROLLBACK`. When a transaction is in an aborted state (after an error like `SELECT 1/0`), catalog lookups via `SearchSysCache` are forbidden. This caused an assertion failure on debug builds and a "ResourceOwnerEnlarge called after release started" crash on release builds.
- Guard the hook with `IsTransactionState()` to skip catalog lookups when the transaction is not in a valid state.

## Testing

- New `abort.sql` regression test covering 8 scenarios: basic abort, abort with BM25 index present, abort during CREATE INDEX, abort during DROP TABLE with BM25 index, multiple sequential errors, SAVEPOINT/ROLLBACK TO, error in BM25 query, and abort after successful BM25 query.
