### PR TITLE
fix: remove dead code in scan cleanup

### DIFF
--- a/src/am/scan.c
+++ b/src/am/scan.c
@@ -133,40 +133,24 @@ tp_rescan_cleanup_results(TpScanOpaque so)
 	if (!so)
 		return;
 
+	Assert(so->scan_context != NULL);
+
 	/* Clean up result CTIDs */
 	if (so->result_ctids)
 	{
-		if (so->scan_context)
-		{
-			MemoryContext oldcontext = MemoryContextSwitchTo(so->scan_context);
-			pfree(so->result_ctids);
-			so->result_ctids = NULL;
-			MemoryContextSwitchTo(oldcontext);
-		}
-		else
-		{
-			elog(WARNING,
-				 "No scan context available for cleanup - memory leak!");
-			so->result_ctids = NULL;
-		}
+		MemoryContext oldcontext = MemoryContextSwitchTo(so->scan_context);
+		pfree(so->result_ctids);
+		so->result_ctids = NULL;
+		MemoryContextSwitchTo(oldcontext);
 	}
 
 	/* Clean up result scores */
 	if (so->result_scores)
 	{
-		if (so->scan_context)
-		{
-			MemoryContext oldcontext = MemoryContextSwitchTo(so->scan_context);
-			pfree(so->result_scores);
-			so->result_scores = NULL;
-			MemoryContextSwitchTo(oldcontext);
-		}
-		else
-		{
-			elog(WARNING,
-				 "No scan context available for cleanup - memory leak!");
-			so->result_scores = NULL;
-		}
+		MemoryContext oldcontext = MemoryContextSwitchTo(so->scan_context);
+		pfree(so->result_scores);
+		so->result_scores = NULL;
+		MemoryContextSwitchTo(oldcontext);
 	}
 }
 

--- a/test/expected/rescan.out
+++ b/test/expected/rescan.out
@@ -271,27 +271,29 @@ FROM (
 
 SET pg_textsearch.default_limit = 1000;
 ------------------------------------------------------------------------
--- Test 10: Postgres-level rescan via LATERAL join
+-- Test 10: Postgres-level rescan via correlated LATERAL join
 --
 -- Forces the executor to call the index's rescan function after
--- results have already been returned.  Each outer row triggers a
--- fresh index scan, so the second iteration must clean up the
--- result arrays from the first.
+-- results have already been returned.  The correlation (category =
+-- v.x) prevents Postgres from materializing the subquery, so each
+-- outer row triggers a true index rescan that must clean up the
+-- result arrays from the previous iteration.
 ------------------------------------------------------------------------
-SELECT v.x, t.id
-FROM (VALUES (1), (2)) AS v(x),
+SELECT v.x, t.id, t.category
+FROM (VALUES ('common'), ('rare')) AS v(x),
 LATERAL (
-    SELECT id FROM rescan_test
+    SELECT id, category FROM rescan_test
+    WHERE category = v.x
     ORDER BY content <@> to_bm25query('database', 'rescan_idx')
     LIMIT 2
 ) t
 ORDER BY v.x, t.id;
- x | id 
----+----
- 1 |  1
- 1 |  2
- 2 |  1
- 2 |  2
+   x    | id | category 
+--------+----+----------
+ common |  1 | common
+ common |  2 | common
+ rare   | 31 | rare
+ rare   | 32 | rare
 (4 rows)
 
 ------------------------------------------------------------------------

--- a/test/expected/rescan.out
+++ b/test/expected/rescan.out
@@ -271,6 +271,30 @@ FROM (
 
 SET pg_textsearch.default_limit = 1000;
 ------------------------------------------------------------------------
+-- Test 10: Postgres-level rescan via LATERAL join
+--
+-- Forces the executor to call the index's rescan function after
+-- results have already been returned.  Each outer row triggers a
+-- fresh index scan, so the second iteration must clean up the
+-- result arrays from the first.
+------------------------------------------------------------------------
+SELECT v.x, t.id
+FROM (VALUES (1), (2)) AS v(x),
+LATERAL (
+    SELECT id FROM rescan_test
+    ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+    LIMIT 2
+) t
+ORDER BY v.x, t.id;
+ x | id 
+---+----
+ 1 |  1
+ 1 |  2
+ 2 |  1
+ 2 |  2
+(4 rows)
+
+------------------------------------------------------------------------
 -- Cleanup
 ------------------------------------------------------------------------
 DROP TABLE rescan_test CASCADE;

--- a/test/sql/rescan.sql
+++ b/test/sql/rescan.sql
@@ -246,18 +246,20 @@ FROM (
 SET pg_textsearch.default_limit = 1000;
 
 ------------------------------------------------------------------------
--- Test 10: Postgres-level rescan via LATERAL join
+-- Test 10: Postgres-level rescan via correlated LATERAL join
 --
 -- Forces the executor to call the index's rescan function after
--- results have already been returned.  Each outer row triggers a
--- fresh index scan, so the second iteration must clean up the
--- result arrays from the first.
+-- results have already been returned.  The correlation (category =
+-- v.x) prevents Postgres from materializing the subquery, so each
+-- outer row triggers a true index rescan that must clean up the
+-- result arrays from the previous iteration.
 ------------------------------------------------------------------------
 
-SELECT v.x, t.id
-FROM (VALUES (1), (2)) AS v(x),
+SELECT v.x, t.id, t.category
+FROM (VALUES ('common'), ('rare')) AS v(x),
 LATERAL (
-    SELECT id FROM rescan_test
+    SELECT id, category FROM rescan_test
+    WHERE category = v.x
     ORDER BY content <@> to_bm25query('database', 'rescan_idx')
     LIMIT 2
 ) t

--- a/test/sql/rescan.sql
+++ b/test/sql/rescan.sql
@@ -246,6 +246,24 @@ FROM (
 SET pg_textsearch.default_limit = 1000;
 
 ------------------------------------------------------------------------
+-- Test 10: Postgres-level rescan via LATERAL join
+--
+-- Forces the executor to call the index's rescan function after
+-- results have already been returned.  Each outer row triggers a
+-- fresh index scan, so the second iteration must clean up the
+-- result arrays from the first.
+------------------------------------------------------------------------
+
+SELECT v.x, t.id
+FROM (VALUES (1), (2)) AS v(x),
+LATERAL (
+    SELECT id FROM rescan_test
+    ORDER BY content <@> to_bm25query('database', 'rescan_idx')
+    LIMIT 2
+) t
+ORDER BY v.x, t.id;
+
+------------------------------------------------------------------------
 -- Cleanup
 ------------------------------------------------------------------------
 DROP TABLE rescan_test CASCADE;


### PR DESCRIPTION
## Summary

- Replace unreachable else branch in `tp_rescan_cleanup_results()` with an `Assert`, matching the pattern used elsewhere in scan.c
- `scan_context` is unconditionally created in `tp_beginscan` (line 479), so it's always non-NULL when results exist
- Removes misleading WARNING elog that suggested a memory leak could happen in normal operation

Supersedes #302 — thanks to @hobostay for flagging the code smell.

## Testing

- All 53 regression tests pass