### PR TITLE
Fix memory leak in scan cleanup when scan context is unavailable

### DIFF
--- a/src/am/scan.c
+++ b/src/am/scan.c
@@ -146,7 +146,8 @@ tp_rescan_cleanup_results(TpScanOpaque so)
 		else
 		{
 			elog(WARNING,
-				 "No scan context available for cleanup - memory leak!");
+				 "No scan context available for cleanup - freeing directly");
+			pfree(so->result_ctids);
 			so->result_ctids = NULL;
 		}
 	}
@@ -164,7 +165,8 @@ tp_rescan_cleanup_results(TpScanOpaque so)
 		else
 		{
 			elog(WARNING,
-				 "No scan context available for cleanup - memory leak!");
+				 "No scan context available for cleanup - freeing directly");
+			pfree(so->result_scores);
 			so->result_scores = NULL;
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes a memory leak in `tp_rescan_cleanup_results()` that occurs when `scan_context` is unavailable.

## Problem

In `src/am/scan.c`, the `tp_rescan_cleanup_results()` function has a code path that handles cleanup when `scan_context` is not available. The original code logged a warning about a memory leak but then only set the pointer to NULL without actually freeing the memory:

```c
else
{
    elog(WARNING,
         "No scan context available for cleanup - memory leak!");
    so->result_ctids = NULL;  // Memory leaked!
}
```

This affected both `result_ctids` and `result_scores` allocations.

## Solution

Add `pfree()` calls to properly release the allocated memory:

```c
else
{
    elog(WARNING,
         "No scan context available for cleanup - freeing directly");
    pfree(so->result_ctids);
    so->result_ctids = NULL;
}
```

## Impact

This prevents memory leaks in edge cases where scan context cleanup occurs in unusual scenarios, such as:
- During error handling paths
- Certain rescan patterns
- Edge cases in index scan lifecycle management

The fix is minimal and safe - it only adds the missing `pfree()` calls that should have been there.

## Test plan

- [x] Code compiles without warnings
- [x] No functional changes to existing behavior
- [x] Only adds missing cleanup in error paths

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>