### PR TITLE
bench: concurrent INSERT runner for pg_textsearch vs ParadeDB

### DIFF
--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -1,7 +1,8 @@
 name: Concurrent INSERT Benchmark
 
 permissions:
-  contents: read
+  contents: write
+  deployments: write
 
 env:
   PARADEDB_VERSION: "0.21.6"
@@ -11,6 +12,9 @@ on:
   push:
     branches:
       - benchmark/concurrent-insert-runner
+
+  schedule:
+    - cron: '0 7 * * *'  # Daily at 7 AM UTC (after main benchmarks)
 
   workflow_dispatch:
     inputs:
@@ -36,11 +40,11 @@ on:
         required: false
         default: '60'
         type: string
-      clients:
-        description: 'Client counts (space-separated)'
+      dry_run:
+        description: 'Dry run - skip publishing to GitHub Pages'
         required: false
-        default: '1 2 4 8 16'
-        type: string
+        default: false
+        type: boolean
 
 jobs:
   pg-textsearch:
@@ -60,7 +64,7 @@ jobs:
     - name: Install PostgreSQL
       run: |
         sudo apt-get update
-        sudo apt-get install -y wget ca-certificates build-essential
+        sudo apt-get install -y wget ca-certificates build-essential jq
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
             sudo apt-key add -
         echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | \
@@ -148,6 +152,9 @@ jobs:
 
         cd benchmarks/datasets/msmarco
 
+        # Collect results as JSON for reporting
+        echo '[]' > /tmp/tapir_results.json
+
         printf "%-10s %10s %12s %12s %15s\n" \
             "CLIENTS" "TPS" "AVG_LAT_MS" "ROWS" "CUMULATIVE"
         echo "--------------------------------------------------------------"
@@ -185,13 +192,41 @@ jobs:
           if [ "$failed" != "0" ]; then
             echo "  WARNING: $failed failed transactions at c=$c"
           fi
+
+          # Append to JSON results
+          jq --arg c "$c" --arg tps "$tps" --arg lat "$lat" \
+              '. += [
+                {"name": "pg_textsearch INSERT TPS (c=\($c))",
+                 "unit": "tps",
+                 "value": ($tps | tonumber)},
+                {"name": "pg_textsearch INSERT latency (c=\($c))",
+                 "unit": "ms",
+                 "value": ($lat | tonumber)}
+              ]' /tmp/tapir_results.json > /tmp/tapir_results_tmp.json
+          mv /tmp/tapir_results_tmp.json /tmp/tapir_results.json
         done
+
+        cp /tmp/tapir_results.json "$GITHUB_WORKSPACE/tapir_concurrent_insert.json"
+        echo ""
+        echo "--- Results JSON ---"
+        cat "$GITHUB_WORKSPACE/tapir_concurrent_insert.json"
 
         echo ""
         echo "--- Index State ---"
         psql -c "SELECT * FROM bm25_summarize_index('msmarco_bm25_idx');"
         psql -c "SELECT pg_size_pretty(pg_relation_size('msmarco_bm25_idx')) as index_size,
                         pg_size_pretty(pg_table_size('msmarco_passages')) as table_size;"
+
+    - name: Publish pg_textsearch TPS results
+      if: always() && hashFiles('tapir_concurrent_insert.json') != '' && github.event.inputs.dry_run != 'true'
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: 'Concurrent INSERT (pg_textsearch)'
+        tool: 'customBiggerIsBetter'
+        output-file-path: tapir_concurrent_insert.json
+        auto-push: true
+        gh-pages-branch: gh-pages
+        benchmark-data-dir-path: benchmarks/concurrent-insert/pg_textsearch
 
     - name: Cleanup
       if: always()
@@ -216,7 +251,7 @@ jobs:
     - name: Install PostgreSQL and ParadeDB
       run: |
         sudo apt-get update
-        sudo apt-get install -y wget ca-certificates build-essential
+        sudo apt-get install -y wget ca-certificates build-essential jq
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
             sudo apt-key add -
         echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | \
@@ -301,6 +336,9 @@ jobs:
 
         cd benchmarks/datasets/msmarco
 
+        # Collect results as JSON for reporting
+        echo '[]' > /tmp/paradedb_results.json
+
         printf "%-10s %10s %12s %12s %15s\n" \
             "CLIENTS" "TPS" "AVG_LAT_MS" "ROWS" "CUMULATIVE"
         echo "--------------------------------------------------------------"
@@ -338,7 +376,35 @@ jobs:
           if [ "$failed" != "0" ]; then
             echo "  WARNING: $failed failed transactions at c=$c"
           fi
+
+          # Append to JSON results
+          jq --arg c "$c" --arg tps "$tps" --arg lat "$lat" \
+              '. += [
+                {"name": "ParadeDB INSERT TPS (c=\($c))",
+                 "unit": "tps",
+                 "value": ($tps | tonumber)},
+                {"name": "ParadeDB INSERT latency (c=\($c))",
+                 "unit": "ms",
+                 "value": ($lat | tonumber)}
+              ]' /tmp/paradedb_results.json > /tmp/paradedb_results_tmp.json
+          mv /tmp/paradedb_results_tmp.json /tmp/paradedb_results.json
         done
+
+        cp /tmp/paradedb_results.json "$GITHUB_WORKSPACE/paradedb_concurrent_insert.json"
+        echo ""
+        echo "--- Results JSON ---"
+        cat "$GITHUB_WORKSPACE/paradedb_concurrent_insert.json"
+
+    - name: Publish ParadeDB TPS results
+      if: always() && hashFiles('paradedb_concurrent_insert.json') != '' && github.event.inputs.dry_run != 'true'
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: 'Concurrent INSERT (ParadeDB)'
+        tool: 'customBiggerIsBetter'
+        output-file-path: paradedb_concurrent_insert.json
+        auto-push: true
+        gh-pages-branch: gh-pages
+        benchmark-data-dir-path: benchmarks/concurrent-insert/paradedb
 
     - name: Cleanup
       if: always()

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -17,11 +17,11 @@ on:
       runner:
         description: 'GitHub Actions runner label'
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-latest-8-cores-TJ'
         type: choice
         options:
-          - ubuntu-latest
-          - ubuntu-latest
+          - ubuntu-latest-8-cores-TJ
+          - ubuntu-latest-8-cores-TJ
       msmarco_size:
         description: 'MS MARCO subset size (must exceed duration * max_tps * num_levels)'
         required: false
@@ -45,7 +45,7 @@ on:
 jobs:
   pg-textsearch:
     name: "pg_textsearch concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
     timeout-minutes: 120
 
     steps:
@@ -137,7 +137,7 @@ jobs:
         echo "=============================================="
         echo " pg_textsearch Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
         echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"
@@ -201,7 +201,7 @@ jobs:
 
   paradedb:
     name: "ParadeDB concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
     timeout-minutes: 120
 
     steps:
@@ -290,7 +290,7 @@ jobs:
         echo "=============================================="
         echo " ParadeDB Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
         echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -17,11 +17,11 @@ on:
       runner:
         description: 'GitHub Actions runner label'
         required: false
-        default: 'ubuntu-latest-8-cores-TJ'
+        default: 'ubuntu-latest'
         type: choice
         options:
           - ubuntu-latest
-          - ubuntu-latest-8-cores-TJ
+          - ubuntu-latest
       msmarco_size:
         description: 'MS MARCO subset size'
         required: false
@@ -46,7 +46,7 @@ on:
 jobs:
   pg-textsearch:
     name: "pg_textsearch concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 120
 
     steps:
@@ -126,7 +126,7 @@ jobs:
         echo "=============================================="
         echo " pg_textsearch Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
         echo "vCPUs:    $(nproc)"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"
@@ -180,7 +180,7 @@ jobs:
 
   paradedb:
     name: "ParadeDB concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 120
 
     steps:
@@ -257,7 +257,7 @@ jobs:
         echo "=============================================="
         echo " ParadeDB Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
         echo "vCPUs:    $(nproc)"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -21,11 +21,11 @@ on:
       runner:
         description: 'GitHub Actions runner label'
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-latest-8-cores-TJ'
         type: choice
         options:
-          - ubuntu-latest
-          - ubuntu-latest
+          - ubuntu-latest-8-cores-TJ
+          - ubuntu-latest-8-cores-TJ
       msmarco_size:
         description: 'MS MARCO subset size (must exceed duration * max_tps * num_levels)'
         required: false
@@ -49,7 +49,7 @@ on:
 jobs:
   pg-textsearch:
     name: "pg_textsearch concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
     timeout-minutes: 120
 
     steps:
@@ -141,7 +141,7 @@ jobs:
         echo "=============================================="
         echo " pg_textsearch Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
         echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"
@@ -237,7 +237,7 @@ jobs:
 
   paradedb:
     name: "ParadeDB concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
     timeout-minutes: 120
 
     steps:
@@ -326,7 +326,7 @@ jobs:
         echo "=============================================="
         echo " ParadeDB Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
         echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -163,7 +163,7 @@ jobs:
           # Check remaining rows before each level
           remaining=$(psql -qtAc \
               "SELECT count(*) FROM msmarco_staging s
-               WHERE s.staging_id > currval('insert_seq');" \
+               WHERE s.staging_id > (SELECT last_value FROM insert_seq);" \
               2>/dev/null || echo "$STAGING_ROWS")
           if [ "$remaining" -lt 1000 ]; then
             echo "STOPPING: only $remaining rows remaining in staging"
@@ -189,7 +189,7 @@ jobs:
           printf "%-10s %10s %12s %12s %15s\n" \
               "$c" "$tps" "$lat" "$txns" "$cumulative"
 
-          if [ "$failed" != "0" ]; then
+          if [ "${failed:-0}" != "0" ]; then
             echo "  WARNING: $failed failed transactions at c=$c"
           fi
 
@@ -348,7 +348,7 @@ jobs:
           # Check remaining rows before each level
           remaining=$(psql -qtAc \
               "SELECT count(*) FROM msmarco_paradedb_staging s
-               WHERE s.staging_id > currval('insert_seq');" \
+               WHERE s.staging_id > (SELECT last_value FROM insert_seq);" \
               2>/dev/null || echo "$STAGING_ROWS")
           if [ "$remaining" -lt 1000 ]; then
             echo "STOPPING: only $remaining rows remaining in staging"
@@ -374,7 +374,7 @@ jobs:
           printf "%-10s %10s %12s %12s %15s\n" \
               "$c" "$tps" "$lat" "$txns" "$cumulative"
 
-          if [ "$failed" != "0" ]; then
+          if [ "${failed:-0}" != "0" ]; then
             echo "  WARNING: $failed failed transactions at c=$c"
           fi
 

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         cd benchmarks/datasets/msmarco
         chmod +x download.sh
-        ./download.sh ${{ inputs.msmarco_size || '1M' }}
+        ./download.sh ${{ inputs.msmarco_size || 'full' }}
 
     - name: Run concurrent insert setup
       run: |

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -17,11 +17,11 @@ on:
       runner:
         description: 'GitHub Actions runner label'
         required: false
-        default: 'ubuntu-latest-8-cores-TJ'
+        default: 'ubuntu-latest'
         type: choice
         options:
-          - ubuntu-latest-8-cores-TJ
-          - ubuntu-latest-8-cores-TJ
+          - ubuntu-latest
+          - ubuntu-latest
       msmarco_size:
         description: 'MS MARCO subset size (must exceed duration * max_tps * num_levels)'
         required: false
@@ -45,7 +45,7 @@ on:
 jobs:
   pg-textsearch:
     name: "pg_textsearch concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 120
 
     steps:
@@ -137,7 +137,7 @@ jobs:
         echo "=============================================="
         echo " pg_textsearch Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
         echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"
@@ -201,7 +201,7 @@ jobs:
 
   paradedb:
     name: "ParadeDB concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 120
 
     steps:
@@ -290,7 +290,7 @@ jobs:
         echo "=============================================="
         echo " ParadeDB Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
         echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -7,16 +7,21 @@ env:
   PARADEDB_VERSION: "0.21.6"
 
 on:
+  # TODO: remove push trigger before merging
+  push:
+    branches:
+      - benchmark/concurrent-insert-runner
+
   workflow_dispatch:
     inputs:
       runner:
         description: 'GitHub Actions runner label'
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-latest-8-cores-TJ'
         type: choice
         options:
           - ubuntu-latest
-          - ubuntu-latest-8-cores
+          - ubuntu-latest-8-cores-TJ
       msmarco_size:
         description: 'MS MARCO subset size'
         required: false
@@ -41,7 +46,7 @@ on:
 jobs:
   pg-textsearch:
     name: "pg_textsearch concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
     timeout-minutes: 120
 
     steps:
@@ -121,7 +126,7 @@ jobs:
         echo "=============================================="
         echo " pg_textsearch Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
         echo "vCPUs:    $(nproc)"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"
@@ -175,7 +180,7 @@ jobs:
 
   paradedb:
     name: "ParadeDB concurrent INSERT"
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}
     timeout-minutes: 120
 
     steps:
@@ -252,7 +257,7 @@ jobs:
         echo "=============================================="
         echo " ParadeDB Concurrent INSERT Benchmark"
         echo "=============================================="
-        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest-8-cores-TJ' }}"
         echo "vCPUs:    $(nproc)"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
         echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -225,6 +225,7 @@ jobs:
         tool: 'customBiggerIsBetter'
         output-file-path: tapir_concurrent_insert.json
         auto-push: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         gh-pages-branch: gh-pages
         benchmark-data-dir-path: benchmarks/concurrent-insert/pg_textsearch
 
@@ -403,6 +404,7 @@ jobs:
         tool: 'customBiggerIsBetter'
         output-file-path: paradedb_concurrent_insert.json
         auto-push: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         gh-pages-branch: gh-pages
         benchmark-data-dir-path: benchmarks/concurrent-insert/paradedb
 

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -1,0 +1,299 @@
+name: Concurrent INSERT Benchmark
+
+permissions:
+  contents: read
+
+env:
+  PARADEDB_VERSION: "0.21.6"
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'GitHub Actions runner label'
+        required: false
+        default: 'ubuntu-latest'
+        type: choice
+        options:
+          - ubuntu-latest
+          - ubuntu-latest-8-cores
+      msmarco_size:
+        description: 'MS MARCO subset size'
+        required: false
+        default: '1M'
+        type: choice
+        options:
+          - '100K'
+          - '500K'
+          - '1M'
+          - 'full'
+      duration:
+        description: 'Seconds per concurrency level'
+        required: false
+        default: '60'
+        type: string
+      clients:
+        description: 'Client counts (space-separated)'
+        required: false
+        default: '1 2 4 8 16'
+        type: string
+
+jobs:
+  pg-textsearch:
+    name: "pg_textsearch concurrent INSERT"
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    timeout-minutes: 120
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL /usr/share/swift
+        df -h /
+
+    - name: Install PostgreSQL
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wget ca-certificates build-essential
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+            sudo apt-key add -
+        echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | \
+            sudo tee /etc/apt/sources.list.d/pgdg.list
+        sudo apt-get update
+        sudo apt-get install -y postgresql-17 postgresql-server-dev-17
+
+    - name: Build and install pg_textsearch
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        make clean && make -j$(nproc)
+        sudo make install
+
+    - name: Configure and start PostgreSQL
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        rm -rf tmp_bench
+        mkdir -p tmp_bench/socket
+        initdb -D tmp_bench/data --auth-local=trust --auth-host=trust
+
+        NCPUS=$(nproc)
+        cat >> tmp_bench/data/postgresql.conf << EOF
+        unix_socket_directories = '$PWD/tmp_bench/socket'
+        shared_buffers = 1GB
+        effective_cache_size = 4GB
+        maintenance_work_mem = 512MB
+        work_mem = 64MB
+        max_connections = 100
+        checkpoint_completion_target = 0.9
+        wal_buffers = 16MB
+        max_parallel_maintenance_workers = $NCPUS
+        shared_preload_libraries = 'pg_textsearch'
+        EOF
+
+        pg_ctl start -D tmp_bench/data -l tmp_bench/postgres.log -w
+        export PGHOST="$PWD/tmp_bench/socket"
+        createdb bench_test
+        psql -d bench_test -c "CREATE EXTENSION pg_textsearch"
+        echo "PGHOST=$PWD/tmp_bench/socket" >> $GITHUB_ENV
+
+    - name: Download MS MARCO dataset
+      run: |
+        cd benchmarks/datasets/msmarco
+        chmod +x download.sh
+        ./download.sh ${{ inputs.msmarco_size || '1M' }}
+
+    - name: Run concurrent insert setup
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        export PGDATABASE=bench_test
+        export DATA_DIR="$PWD/benchmarks/datasets/msmarco/data"
+        cd benchmarks/datasets/msmarco
+        psql -f insert/concurrent-setup.sql
+
+    - name: Run concurrent insert benchmark
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        export PGDATABASE=bench_test
+        DURATION="${{ inputs.duration || '60' }}"
+        CLIENTS="${{ inputs.clients || '1 2 4 8 16' }}"
+
+        echo "=============================================="
+        echo " pg_textsearch Concurrent INSERT Benchmark"
+        echo "=============================================="
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "vCPUs:    $(nproc)"
+        echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
+        echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"
+        echo "Duration: ${DURATION}s per level"
+        echo "Clients:  $CLIENTS"
+        echo "Date:     $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+        echo ""
+
+        cd benchmarks/datasets/msmarco
+
+        printf "%-10s %10s %12s %12s %15s\n" \
+            "CLIENTS" "TPS" "AVG_LAT_MS" "ROWS" "CUMULATIVE"
+        echo "--------------------------------------------------------------"
+
+        for c in $CLIENTS; do
+          output=$(pgbench -n -c "$c" -j "$c" -T "$DURATION" \
+              -f insert/pgbench-insert.sql 2>&1)
+
+          tps=$(echo "$output" | grep "^tps" | \
+              grep -oE '[0-9]+\.[0-9]+' | head -1)
+          lat=$(echo "$output" | grep "latency average" | \
+              grep -oE '[0-9]+\.[0-9]+')
+          txns=$(echo "$output" | \
+              grep "number of transactions actually processed" | \
+              grep -oE '[0-9]+' | head -1)
+          failed=$(echo "$output" | \
+              grep "number of failed transactions" | \
+              grep -oE '[0-9]+' | head -1)
+          cumulative=$(psql -qtAc \
+              "SELECT count(*) FROM msmarco_passages;")
+
+          printf "%-10s %10s %12s %12s %15s\n" \
+              "$c" "$tps" "$lat" "$txns" "$cumulative"
+
+          if [ "$failed" != "0" ]; then
+            echo "  WARNING: $failed failed transactions at c=$c"
+          fi
+        done
+
+        echo ""
+        echo "--- Index State ---"
+        psql -c "SELECT * FROM bm25_summarize_index('msmarco_bm25_idx');"
+        psql -c "SELECT pg_size_pretty(pg_relation_size('msmarco_bm25_idx')) as index_size,
+                        pg_size_pretty(pg_table_size('msmarco_passages')) as table_size;"
+
+    - name: Cleanup
+      if: always()
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        pg_ctl stop -D tmp_bench/data || true
+
+  paradedb:
+    name: "ParadeDB concurrent INSERT"
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    timeout-minutes: 120
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL /usr/share/swift
+        df -h /
+
+    - name: Install PostgreSQL and ParadeDB
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wget ca-certificates build-essential
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+            sudo apt-key add -
+        echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | \
+            sudo tee /etc/apt/sources.list.d/pgdg.list
+        sudo apt-get update
+        sudo apt-get install -y postgresql-17 postgresql-server-dev-17
+
+        # Install ParadeDB
+        wget -q "https://github.com/paradedb/paradedb/releases/download/v${PARADEDB_VERSION}/postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
+        sudo dpkg -i "postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
+
+    - name: Configure and start PostgreSQL
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        rm -rf tmp_bench
+        mkdir -p tmp_bench/socket
+        initdb -D tmp_bench/data --auth-local=trust --auth-host=trust
+
+        NCPUS=$(nproc)
+        cat >> tmp_bench/data/postgresql.conf << EOF
+        unix_socket_directories = '$PWD/tmp_bench/socket'
+        shared_buffers = 1GB
+        effective_cache_size = 4GB
+        maintenance_work_mem = 512MB
+        work_mem = 64MB
+        max_connections = 100
+        checkpoint_completion_target = 0.9
+        wal_buffers = 16MB
+        max_parallel_maintenance_workers = $NCPUS
+        EOF
+
+        pg_ctl start -D tmp_bench/data -l tmp_bench/postgres.log -w
+        export PGHOST="$PWD/tmp_bench/socket"
+        createdb bench_test
+        psql -d bench_test -c "CREATE EXTENSION pg_search"
+        echo "PGHOST=$PWD/tmp_bench/socket" >> $GITHUB_ENV
+
+    - name: Download MS MARCO dataset
+      run: |
+        cd benchmarks/datasets/msmarco
+        chmod +x download.sh
+        ./download.sh ${{ inputs.msmarco_size || '1M' }}
+
+    - name: Run concurrent insert setup
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        export PGDATABASE=bench_test
+        export DATA_DIR="$PWD/benchmarks/datasets/msmarco/data"
+        cd benchmarks/datasets/msmarco
+        psql -f paradedb/concurrent-setup.sql
+
+    - name: Run concurrent insert benchmark
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        export PGDATABASE=bench_test
+        DURATION="${{ inputs.duration || '60' }}"
+        CLIENTS="${{ inputs.clients || '1 2 4 8 16' }}"
+
+        echo "=============================================="
+        echo " ParadeDB Concurrent INSERT Benchmark"
+        echo "=============================================="
+        echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
+        echo "vCPUs:    $(nproc)"
+        echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
+        echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"
+        echo "Duration: ${DURATION}s per level"
+        echo "Clients:  $CLIENTS"
+        echo "Date:     $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+        echo ""
+
+        cd benchmarks/datasets/msmarco
+
+        printf "%-10s %10s %12s %12s %15s\n" \
+            "CLIENTS" "TPS" "AVG_LAT_MS" "ROWS" "CUMULATIVE"
+        echo "--------------------------------------------------------------"
+
+        for c in $CLIENTS; do
+          output=$(pgbench -n -c "$c" -j "$c" -T "$DURATION" \
+              -f paradedb/pgbench-insert.sql 2>&1)
+
+          tps=$(echo "$output" | grep "^tps" | \
+              grep -oE '[0-9]+\.[0-9]+' | head -1)
+          lat=$(echo "$output" | grep "latency average" | \
+              grep -oE '[0-9]+\.[0-9]+')
+          txns=$(echo "$output" | \
+              grep "number of transactions actually processed" | \
+              grep -oE '[0-9]+' | head -1)
+          failed=$(echo "$output" | \
+              grep "number of failed transactions" | \
+              grep -oE '[0-9]+' | head -1)
+          cumulative=$(psql -qtAc \
+              "SELECT count(*) FROM msmarco_passages_paradedb;")
+
+          printf "%-10s %10s %12s %12s %15s\n" \
+              "$c" "$tps" "$lat" "$txns" "$cumulative"
+
+          if [ "$failed" != "0" ]; then
+            echo "  WARNING: $failed failed transactions at c=$c"
+          fi
+        done
+
+    - name: Cleanup
+      if: always()
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        pg_ctl stop -D tmp_bench/data || true

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -23,12 +23,11 @@ on:
           - ubuntu-latest
           - ubuntu-latest
       msmarco_size:
-        description: 'MS MARCO subset size'
+        description: 'MS MARCO subset size (must exceed duration * max_tps * num_levels)'
         required: false
-        default: '1M'
+        default: 'full'
         type: choice
         options:
-          - '100K'
           - '500K'
           - '1M'
           - 'full'
@@ -121,15 +120,27 @@ jobs:
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
         DURATION="${{ inputs.duration || '60' }}"
-        CLIENTS="${{ inputs.clients || '1 2 4 8 16' }}"
+
+        # Cap client counts to available vCPUs
+        NCPUS=$(nproc)
+        CLIENTS=""
+        for c in 1 2 4 8 16 32; do
+          if [ "$c" -le "$NCPUS" ]; then
+            CLIENTS="$CLIENTS $c"
+          fi
+        done
+        CLIENTS="${CLIENTS# }"
+
+        STAGING_ROWS=$(psql -qtAc \
+            "SELECT count(*) FROM msmarco_staging;")
 
         echo "=============================================="
         echo " pg_textsearch Concurrent INSERT Benchmark"
         echo "=============================================="
         echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
-        echo "vCPUs:    $(nproc)"
+        echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
-        echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"
+        echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"
         echo "Duration: ${DURATION}s per level"
         echo "Clients:  $CLIENTS"
         echo "Date:     $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
@@ -142,6 +153,16 @@ jobs:
         echo "--------------------------------------------------------------"
 
         for c in $CLIENTS; do
+          # Check remaining rows before each level
+          remaining=$(psql -qtAc \
+              "SELECT count(*) FROM msmarco_staging s
+               WHERE s.staging_id > currval('insert_seq');" \
+              2>/dev/null || echo "$STAGING_ROWS")
+          if [ "$remaining" -lt 1000 ]; then
+            echo "STOPPING: only $remaining rows remaining in staging"
+            break
+          fi
+
           output=$(pgbench -n -c "$c" -j "$c" -T "$DURATION" \
               -f insert/pgbench-insert.sql 2>&1)
 
@@ -237,7 +258,7 @@ jobs:
       run: |
         cd benchmarks/datasets/msmarco
         chmod +x download.sh
-        ./download.sh ${{ inputs.msmarco_size || '1M' }}
+        ./download.sh ${{ inputs.msmarco_size || 'full' }}
 
     - name: Run concurrent insert setup
       run: |
@@ -252,15 +273,27 @@ jobs:
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
         DURATION="${{ inputs.duration || '60' }}"
-        CLIENTS="${{ inputs.clients || '1 2 4 8 16' }}"
+
+        # Cap client counts to available vCPUs
+        NCPUS=$(nproc)
+        CLIENTS=""
+        for c in 1 2 4 8 16 32; do
+          if [ "$c" -le "$NCPUS" ]; then
+            CLIENTS="$CLIENTS $c"
+          fi
+        done
+        CLIENTS="${CLIENTS# }"
+
+        STAGING_ROWS=$(psql -qtAc \
+            "SELECT count(*) FROM msmarco_paradedb_staging;")
 
         echo "=============================================="
         echo " ParadeDB Concurrent INSERT Benchmark"
         echo "=============================================="
         echo "Runner:   ${{ inputs.runner || 'ubuntu-latest' }}"
-        echo "vCPUs:    $(nproc)"
+        echo "vCPUs:    $NCPUS"
         echo "RAM:      $(free -h | awk '/Mem:/{print $2}')"
-        echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || '1M' }}"
+        echo "Dataset:  MS MARCO ${{ inputs.msmarco_size || 'full' }} ($STAGING_ROWS rows)"
         echo "Duration: ${DURATION}s per level"
         echo "Clients:  $CLIENTS"
         echo "Date:     $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
@@ -273,6 +306,16 @@ jobs:
         echo "--------------------------------------------------------------"
 
         for c in $CLIENTS; do
+          # Check remaining rows before each level
+          remaining=$(psql -qtAc \
+              "SELECT count(*) FROM msmarco_paradedb_staging s
+               WHERE s.staging_id > currval('insert_seq');" \
+              2>/dev/null || echo "$STAGING_ROWS")
+          if [ "$remaining" -lt 1000 ]; then
+            echo "STOPPING: only $remaining rows remaining in staging"
+            break
+          fi
+
           output=$(pgbench -n -c "$c" -j "$c" -T "$DURATION" \
               -f paradedb/pgbench-insert.sql 2>&1)
 

--- a/benchmarks/datasets/msmarco/insert/run_concurrent_insert.sh
+++ b/benchmarks/datasets/msmarco/insert/run_concurrent_insert.sh
@@ -69,12 +69,14 @@ case "$ENGINE" in
         SETUP_SQL="$SCRIPT_DIR/concurrent-setup.sql"
         PGBENCH_SQL="$SCRIPT_DIR/pgbench-insert.sql"
         COUNT_TABLE="msmarco_passages"
+        STAGING_TABLE="msmarco_staging"
         ;;
     paradedb|pg_search)
         ENGINE_LABEL="ParadeDB"
         SETUP_SQL="$MSMARCO_DIR/paradedb/concurrent-setup.sql"
         PGBENCH_SQL="$MSMARCO_DIR/paradedb/pgbench-insert.sql"
         COUNT_TABLE="msmarco_passages_paradedb"
+        STAGING_TABLE="msmarco_paradedb_staging"
         ;;
     *)
         echo "Unknown engine: $ENGINE" >&2
@@ -108,15 +110,11 @@ echo "--- Results ---"
 printf "%-10s %10s %12s %12s %15s\n" \
     "CLIENTS" "TPS" "AVG_LAT_MS" "ROWS_60S" "CUMULATIVE"
 
-STAGING_TABLE="${COUNT_TABLE/passages/staging}"
-[[ "$STAGING_TABLE" == "$COUNT_TABLE" ]] && \
-    STAGING_TABLE="${COUNT_TABLE}_staging"
-
 for c in $CLIENTS; do
     # Check remaining rows before each level
     remaining=$(psql -qtAc \
         "SELECT count(*) FROM $STAGING_TABLE s
-         WHERE s.staging_id > currval('insert_seq');" \
+         WHERE s.staging_id > (SELECT last_value FROM insert_seq);" \
         2>/dev/null || echo "999999")
     if [[ "$remaining" -lt 1000 ]]; then
         echo "STOPPING: only $remaining rows remaining in staging"

--- a/benchmarks/datasets/msmarco/insert/run_concurrent_insert.sh
+++ b/benchmarks/datasets/msmarco/insert/run_concurrent_insert.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Concurrent INSERT benchmark for MS MARCO dataset.
+#
+# Runs pgbench at multiple concurrency levels (1, 2, 4, 8, 16 clients)
+# for a configurable duration per level. Reports TPS and latency.
+#
+# The script does NOT reset between concurrency levels — the index
+# accumulates data across runs, which is more realistic (the memtable
+# grows, spills happen, segments compact under load).
+#
+# Prerequisites:
+#   - Postgres running with the target extension installed
+#   - msmarco staging data loaded via concurrent-setup.sql (or the
+#     ParadeDB equivalent in paradedb/concurrent-setup.sql)
+#
+# Usage:
+#   # pg_textsearch (default):
+#   ./run_concurrent_insert.sh
+#
+#   # ParadeDB:
+#   ./run_concurrent_insert.sh --engine paradedb
+#
+#   # Custom port/duration:
+#   PGPORT=5434 DURATION=30 ./run_concurrent_insert.sh
+#
+# Environment variables:
+#   PGPORT      Postgres port (default: 5434)
+#   PGDATABASE  Database name (default: postgres)
+#   DURATION    Seconds per concurrency level (default: 60)
+#   CLIENTS     Space-separated client counts (default: "1 2 4 8 16")
+#   SKIP_SETUP  Set to 1 to skip setup phase (reuse existing staging)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MSMARCO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATA_DIR="${DATA_DIR:-$MSMARCO_DIR/data}"
+
+PGPORT="${PGPORT:-5434}"
+PGDATABASE="${PGDATABASE:-postgres}"
+DURATION="${DURATION:-60}"
+CLIENTS="${CLIENTS:-1 2 4 8 16}"
+SKIP_SETUP="${SKIP_SETUP:-0}"
+ENGINE="${1:-tapir}"
+
+# Strip leading -- from engine flag
+ENGINE="${ENGINE#--engine=}"
+ENGINE="${ENGINE#--engine }"
+if [[ "$ENGINE" == "--engine" ]]; then
+    ENGINE="${2:-tapir}"
+fi
+
+# Resolve paths based on engine
+case "$ENGINE" in
+    tapir|pg_textsearch)
+        ENGINE_LABEL="pg_textsearch"
+        SETUP_SQL="$SCRIPT_DIR/concurrent-setup.sql"
+        PGBENCH_SQL="$SCRIPT_DIR/pgbench-insert.sql"
+        COUNT_TABLE="msmarco_passages"
+        ;;
+    paradedb|pg_search)
+        ENGINE_LABEL="ParadeDB"
+        SETUP_SQL="$MSMARCO_DIR/paradedb/concurrent-setup.sql"
+        PGBENCH_SQL="$MSMARCO_DIR/paradedb/pgbench-insert.sql"
+        COUNT_TABLE="msmarco_passages_paradedb"
+        ;;
+    *)
+        echo "Unknown engine: $ENGINE" >&2
+        echo "Usage: $0 [--engine tapir|paradedb]" >&2
+        exit 1
+        ;;
+esac
+
+export PGPORT PGDATABASE
+
+echo "=============================================="
+echo " Concurrent INSERT Benchmark: $ENGINE_LABEL"
+echo "=============================================="
+echo "Port:     $PGPORT"
+echo "Database: $PGDATABASE"
+echo "Duration: ${DURATION}s per level"
+echo "Clients:  $CLIENTS"
+echo "Date:     $(date '+%Y-%m-%d %H:%M:%S')"
+echo ""
+
+# --- Setup phase ---
+if [[ "$SKIP_SETUP" != "1" ]]; then
+    echo "--- Setup: loading staging data ---"
+    (cd "$MSMARCO_DIR" && DATA_DIR="$DATA_DIR" \
+        psql -f "$SETUP_SQL" 2>&1) | tail -5
+    echo ""
+fi
+
+# --- Benchmark runs ---
+echo "--- Results ---"
+printf "%-10s %10s %12s %12s %15s\n" \
+    "CLIENTS" "TPS" "AVG_LAT_MS" "ROWS_60S" "CUMULATIVE"
+
+for c in $CLIENTS; do
+    output=$(pgbench -n -c "$c" -j "$c" -T "$DURATION" \
+        -f "$PGBENCH_SQL" 2>&1)
+
+    tps=$(echo "$output" | grep "^tps" | \
+        grep -oE '[0-9]+\.[0-9]+' | head -1)
+    lat=$(echo "$output" | grep "latency average" | \
+        grep -oE '[0-9]+\.[0-9]+')
+    txns=$(echo "$output" | \
+        grep "number of transactions actually processed" | \
+        grep -oE '[0-9]+' | head -1)
+    cumulative=$(psql -qtAc \
+        "SELECT count(*) FROM $COUNT_TABLE;")
+
+    printf "%-10s %10s %12s %12s %15s\n" \
+        "$c" "$tps" "$lat" "$txns" "$cumulative"
+done
+
+echo ""
+echo "--- Done ---"

--- a/benchmarks/datasets/msmarco/insert/run_concurrent_insert.sh
+++ b/benchmarks/datasets/msmarco/insert/run_concurrent_insert.sh
@@ -40,8 +40,19 @@ DATA_DIR="${DATA_DIR:-$MSMARCO_DIR/data}"
 PGPORT="${PGPORT:-5434}"
 PGDATABASE="${PGDATABASE:-postgres}"
 DURATION="${DURATION:-60}"
-CLIENTS="${CLIENTS:-1 2 4 8 16}"
 SKIP_SETUP="${SKIP_SETUP:-0}"
+
+# Default client counts: powers of 2 up to available CPUs
+NCPUS=$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
+if [[ -z "${CLIENTS:-}" ]]; then
+    CLIENTS=""
+    for c in 1 2 4 8 16 32; do
+        if [[ "$c" -le "$NCPUS" ]]; then
+            CLIENTS="$CLIENTS $c"
+        fi
+    done
+    CLIENTS="${CLIENTS# }"
+fi
 ENGINE="${1:-tapir}"
 
 # Strip leading -- from engine flag
@@ -97,7 +108,21 @@ echo "--- Results ---"
 printf "%-10s %10s %12s %12s %15s\n" \
     "CLIENTS" "TPS" "AVG_LAT_MS" "ROWS_60S" "CUMULATIVE"
 
+STAGING_TABLE="${COUNT_TABLE/passages/staging}"
+[[ "$STAGING_TABLE" == "$COUNT_TABLE" ]] && \
+    STAGING_TABLE="${COUNT_TABLE}_staging"
+
 for c in $CLIENTS; do
+    # Check remaining rows before each level
+    remaining=$(psql -qtAc \
+        "SELECT count(*) FROM $STAGING_TABLE s
+         WHERE s.staging_id > currval('insert_seq');" \
+        2>/dev/null || echo "999999")
+    if [[ "$remaining" -lt 1000 ]]; then
+        echo "STOPPING: only $remaining rows remaining in staging"
+        break
+    fi
+
     output=$(pgbench -n -c "$c" -j "$c" -T "$DURATION" \
         -f "$PGBENCH_SQL" 2>&1)
 

--- a/benchmarks/gh-pages/index.html
+++ b/benchmarks/gh-pages/index.html
@@ -68,7 +68,9 @@
         <br>
         <a href="comparison.html">ParadeDB Comparison</a> |
         <a href="methodology.html">Methodology</a> |
-        <a href="profiles/">CPU Profiles</a>
+        <a href="profiles/">CPU Profiles</a> |
+        <a href="concurrent-insert/pg_textsearch/">Concurrent INSERT (pg_textsearch)</a> |
+        <a href="concurrent-insert/paradedb/">Concurrent INSERT (ParadeDB)</a>
     </p>
     <div id="charts"></div>
 


### PR DESCRIPTION
## Summary

- Adds `benchmarks/datasets/msmarco/insert/run_concurrent_insert.sh`, a pgbench-based runner that measures concurrent INSERT throughput at multiple client levels (powers of 2 up to available vCPUs)
- Supports both pg_textsearch and ParadeDB via `--engine` flag
- Configurable via `PGPORT`, `DURATION`, `CLIENTS`, `SKIP_SETUP` env vars
- Builds on existing `concurrent-setup.sql` and `pgbench-insert.sql` infrastructure
- Adds CI workflow (`benchmark-concurrent-insert.yml`) with nightly schedule and gh-pages reporting
- Auto-caps client counts to available vCPUs, checks for data exhaustion between levels

Baseline results (MSMARCO 8.8M passages, ubuntu-latest-8-cores-TJ, 8 vCPUs, 31 GB RAM):

| Clients | pg_textsearch TPS | ParadeDB TPS | Ratio |
|---------|-------------------|--------------|-------|
| 1       | 2,546             | 3,029        | 0.84x |
| 2       | 4,314             | 5,857        | 0.74x |
| 4       | 4,196             | 9,752        | 0.43x |
| 8       | 4,254             | 14,802       | 0.29x |

pg_textsearch plateaus at ~4.3K TPS regardless of concurrency; ParadeDB scales nearly linearly. Bottleneck is likely shared-memory memtable lock contention.

## Testing

Ran on CI with `ubuntu-latest-8-cores-TJ` (8 vCPUs). Results published to gh-pages.