### PR TITLE
feat: native TEXT[] support for BM25 indexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ OBJS = \
 	src/segment/compression.o \
 	src/query/bmw.o \
 	src/query/score.o \
+	src/types/array.o \
 	src/types/vector.o \
 	src/types/query.o \
 	src/state/state.o \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ PG_CPPFLAGS += -Wno-unknown-warning-option -Wno-clobbered -Wno-packed-not-aligne
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = abort aerodocs basic binary_io bmw bulk_load catalog_stats compression concurrent_build coverage deletion vacuum vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index force_merge implicit index inheritance limits lock manyterms max_shared_memory memory merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table unsupported updates vector unlogged_index wand text_config
+REGRESS = abort aerodocs basic binary_io bmw bulk_load catalog_stats compression concurrent_build coverage deletion vacuum vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index force_merge implicit index inheritance limits lock manyterms max_shared_memory memory merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table text_array text_config unsupported updates vector unlogged_index wand
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/sql/pg_textsearch--1.0.0-dev.sql
+++ b/sql/pg_textsearch--1.0.0-dev.sql
@@ -186,6 +186,43 @@ DEFAULT FOR TYPE text USING bm25 AS
     OPERATOR    1   @extschema@.<@> (text, @extschema@.bm25query) FOR ORDER BY float_ops,
     FUNCTION    8   (text, @extschema@.bm25query)   @extschema@.bm25_text_bm25query_score(text, @extschema@.bm25query);
 
+-- BM25 scoring function for text[] <@> bm25query operations
+-- Flattens array elements with spaces, then scores as a single document.
+CREATE FUNCTION @extschema@.bm25_textarray_bm25query_score(
+    left_arr text[], right_query @extschema@.bm25query)
+RETURNS float8
+AS 'MODULE_PATHNAME', 'bm25_textarray_bm25query_score'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE COST 1000;
+
+-- Error stub for text[] <@> text (planner should rewrite to bm25query)
+CREATE FUNCTION @extschema@.bm25_textarray_text_score(text[], text)
+RETURNS float8
+AS 'MODULE_PATHNAME', 'bm25_textarray_text_score'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE COST 1000;
+
+-- <@> operator for text[] <@> bm25query operations
+CREATE OPERATOR @extschema@.<@> (
+    LEFTARG = text[],
+    RIGHTARG = @extschema@.bm25query,
+    PROCEDURE = @extschema@.bm25_textarray_bm25query_score
+);
+
+-- <@> operator for text[] <@> text operations (implicit index resolution)
+CREATE OPERATOR @extschema@.<@> (
+    LEFTARG = text[],
+    RIGHTARG = text,
+    PROCEDURE = @extschema@.bm25_textarray_text_score
+);
+
+-- bm25 operator class for text[] columns
+CREATE OPERATOR CLASS @extschema@.text_array_bm25_ops
+DEFAULT FOR TYPE text[] USING bm25 AS
+    OPERATOR    1   @extschema@.<@> (text[], @extschema@.bm25query)
+                    FOR ORDER BY float_ops,
+    FUNCTION    8   (text[], @extschema@.bm25query)
+                    @extschema@.bm25_textarray_bm25query_score(
+                        text[], @extschema@.bm25query);
+
 -- Debug function to dump index contents (memtable and segments)
 CREATE FUNCTION @extschema@.bm25_dump_index(text) RETURNS text
     AS 'MODULE_PATHNAME', 'tp_dump_index'

--- a/src/am/am.h
+++ b/src/am/am.h
@@ -121,6 +121,9 @@ bool tp_process_document_text(
 		Relation		   index_rel,
 		int32			  *doc_length_out);
 
+/* Flatten a text array into a space-separated text value */
+text *tp_flatten_text_array(Datum array_datum);
+
 /* Extract terms and frequencies from a TSVector */
 int tp_extract_terms_from_tsvector(
 		TSVector tsvector,

--- a/src/am/am.h
+++ b/src/am/am.h
@@ -121,9 +121,6 @@ bool tp_process_document_text(
 		Relation		   index_rel,
 		int32			  *doc_length_out);
 
-/* Flatten a text array into a space-separated text value */
-text *tp_flatten_text_array(Datum array_datum);
-
 /* Extract terms and frequencies from a TSVector */
 int tp_extract_terms_from_tsvector(
 		TSVector tsvector,

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -803,28 +803,117 @@ tp_process_document_text(
 }
 
 /*
- * Set up a table scan for serial index build.
- * Returns the snapshot (PG18+ only) for later unregistration
+ * Callback state for table_index_build_scan during serial builds.
  */
-static Snapshot
-tp_setup_table_scan(
-		Relation heap, TableScanDesc *scan_out, TupleTableSlot **slot_out)
+typedef struct TpBuildCallbackState
 {
-	Snapshot snapshot = NULL;
+	TpBuildContext *build_ctx;
+	Relation		index;
+	Oid				text_config_oid;
+	MemoryContext	per_doc_ctx;
+	bool			is_text_array;
+	uint64			total_docs;
+	uint64			total_len;
+	uint64			tuples_done;
+} TpBuildCallbackState;
 
-#if PG_VERSION_NUM >= 180000
-	/* PG18: Must register the snapshot for index builds */
-	snapshot = GetTransactionSnapshot();
-	if (snapshot)
-		snapshot = RegisterSnapshot(snapshot);
-	*scan_out = table_beginscan(heap, snapshot, 0, NULL);
-#else
-	*scan_out = table_beginscan(heap, GetTransactionSnapshot(), 0, NULL);
-#endif
+/*
+ * Per-tuple callback for table_index_build_scan.
+ *
+ * Receives pre-evaluated index expression values from the scan,
+ * tokenizes the document text, and adds it to the build context.
+ */
+static void
+tp_build_callback(
+		Relation	index,
+		ItemPointer ctid,
+		Datum	   *values,
+		bool	   *isnull,
+		bool		tupleIsAlive,
+		void	   *state)
+{
+	TpBuildCallbackState *bs = (TpBuildCallbackState *)state;
+	text				 *document_text;
+	Datum				  tsvector_datum;
+	TSVector			  tsvector;
+	char				**terms;
+	int32				 *frequencies;
+	int					  term_count;
+	int					  doc_length;
+	MemoryContext		  oldctx;
 
-	*slot_out = table_slot_create(heap, NULL);
+	/* Suppress unused parameter warnings for callback signature */
+	(void)index;
+	(void)tupleIsAlive;
 
-	return snapshot;
+	if (isnull[0])
+		return;
+
+	if (!ItemPointerIsValid(ctid))
+		return;
+
+	/*
+	 * Tokenize in temporary context to prevent
+	 * to_tsvector_byid memory from accumulating.
+	 * Detoasting also happens here so the copy is freed
+	 * by MemoryContextReset below.
+	 */
+	oldctx = MemoryContextSwitchTo(bs->per_doc_ctx);
+
+	if (bs->is_text_array)
+		document_text = tp_flatten_text_array(values[0]);
+	else
+		document_text = DatumGetTextPP(values[0]);
+
+	tsvector_datum = DirectFunctionCall2Coll(
+			to_tsvector_byid,
+			InvalidOid,
+			ObjectIdGetDatum(bs->text_config_oid),
+			PointerGetDatum(document_text));
+	tsvector = DatumGetTSVector(tsvector_datum);
+
+	doc_length = tp_extract_terms_from_tsvector(
+			tsvector, &terms, &frequencies, &term_count);
+
+	MemoryContextSwitchTo(oldctx);
+
+	if (term_count > 0)
+	{
+		tp_build_context_add_document(
+				bs->build_ctx,
+				terms,
+				frequencies,
+				term_count,
+				doc_length,
+				ctid);
+	}
+
+	/* Reset per-doc context (frees tsvector, terms) */
+	MemoryContextReset(bs->per_doc_ctx);
+
+	/* Budget-based flush */
+	if (tp_build_context_should_flush(bs->build_ctx))
+	{
+		bs->total_docs += bs->build_ctx->num_docs;
+		bs->total_len += bs->build_ctx->total_len;
+
+		tp_build_flush_and_link(bs->build_ctx, bs->index);
+		tp_build_context_reset(bs->build_ctx);
+
+		pgstat_progress_update_param(
+				PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_COMPACTING);
+		tp_maybe_compact_level(bs->index, 0);
+		pgstat_progress_update_param(
+				PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_LOADING);
+	}
+
+	bs->tuples_done++;
+	if (bs->tuples_done % TP_PROGRESS_REPORT_INTERVAL == 0)
+	{
+		pgstat_progress_update_param(
+				PROGRESS_CREATEIDX_TUPLES_DONE, bs->tuples_done);
+		CHECK_FOR_INTERRUPTS();
+	}
 }
 
 /*
@@ -837,9 +926,6 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 	char			  *text_config_name = NULL;
 	Oid				   text_config_oid	= InvalidOid;
 	double			   k1, b;
-	TableScanDesc	   scan;
-	TupleTableSlot	  *slot;
-	Snapshot		   snapshot	  = NULL;
 	uint64			   total_docs = 0;
 	uint64			   total_len  = 0;
 	TpLocalIndexState *index_state;
@@ -861,13 +947,20 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 	/*
 	 * Determine if the indexed column is a text array type.
 	 * If so, we flatten array elements into a single text value
-	 * before tokenization. This check runs once before the scan.
+	 * before tokenization. Expression indexes (attnum == 0)
+	 * are never text arrays.
 	 */
 	{
 		AttrNumber attnum = indexInfo->ii_IndexAttrNumbers[0];
-		Oid		   atttype =
-				TupleDescAttr(RelationGetDescr(heap), attnum - 1)->atttypid;
-		is_text_array = tp_is_text_array_type(atttype);
+
+		if (attnum > 0)
+		{
+			Oid atttype = TupleDescAttr(RelationGetDescr(heap), attnum - 1)
+								  ->atttypid;
+			is_text_array = tp_is_text_array_type(atttype);
+		}
+		else
+			is_text_array = false;
 	}
 
 	/* Report initialization phase */
@@ -1066,11 +1159,10 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 	 * maintenance_work_mem controls the per-batch memory budget.
 	 */
 	{
-		TpBuildContext *build_ctx;
-		MemoryContext	build_tmpctx;
-		MemoryContext	oldctx;
-		Size			budget;
-		uint64			tuples_done = 0;
+		TpBuildCallbackState bs;
+		TpBuildContext		*build_ctx;
+		Size				 budget;
+		double				 reltuples;
 
 		/*
 		 * Still create build index state for:
@@ -1085,15 +1177,18 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 		budget	  = (Size)maintenance_work_mem * 1024L;
 		build_ctx = tp_build_context_create(budget);
 
-		/*
-		 * Per-document memory context for tokenization temporaries.
-		 * Reset after each document to prevent unbounded growth
-		 * from to_tsvector_byid allocations.
-		 */
-		build_tmpctx = AllocSetContextCreate(
+		/* Initialize callback state */
+		bs.build_ctx	   = build_ctx;
+		bs.index		   = index;
+		bs.text_config_oid = text_config_oid;
+		bs.is_text_array   = is_text_array;
+		bs.per_doc_ctx	   = AllocSetContextCreate(
 				CurrentMemoryContext,
 				"build per-doc temp",
 				ALLOCSET_DEFAULT_SIZES);
+		bs.total_docs  = 0;
+		bs.total_len   = 0;
+		bs.tuples_done = 0;
 
 		/* Report loading phase */
 		pgstat_progress_update_param(
@@ -1107,111 +1202,23 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 					PROGRESS_CREATEIDX_TUPLES_TOTAL, tuples_est);
 		}
 
-		/* Prepare to scan table */
-		snapshot = tp_setup_table_scan(heap, &scan, &slot);
-		(void)snapshot; /* used only on PG18+ for UnregisterSnapshot */
-
-		/* Process each document */
-		while (table_scan_getnextslot(scan, ForwardScanDirection, slot))
-		{
-			bool		isnull;
-			Datum		text_datum;
-			text	   *document_text;
-			ItemPointer ctid;
-			Datum		tsvector_datum;
-			TSVector	tsvector;
-			char	  **terms;
-			int32	   *frequencies;
-			int			term_count;
-			int			doc_length;
-
-			text_datum = slot_getattr(
-					slot, indexInfo->ii_IndexAttrNumbers[0], &isnull);
-			if (isnull)
-				continue;
-
-			slot_getallattrs(slot);
-			ctid = &slot->tts_tid;
-
-			if (!ItemPointerIsValid(ctid))
-				continue;
-
-			/*
-			 * Switch to temporary context before text extraction
-			 * so flatten allocations are freed per-document.
-			 */
-			oldctx = MemoryContextSwitchTo(build_tmpctx);
-
-			if (is_text_array)
-				document_text = tp_flatten_text_array(text_datum);
-			else
-				document_text = DatumGetTextPP(text_datum);
-
-			tsvector_datum = DirectFunctionCall2Coll(
-					to_tsvector_byid,
-					InvalidOid,
-					ObjectIdGetDatum(text_config_oid),
-					PointerGetDatum(document_text));
-			tsvector = DatumGetTSVector(tsvector_datum);
-
-			doc_length = tp_extract_terms_from_tsvector(
-					tsvector, &terms, &frequencies, &term_count);
-
-			MemoryContextSwitchTo(oldctx);
-
-			if (term_count > 0)
-			{
-				tp_build_context_add_document(
-						build_ctx,
-						terms,
-						frequencies,
-						term_count,
-						doc_length,
-						ctid);
-			}
-
-			/* Reset per-doc context (frees tsvector, terms) */
-			MemoryContextReset(build_tmpctx);
-
-			/* Budget-based flush */
-			if (tp_build_context_should_flush(build_ctx))
-			{
-				total_docs += build_ctx->num_docs;
-				total_len += build_ctx->total_len;
-
-				tp_build_flush_and_link(build_ctx, index);
-				tp_build_context_reset(build_ctx);
-
-				pgstat_progress_update_param(
-						PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_COMPACTING);
-				tp_maybe_compact_level(index, 0);
-				pgstat_progress_update_param(
-						PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_LOADING);
-			}
-
-			tuples_done++;
-			if (tuples_done % TP_PROGRESS_REPORT_INTERVAL == 0)
-			{
-				pgstat_progress_update_param(
-						PROGRESS_CREATEIDX_TUPLES_DONE, tuples_done);
-				CHECK_FOR_INTERRUPTS();
-			}
-		}
+		/* Scan table with expression evaluation */
+		reltuples = table_index_build_scan(
+				heap,
+				index,
+				indexInfo,
+				true,
+				false,
+				tp_build_callback,
+				&bs,
+				NULL);
 
 		/* Accumulate final batch stats */
-		total_docs += build_ctx->num_docs;
-		total_len += build_ctx->total_len;
+		total_docs = bs.total_docs + build_ctx->num_docs;
+		total_len  = bs.total_len + build_ctx->total_len;
 
 		pgstat_progress_update_param(
-				PROGRESS_CREATEIDX_TUPLES_DONE, tuples_done);
-
-		ExecDropSingleTupleTableSlot(slot);
-		table_endscan(scan);
-
-#if PG_VERSION_NUM >= 180000
-		if (snapshot)
-			UnregisterSnapshot(snapshot);
-#endif
+				PROGRESS_CREATEIDX_TUPLES_DONE, bs.tuples_done);
 
 		/* Report writing phase */
 		pgstat_progress_update_param(
@@ -1248,7 +1255,7 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 
 		/* Create index build result */
 		result = (IndexBuildResult *)palloc(sizeof(IndexBuildResult));
-		result->heap_tuples	 = total_docs;
+		result->heap_tuples	 = reltuples;
 		result->index_tuples = total_docs;
 
 		if (build_progress.active)
@@ -1283,7 +1290,7 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 
 		/* Cleanup */
 		tp_build_context_destroy(build_ctx);
-		MemoryContextDelete(build_tmpctx);
+		MemoryContextDelete(bs.per_doc_ctx);
 	}
 
 	return result;

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -9,6 +9,7 @@
 #include <access/generic_xlog.h>
 #include <access/tableam.h>
 #include <catalog/namespace.h>
+#include <catalog/pg_type.h>
 #include <catalog/storage.h>
 #include <commands/progress.h>
 #include <executor/spi.h>
@@ -20,6 +21,7 @@
 #include <storage/bufmgr.h>
 #include <tsearch/ts_type.h>
 #include <utils/acl.h>
+#include <utils/array.h>
 #include <utils/backend_progress.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
@@ -643,6 +645,58 @@ tp_build_init_metapage(
 }
 
 /*
+ * Is this type OID a text-like array (text[], varchar[], bpchar[])?
+ */
+static inline bool
+is_text_array_type(Oid typid)
+{
+	return typid == TEXTARRAYOID || typid == 1015 || /* varchar[] */
+		   typid == 1014;							 /* bpchar[] */
+}
+
+/*
+ * Flatten a text array into a single space-separated text value.
+ * NULL elements are skipped. Returns empty text for empty arrays.
+ * Works for text[], varchar[], and bpchar[] (same binary format).
+ */
+text *
+tp_flatten_text_array(Datum array_datum)
+{
+	ArrayType	  *arr;
+	Datum		  *elems;
+	bool		  *nulls;
+	int			   nelems;
+	StringInfoData buf;
+
+	arr = DatumGetArrayTypeP(array_datum);
+	deconstruct_array(
+			arr, TEXTOID, -1, false, TYPALIGN_INT, &elems, &nulls, &nelems);
+
+	initStringInfo(&buf);
+
+	for (int i = 0; i < nelems; i++)
+	{
+		text *elem;
+		int	  len;
+
+		if (nulls[i])
+			continue;
+
+		elem = DatumGetTextPP(elems[i]);
+		len	 = VARSIZE_ANY_EXHDR(elem);
+
+		if (len == 0)
+			continue;
+
+		if (buf.len > 0)
+			appendStringInfoChar(&buf, ' ');
+		appendBinaryStringInfo(&buf, VARDATA_ANY(elem), len);
+	}
+
+	return cstring_to_text_with_len(buf.data, buf.len);
+}
+
+/*
  * Extract terms and frequencies from a TSVector
  * Returns the document length (sum of all term frequencies)
  */
@@ -802,113 +856,28 @@ tp_process_document_text(
 }
 
 /*
- * Callback state for table_index_build_scan during serial builds.
+ * Set up a table scan for serial index build.
+ * Returns the snapshot (PG18+ only) for later unregistration
  */
-typedef struct TpBuildCallbackState
+static Snapshot
+tp_setup_table_scan(
+		Relation heap, TableScanDesc *scan_out, TupleTableSlot **slot_out)
 {
-	TpBuildContext *build_ctx;
-	Relation		index;
-	Oid				text_config_oid;
-	MemoryContext	per_doc_ctx;
-	uint64			total_docs;
-	uint64			total_len;
-	uint64			tuples_done;
-} TpBuildCallbackState;
+	Snapshot snapshot = NULL;
 
-/*
- * Per-tuple callback for table_index_build_scan.
- *
- * Receives pre-evaluated index expression values from the scan,
- * tokenizes the document text, and adds it to the build context.
- */
-static void
-tp_build_callback(
-		Relation	index,
-		ItemPointer ctid,
-		Datum	   *values,
-		bool	   *isnull,
-		bool		tupleIsAlive,
-		void	   *state)
-{
-	TpBuildCallbackState *bs = (TpBuildCallbackState *)state;
-	text				 *document_text;
-	Datum				  tsvector_datum;
-	TSVector			  tsvector;
-	char				**terms;
-	int32				 *frequencies;
-	int					  term_count;
-	int					  doc_length;
-	MemoryContext		  oldctx;
+#if PG_VERSION_NUM >= 180000
+	/* PG18: Must register the snapshot for index builds */
+	snapshot = GetTransactionSnapshot();
+	if (snapshot)
+		snapshot = RegisterSnapshot(snapshot);
+	*scan_out = table_beginscan(heap, snapshot, 0, NULL, 0);
+#else
+	*scan_out = table_beginscan(heap, GetTransactionSnapshot(), 0, NULL);
+#endif
 
-	/* Suppress unused parameter warnings for callback signature */
-	(void)index;
-	(void)tupleIsAlive;
+	*slot_out = table_slot_create(heap, NULL);
 
-	if (isnull[0])
-		return;
-
-	if (!ItemPointerIsValid(ctid))
-		return;
-
-	/*
-	 * Tokenize in temporary context to prevent
-	 * to_tsvector_byid memory from accumulating.
-	 * Detoasting also happens here so the copy is freed
-	 * by MemoryContextReset below.
-	 */
-	oldctx = MemoryContextSwitchTo(bs->per_doc_ctx);
-
-	document_text = DatumGetTextPP(values[0]);
-
-	tsvector_datum = DirectFunctionCall2Coll(
-			to_tsvector_byid,
-			InvalidOid,
-			ObjectIdGetDatum(bs->text_config_oid),
-			PointerGetDatum(document_text));
-	tsvector = DatumGetTSVector(tsvector_datum);
-
-	doc_length = tp_extract_terms_from_tsvector(
-			tsvector, &terms, &frequencies, &term_count);
-
-	MemoryContextSwitchTo(oldctx);
-
-	if (term_count > 0)
-	{
-		tp_build_context_add_document(
-				bs->build_ctx,
-				terms,
-				frequencies,
-				term_count,
-				doc_length,
-				ctid);
-	}
-
-	/* Reset per-doc context (frees tsvector, terms) */
-	MemoryContextReset(bs->per_doc_ctx);
-
-	/* Budget-based flush */
-	if (tp_build_context_should_flush(bs->build_ctx))
-	{
-		bs->total_docs += bs->build_ctx->num_docs;
-		bs->total_len += bs->build_ctx->total_len;
-
-		tp_build_flush_and_link(bs->build_ctx, bs->index);
-		tp_build_context_reset(bs->build_ctx);
-
-		pgstat_progress_update_param(
-				PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_COMPACTING);
-		tp_maybe_compact_level(bs->index, 0);
-		pgstat_progress_update_param(
-				PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_LOADING);
-	}
-
-	bs->tuples_done++;
-	if (bs->tuples_done % TP_PROGRESS_REPORT_INTERVAL == 0)
-	{
-		pgstat_progress_update_param(
-				PROGRESS_CREATEIDX_TUPLES_DONE, bs->tuples_done);
-		CHECK_FOR_INTERRUPTS();
-	}
+	return snapshot;
 }
 
 /*
@@ -921,9 +890,13 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 	char			  *text_config_name = NULL;
 	Oid				   text_config_oid	= InvalidOid;
 	double			   k1, b;
+	TableScanDesc	   scan;
+	TupleTableSlot	  *slot;
+	Snapshot		   snapshot	  = NULL;
 	uint64			   total_docs = 0;
 	uint64			   total_len  = 0;
 	TpLocalIndexState *index_state;
+	bool			   is_text_array;
 
 	/* Show "started" for first partition only (suppresses duplicates) */
 	if (!build_progress.active || build_progress.partition_count == 0)
@@ -937,6 +910,18 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 	 * with different block layout than the old one.
 	 */
 	tp_invalidate_docid_cache();
+
+	/*
+	 * Determine if the indexed column is a text array type.
+	 * If so, we flatten array elements into a single text value
+	 * before tokenization. This check runs once before the scan.
+	 */
+	{
+		AttrNumber attnum = indexInfo->ii_IndexAttrNumbers[0];
+		Oid		   atttype =
+				TupleDescAttr(RelationGetDescr(heap), attnum - 1)->atttypid;
+		is_text_array = is_text_array_type(atttype);
+	}
 
 	/* Report initialization phase */
 	pgstat_progress_update_param(
@@ -1127,10 +1112,11 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 	 * maintenance_work_mem controls the per-batch memory budget.
 	 */
 	{
-		TpBuildCallbackState bs;
-		TpBuildContext		*build_ctx;
-		Size				 budget;
-		double				 reltuples;
+		TpBuildContext *build_ctx;
+		MemoryContext	build_tmpctx;
+		MemoryContext	oldctx;
+		Size			budget;
+		uint64			tuples_done = 0;
 
 		/*
 		 * Still create build index state for:
@@ -1145,17 +1131,15 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 		budget	  = (Size)maintenance_work_mem * 1024L;
 		build_ctx = tp_build_context_create(budget);
 
-		/* Initialize callback state */
-		bs.build_ctx	   = build_ctx;
-		bs.index		   = index;
-		bs.text_config_oid = text_config_oid;
-		bs.per_doc_ctx	   = AllocSetContextCreate(
+		/*
+		 * Per-document memory context for tokenization temporaries.
+		 * Reset after each document to prevent unbounded growth
+		 * from to_tsvector_byid allocations.
+		 */
+		build_tmpctx = AllocSetContextCreate(
 				CurrentMemoryContext,
 				"build per-doc temp",
 				ALLOCSET_DEFAULT_SIZES);
-		bs.total_docs  = 0;
-		bs.total_len   = 0;
-		bs.tuples_done = 0;
 
 		/* Report loading phase */
 		pgstat_progress_update_param(
@@ -1169,22 +1153,110 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 					PROGRESS_CREATEIDX_TUPLES_TOTAL, tuples_est);
 		}
 
-		/* Scan table with expression evaluation */
-		reltuples = table_index_build_scan(
-				heap,
-				index,
-				indexInfo,
-				true,
-				false,
-				tp_build_callback,
-				&bs,
-				NULL);
+		/* Prepare to scan table */
+		snapshot = tp_setup_table_scan(heap, &scan, &slot);
+		(void)snapshot; /* used only on PG18+ for UnregisterSnapshot */
+
+		/* Process each document */
+		while (table_scan_getnextslot(scan, ForwardScanDirection, slot))
+		{
+			bool		isnull;
+			Datum		text_datum;
+			text	   *document_text;
+			ItemPointer ctid;
+			Datum		tsvector_datum;
+			TSVector	tsvector;
+			char	  **terms;
+			int32	   *frequencies;
+			int			term_count;
+			int			doc_length;
+
+			text_datum = slot_getattr(
+					slot, indexInfo->ii_IndexAttrNumbers[0], &isnull);
+			if (isnull)
+				continue;
+
+			if (is_text_array)
+				document_text = tp_flatten_text_array(text_datum);
+			else
+				document_text = DatumGetTextPP(text_datum);
+			slot_getallattrs(slot);
+			ctid = &slot->tts_tid;
+
+			if (!ItemPointerIsValid(ctid))
+				continue;
+
+			/*
+			 * Tokenize in temporary context to prevent
+			 * to_tsvector_byid memory from accumulating.
+			 */
+			oldctx = MemoryContextSwitchTo(build_tmpctx);
+
+			tsvector_datum = DirectFunctionCall2Coll(
+					to_tsvector_byid,
+					InvalidOid,
+					ObjectIdGetDatum(text_config_oid),
+					PointerGetDatum(document_text));
+			tsvector = DatumGetTSVector(tsvector_datum);
+
+			doc_length = tp_extract_terms_from_tsvector(
+					tsvector, &terms, &frequencies, &term_count);
+
+			MemoryContextSwitchTo(oldctx);
+
+			if (term_count > 0)
+			{
+				tp_build_context_add_document(
+						build_ctx,
+						terms,
+						frequencies,
+						term_count,
+						doc_length,
+						ctid);
+			}
+
+			/* Reset per-doc context (frees tsvector, terms) */
+			MemoryContextReset(build_tmpctx);
+
+			/* Budget-based flush */
+			if (tp_build_context_should_flush(build_ctx))
+			{
+				total_docs += build_ctx->num_docs;
+				total_len += build_ctx->total_len;
+
+				tp_build_flush_and_link(build_ctx, index);
+				tp_build_context_reset(build_ctx);
+
+				pgstat_progress_update_param(
+						PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_COMPACTING);
+				tp_maybe_compact_level(index, 0);
+				pgstat_progress_update_param(
+						PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_LOADING);
+			}
+
+			tuples_done++;
+			if (tuples_done % TP_PROGRESS_REPORT_INTERVAL == 0)
+			{
+				pgstat_progress_update_param(
+						PROGRESS_CREATEIDX_TUPLES_DONE, tuples_done);
+				CHECK_FOR_INTERRUPTS();
+			}
+		}
+
 		/* Accumulate final batch stats */
-		total_docs = bs.total_docs + build_ctx->num_docs;
-		total_len  = bs.total_len + build_ctx->total_len;
+		total_docs += build_ctx->num_docs;
+		total_len += build_ctx->total_len;
 
 		pgstat_progress_update_param(
-				PROGRESS_CREATEIDX_TUPLES_DONE, bs.tuples_done);
+				PROGRESS_CREATEIDX_TUPLES_DONE, tuples_done);
+
+		ExecDropSingleTupleTableSlot(slot);
+		table_endscan(scan);
+
+#if PG_VERSION_NUM >= 180000
+		if (snapshot)
+			UnregisterSnapshot(snapshot);
+#endif
 
 		/* Report writing phase */
 		pgstat_progress_update_param(
@@ -1221,7 +1293,7 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 
 		/* Create index build result */
 		result = (IndexBuildResult *)palloc(sizeof(IndexBuildResult));
-		result->heap_tuples	 = reltuples;
+		result->heap_tuples	 = total_docs;
 		result->index_tuples = total_docs;
 
 		if (build_progress.active)
@@ -1256,7 +1328,7 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 
 		/* Cleanup */
 		tp_build_context_destroy(build_ctx);
-		MemoryContextDelete(bs.per_doc_ctx);
+		MemoryContextDelete(build_tmpctx);
 	}
 
 	return result;

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -817,7 +817,7 @@ tp_setup_table_scan(
 	snapshot = GetTransactionSnapshot();
 	if (snapshot)
 		snapshot = RegisterSnapshot(snapshot);
-	*scan_out = table_beginscan(heap, snapshot, 0, NULL, 0);
+	*scan_out = table_beginscan(heap, snapshot, 0, NULL);
 #else
 	*scan_out = table_beginscan(heap, GetTransactionSnapshot(), 0, NULL);
 #endif

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -9,7 +9,6 @@
 #include <access/generic_xlog.h>
 #include <access/tableam.h>
 #include <catalog/namespace.h>
-#include <catalog/pg_type.h>
 #include <catalog/storage.h>
 #include <commands/progress.h>
 #include <executor/spi.h>
@@ -21,7 +20,6 @@
 #include <storage/bufmgr.h>
 #include <tsearch/ts_type.h>
 #include <utils/acl.h>
-#include <utils/array.h>
 #include <utils/backend_progress.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
@@ -40,6 +38,7 @@
 #include "state/metapage.h"
 #include "state/registry.h"
 #include "state/state.h"
+#include "types/array.h"
 #include "types/vector.h"
 
 /*
@@ -645,58 +644,6 @@ tp_build_init_metapage(
 }
 
 /*
- * Is this type OID a text-like array (text[], varchar[], bpchar[])?
- */
-static inline bool
-is_text_array_type(Oid typid)
-{
-	return typid == TEXTARRAYOID || typid == 1015 || /* varchar[] */
-		   typid == 1014;							 /* bpchar[] */
-}
-
-/*
- * Flatten a text array into a single space-separated text value.
- * NULL elements are skipped. Returns empty text for empty arrays.
- * Works for text[], varchar[], and bpchar[] (same binary format).
- */
-text *
-tp_flatten_text_array(Datum array_datum)
-{
-	ArrayType	  *arr;
-	Datum		  *elems;
-	bool		  *nulls;
-	int			   nelems;
-	StringInfoData buf;
-
-	arr = DatumGetArrayTypeP(array_datum);
-	deconstruct_array(
-			arr, TEXTOID, -1, false, TYPALIGN_INT, &elems, &nulls, &nelems);
-
-	initStringInfo(&buf);
-
-	for (int i = 0; i < nelems; i++)
-	{
-		text *elem;
-		int	  len;
-
-		if (nulls[i])
-			continue;
-
-		elem = DatumGetTextPP(elems[i]);
-		len	 = VARSIZE_ANY_EXHDR(elem);
-
-		if (len == 0)
-			continue;
-
-		if (buf.len > 0)
-			appendStringInfoChar(&buf, ' ');
-		appendBinaryStringInfo(&buf, VARDATA_ANY(elem), len);
-	}
-
-	return cstring_to_text_with_len(buf.data, buf.len);
-}
-
-/*
  * Extract terms and frequencies from a TSVector
  * Returns the document length (sum of all term frequencies)
  */
@@ -920,7 +867,7 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 		AttrNumber attnum = indexInfo->ii_IndexAttrNumbers[0];
 		Oid		   atttype =
 				TupleDescAttr(RelationGetDescr(heap), attnum - 1)->atttypid;
-		is_text_array = is_text_array_type(atttype);
+		is_text_array = tp_is_text_array_type(atttype);
 	}
 
 	/* Report initialization phase */
@@ -1183,10 +1130,6 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 			if (isnull)
 				continue;
 
-			if (is_text_array)
-				document_text = tp_flatten_text_array(text_datum);
-			else
-				document_text = DatumGetTextPP(text_datum);
 			slot_getallattrs(slot);
 			ctid = &slot->tts_tid;
 
@@ -1194,10 +1137,15 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 				continue;
 
 			/*
-			 * Tokenize in temporary context to prevent
-			 * to_tsvector_byid memory from accumulating.
+			 * Switch to temporary context before text extraction
+			 * so flatten allocations are freed per-document.
 			 */
 			oldctx = MemoryContextSwitchTo(build_tmpctx);
+
+			if (is_text_array)
+				document_text = tp_flatten_text_array(text_datum);
+			else
+				document_text = DatumGetTextPP(text_datum);
 
 			tsvector_datum = DirectFunctionCall2Coll(
 					to_tsvector_byid,
@@ -1461,7 +1409,7 @@ tp_insert(
 		Oid		   atttype =
 				TupleDescAttr(RelationGetDescr(heapRel), attnum - 1)->atttypid;
 
-		if (is_text_array_type(atttype))
+		if (tp_is_text_array_type(atttype))
 			document_text = tp_flatten_text_array(values[0]);
 		else
 			document_text = DatumGetTextPP(values[0]);

--- a/src/am/build.c
+++ b/src/am/build.c
@@ -1061,7 +1061,14 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 			}
 
 			par_result = tp_build_parallel(
-					heap, index, indexInfo, text_config_oid, k1, b, nworkers);
+					heap,
+					index,
+					indexInfo,
+					text_config_oid,
+					k1,
+					b,
+					is_text_array,
+					nworkers);
 
 			/* Accumulate stats for build progress */
 			if (build_progress.active)
@@ -1441,17 +1448,24 @@ tp_insert(
 	TpLocalIndexState *index_state;
 	char			 **terms = NULL;
 
-	(void)heapRel;		  /* unused */
 	(void)checkUnique;	  /* unused */
 	(void)indexUnchanged; /* unused */
-	(void)indexInfo;	  /* unused */
 
 	/* Skip NULL documents */
 	if (isnull[0])
 		return true;
 
 	/* --- Phase 1: Tokenize (no lock held) --- */
-	document_text = DatumGetTextPP(values[0]);
+	{
+		AttrNumber attnum = indexInfo->ii_IndexAttrNumbers[0];
+		Oid		   atttype =
+				TupleDescAttr(RelationGetDescr(heapRel), attnum - 1)->atttypid;
+
+		if (is_text_array_type(atttype))
+			document_text = tp_flatten_text_array(values[0]);
+		else
+			document_text = DatumGetTextPP(values[0]);
+	}
 	{
 		char *index_name;
 		char *schema_name;

--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -21,6 +21,7 @@
 #include <access/tableam.h>
 #include <access/xact.h>
 #include <catalog/index.h>
+#include <catalog/pg_type.h>
 #include <commands/progress.h>
 #include <executor/executor.h>
 #include <miscadmin.h>
@@ -29,6 +30,7 @@
 #include <storage/bufmgr.h>
 #include <storage/condition_variable.h>
 #include <tsearch/ts_type.h>
+#include <utils/array.h>
 #include <utils/backend_progress.h>
 #include <utils/builtins.h>
 #include <utils/memutils.h>
@@ -128,6 +130,7 @@ tp_init_parallel_shared(
 		Oid					   text_config_oid,
 		double				   k1,
 		double				   b,
+		bool				   is_text_array,
 		int					   nworkers)
 {
 	TpParallelWorkerResult *results;
@@ -141,6 +144,7 @@ tp_init_parallel_shared(
 	shared->text_config_oid = text_config_oid;
 	shared->k1				= k1;
 	shared->b				= b;
+	shared->is_text_array	= is_text_array;
 	shared->nworkers		= nworkers;
 
 	/* Coordination */
@@ -307,7 +311,10 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 		/* Tokenize in temporary context (includes detoasting) */
 		oldctx = MemoryContextSwitchTo(build_tmpctx);
 
-		document_text = DatumGetTextPP(idx_values[0]);
+		if (shared->is_text_array)
+			document_text = tp_flatten_text_array(idx_values[0]);
+		else
+			document_text = DatumGetTextPP(idx_values[0]);
 
 		tsvector_datum = DirectFunctionCall2Coll(
 				to_tsvector_byid,
@@ -471,6 +478,7 @@ tp_build_parallel(
 		Oid		   text_config_oid,
 		double	   k1,
 		double	   b,
+		bool	   is_text_array,
 		int		   nworkers)
 {
 	IndexBuildResult	  *result;
@@ -526,7 +534,14 @@ tp_build_parallel(
 	/* Allocate and initialize shared state */
 	shared = (TpParallelBuildShared *)shm_toc_allocate(pcxt->toc, shmem_size);
 	tp_init_parallel_shared(
-			shared, heap, index, text_config_oid, k1, b, nworkers);
+			shared,
+			heap,
+			index,
+			text_config_oid,
+			k1,
+			b,
+			is_text_array,
+			nworkers);
 
 	/* Initialize SharedFileSet for worker temp files */
 	SharedFileSetInit(&shared->fileset, pcxt->seg);

--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -245,7 +245,11 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 
 			ItemPointerSet(&min_tid, start_blk, FirstOffsetNumber);
 			ItemPointerSet(&max_tid, end_blk - 1, MaxOffsetNumber);
+#if PG_VERSION_NUM >= 180000
+			scan = table_beginscan_tidrange(heap, snap, &min_tid, &max_tid, 0);
+#else
 			scan = table_beginscan_tidrange(heap, snap, &min_tid, &max_tid);
+#endif
 		}
 		else
 		{

--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -248,11 +248,7 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 
 			ItemPointerSet(&min_tid, start_blk, FirstOffsetNumber);
 			ItemPointerSet(&max_tid, end_blk - 1, MaxOffsetNumber);
-#if PG_VERSION_NUM >= 180000
-			scan = table_beginscan_tidrange(heap, snap, &min_tid, &max_tid, 0);
-#else
 			scan = table_beginscan_tidrange(heap, snap, &min_tid, &max_tid);
-#endif
 		}
 		else
 		{

--- a/src/am/build_parallel.c
+++ b/src/am/build_parallel.c
@@ -21,7 +21,6 @@
 #include <access/tableam.h>
 #include <access/xact.h>
 #include <catalog/index.h>
-#include <catalog/pg_type.h>
 #include <commands/progress.h>
 #include <executor/executor.h>
 #include <miscadmin.h>
@@ -30,7 +29,6 @@
 #include <storage/bufmgr.h>
 #include <storage/condition_variable.h>
 #include <tsearch/ts_type.h>
-#include <utils/array.h>
 #include <utils/backend_progress.h>
 #include <utils/builtins.h>
 #include <utils/memutils.h>
@@ -47,6 +45,7 @@
 #include "segment/segment.h"
 #include "segment/segment_io.h"
 #include "state/metapage.h"
+#include "types/array.h"
 
 /* ----------------------------------------------------------------
  * Worker-local segment tracking
@@ -308,7 +307,10 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 		if (!ItemPointerIsValid(ctid))
 			goto next_tuple;
 
-		/* Tokenize in temporary context (includes detoasting) */
+		/*
+		 * Switch to temporary context before text extraction
+		 * so flatten allocations are freed per-document.
+		 */
 		oldctx = MemoryContextSwitchTo(build_tmpctx);
 
 		if (shared->is_text_array)

--- a/src/am/build_parallel.h
+++ b/src/am/build_parallel.h
@@ -68,6 +68,7 @@ typedef struct TpParallelBuildShared
 	Oid	   text_config_oid;	  /* Text search config OID */
 	double k1;				  /* BM25 k1 parameter */
 	double b;				  /* BM25 b parameter */
+	bool   is_text_array;	  /* Indexed column is text[] */
 	int32  nworkers;		  /* Workers requested */
 	int32  nworkers_launched; /* Actual workers launched */
 
@@ -119,6 +120,7 @@ extern struct IndexBuildResult *tp_build_parallel(
 		Oid				  text_config_oid,
 		double			  k1,
 		double			  b,
+		bool			  is_text_array,
 		int				  nworkers);
 
 /* Worker entry point (called by parallel infrastructure) */

--- a/src/am/handler.c
+++ b/src/am/handler.c
@@ -10,6 +10,7 @@
 #include <access/htup_details.h>
 #include <access/reloptions.h>
 #include <catalog/pg_opclass.h>
+#include <catalog/pg_type.h>
 #include <commands/vacuum.h>
 #include <utils/syscache.h>
 
@@ -174,13 +175,17 @@ tp_validate(Oid opclassoid)
 	{
 	case TEXTOID:
 	case VARCHAROID:
-	case BPCHAROID: /* char(n) */
+	case BPCHAROID:	   /* char(n) */
+	case TEXTARRAYOID: /* text[] */
+	case 1015:		   /* varchar[] */
+	case 1014:		   /* bpchar[] */
 		result = true;
 		break;
 	default:
 		elog(WARNING,
-			 "Tapir index can only be created on text, varchar, or char "
-			 "columns (got type OID %u)",
+			 "Tapir index can only be created on text, varchar, "
+			 "or char columns (or arrays thereof) "
+			 "(got type OID %u)",
 			 opcintype);
 		result = false;
 		break;

--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -62,6 +62,8 @@ typedef struct BM25OidCache
 	Oid tpquery_type_oid;
 	Oid text_tpquery_operator_oid;
 	Oid text_text_operator_oid;
+	Oid textarray_tpquery_operator_oid;
+	Oid textarray_text_operator_oid;
 } BM25OidCache;
 
 /*
@@ -169,6 +171,18 @@ lookup_bm25_oids_internal(BM25OidCache *cache)
 	/* Look up the <@> operator for (text, text) */
 	opname						  = list_make1(makeString("<@>"));
 	cache->text_text_operator_oid = OpernameGetOprid(opname, TEXTOID, TEXTOID);
+	list_free(opname);
+
+	/* Look up the <@> operator for (text[], bm25query) */
+	opname = list_make1(makeString("<@>"));
+	cache->textarray_tpquery_operator_oid =
+			OpernameGetOprid(opname, TEXTARRAYOID, cache->tpquery_type_oid);
+	list_free(opname);
+
+	/* Look up the <@> operator for (text[], text) */
+	opname = list_make1(makeString("<@>"));
+	cache->textarray_text_operator_oid =
+			OpernameGetOprid(opname, TEXTARRAYOID, TEXTOID);
 	list_free(opname);
 
 	return true;
@@ -646,7 +660,8 @@ transform_tpquery_opexpr(OpExpr *opexpr, ResolveIndexContext *context)
 	Oid			  index_oid;
 	Const		 *new_const;
 
-	if (opexpr->opno != oids->text_tpquery_operator_oid)
+	if (opexpr->opno != oids->text_tpquery_operator_oid &&
+		opexpr->opno != oids->textarray_tpquery_operator_oid)
 		return NULL;
 
 	/* Mark that we found a BM25 operator for later optimization */
@@ -785,8 +800,10 @@ transform_text_text_opexpr(OpExpr *opexpr, ResolveIndexContext *context)
 	char		 *query_text;
 	TpQuery		 *tpquery;
 	Const		 *tpquery_const;
+	bool		  is_text_array_op =
+			(opexpr->opno == oids->textarray_text_operator_oid);
 
-	if (opexpr->opno != oids->text_text_operator_oid)
+	if (opexpr->opno != oids->text_text_operator_oid && !is_text_array_op)
 		return NULL;
 
 	/* Mark that we found a BM25 operator for later optimization */
@@ -853,7 +870,8 @@ transform_text_text_opexpr(OpExpr *opexpr, ResolveIndexContext *context)
 			false);
 
 	return (Node *)create_opexpr(
-			oids->text_tpquery_operator_oid,
+			is_text_array_op ? oids->textarray_tpquery_operator_oid
+							 : oids->text_tpquery_operator_oid,
 			left,
 			(Node *)tpquery_const,
 			opexpr->inputcollid,
@@ -1035,7 +1053,8 @@ is_bm25_score_opexpr(Node *node, BM25OidCache *oids)
 		return false;
 
 	opexpr = (OpExpr *)node;
-	return opexpr->opno == oids->text_tpquery_operator_oid;
+	return opexpr->opno == oids->text_tpquery_operator_oid ||
+		   opexpr->opno == oids->textarray_tpquery_operator_oid;
 }
 
 /*
@@ -1271,7 +1290,8 @@ extract_tpquery_from_expr(Node *node, BM25OidCache *oids)
 	{
 		OpExpr *opexpr = (OpExpr *)node;
 
-		if (opexpr->opno == oids->text_tpquery_operator_oid &&
+		if ((opexpr->opno == oids->text_tpquery_operator_oid ||
+			 opexpr->opno == oids->textarray_tpquery_operator_oid) &&
 			list_length(opexpr->args) == 2)
 		{
 			Node *right = lsecond(opexpr->args);
@@ -1474,7 +1494,9 @@ collect_explicit_indexes_walker(
 	{
 		OpExpr *opexpr = (OpExpr *)node;
 
-		if (opexpr->opno == context->oid_cache->text_tpquery_operator_oid &&
+		if ((opexpr->opno == context->oid_cache->text_tpquery_operator_oid ||
+			 opexpr->opno ==
+					 context->oid_cache->textarray_tpquery_operator_oid) &&
 			list_length(opexpr->args) == 2)
 		{
 			Node *left	= linitial(opexpr->args);

--- a/src/types/array.c
+++ b/src/types/array.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
+ * Licensed under the PostgreSQL License. See LICENSE for details.
+ *
+ * array.c - Text array helpers for BM25 indexing
+ *
+ * Provides utilities for flattening text-like array columns
+ * (text[], varchar[], bpchar[]) into a single text value for
+ * tokenization by the BM25 index build, insert, and scoring
+ * paths.
+ */
+#include <postgres.h>
+
+#include <catalog/pg_type.h>
+#include <utils/array.h>
+#include <utils/builtins.h>
+
+#include "array.h"
+
+/*
+ * Is this type OID a text-like array (text[], varchar[], bpchar[])?
+ */
+bool
+tp_is_text_array_type(Oid typid)
+{
+	return typid == TEXTARRAYOID || typid == 1015 || /* varchar[] */
+		   typid == 1014;							 /* bpchar[] */
+}
+
+/*
+ * Flatten a text array into a single space-separated text value.
+ * NULL elements are skipped. Returns empty text for empty arrays.
+ * Works for text[], varchar[], and bpchar[] (same binary format).
+ */
+text *
+tp_flatten_text_array(Datum array_datum)
+{
+	ArrayType	  *arr;
+	Datum		  *elems;
+	bool		  *nulls;
+	int			   nelems;
+	StringInfoData buf;
+
+	arr = DatumGetArrayTypeP(array_datum);
+	deconstruct_array(
+			arr, TEXTOID, -1, false, TYPALIGN_INT, &elems, &nulls, &nelems);
+
+	initStringInfo(&buf);
+
+	for (int i = 0; i < nelems; i++)
+	{
+		text *elem;
+		int	  len;
+
+		if (nulls[i])
+			continue;
+
+		elem = DatumGetTextPP(elems[i]);
+		len	 = VARSIZE_ANY_EXHDR(elem);
+
+		if (len == 0)
+			continue;
+
+		if (buf.len > 0)
+			appendStringInfoChar(&buf, ' ');
+		appendBinaryStringInfo(&buf, VARDATA_ANY(elem), len);
+	}
+
+	return cstring_to_text_with_len(buf.data, buf.len);
+}

--- a/src/types/array.h
+++ b/src/types/array.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
+ * Licensed under the PostgreSQL License. See LICENSE for details.
+ *
+ * array.h - Text array helpers for BM25 indexing
+ */
+#pragma once
+
+#include <postgres.h>
+
+/* Check if a type OID is a text-like array */
+extern bool tp_is_text_array_type(Oid typid);
+
+/* Flatten a text array into a single space-separated text */
+extern text *tp_flatten_text_array(Datum array_datum);

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -43,6 +43,7 @@
 #include "segment/segment_io.h"
 #include "state/metapage.h"
 #include "state/state.h"
+#include "types/array.h"
 #include "types/query.h"
 #include "types/vector.h"
 

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -1193,11 +1193,17 @@ bm25_text_text_score(PG_FUNCTION_ARGS)
 Datum
 bm25_textarray_bm25query_score(PG_FUNCTION_ARGS)
 {
-	/* Stub - will be implemented with tp_flatten_text_array */
-	ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("text[] scoring not yet implemented")));
-	PG_RETURN_NULL();
+	Datum array_datum = PG_GETARG_DATUM(0);
+	text *flattened	  = tp_flatten_text_array(array_datum);
+
+	/*
+	 * Replace the first argument with the flattened text,
+	 * then delegate to the scalar scoring function.
+	 */
+	fcinfo->args[0].value  = PointerGetDatum(flattened);
+	fcinfo->args[0].isnull = false;
+
+	return bm25_text_bm25query_score(fcinfo);
 }
 
 /*

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -162,6 +162,8 @@ PG_FUNCTION_INFO_V1(to_tpquery_text);
 PG_FUNCTION_INFO_V1(to_tpquery_text_index);
 PG_FUNCTION_INFO_V1(bm25_text_bm25query_score);
 PG_FUNCTION_INFO_V1(bm25_text_text_score);
+PG_FUNCTION_INFO_V1(bm25_textarray_bm25query_score);
+PG_FUNCTION_INFO_V1(bm25_textarray_text_score);
 PG_FUNCTION_INFO_V1(tpquery_eq);
 PG_FUNCTION_INFO_V1(bm25_get_current_score);
 
@@ -1178,6 +1180,41 @@ bm25_text_text_score(PG_FUNCTION_ARGS)
 			 errmsg("no BM25 index found for text <@> text expression"),
 			 errdetail("Create a BM25 index on the column or use ORDER BY."),
 			 errhint("SELECT col <@> to_bm25query('q', 'idx') AS score")));
+
+	PG_RETURN_NULL(); /* never reached */
+}
+
+/*
+ * Standalone scoring for text[] <@> bm25query.
+ *
+ * Flattens the array elements into a single space-separated text
+ * value, then delegates to bm25_text_bm25query_score().
+ */
+Datum
+bm25_textarray_bm25query_score(PG_FUNCTION_ARGS)
+{
+	/* Stub - will be implemented with tp_flatten_text_array */
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("text[] scoring not yet implemented")));
+	PG_RETURN_NULL();
+}
+
+/*
+ * Error stub for text[] <@> text when planner rewrite fails.
+ */
+Datum
+bm25_textarray_text_score(PG_FUNCTION_ARGS)
+{
+	ereport(ERROR,
+			(errcode(ERRCODE_UNDEFINED_OBJECT),
+			 errmsg("no BM25 index found for text[] <@> text "
+					"expression"),
+			 errdetail(
+					 "Create a BM25 index on the column or "
+					 "use ORDER BY."),
+			 errhint("SELECT col <@> to_bm25query('q', 'idx') "
+					 "AS score")));
 
 	PG_RETURN_NULL(); /* never reached */
 }

--- a/src/types/query.h
+++ b/src/types/query.h
@@ -59,6 +59,8 @@ Datum to_tpquery_text_index(PG_FUNCTION_ARGS);
 /* Operator functions */
 Datum bm25_text_bm25query_score(PG_FUNCTION_ARGS);
 Datum bm25_text_text_score(PG_FUNCTION_ARGS);
+Datum bm25_textarray_bm25query_score(PG_FUNCTION_ARGS);
+Datum bm25_textarray_text_score(PG_FUNCTION_ARGS);
 Datum tpquery_eq(PG_FUNCTION_ARGS);
 
 /* Utility functions */

--- a/test/expected/text_array.out
+++ b/test/expected/text_array.out
@@ -1,0 +1,125 @@
+-- Test BM25 index on text[] columns
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+INFO:  pg_textsearch v1.0.0-dev
+-- Basic text array table and index
+CREATE TABLE docs_array (
+    id SERIAL PRIMARY KEY,
+    content text[]
+);
+CREATE INDEX docs_array_bm25_idx ON docs_array
+    USING bm25(content) WITH (text_config='english');
+NOTICE:  BM25 index build started for relation docs_array_bm25_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+INSERT INTO docs_array (content) VALUES
+    (ARRAY['the quick brown fox', 'jumped over the lazy dog']),
+    (ARRAY['database system design', 'query optimization']),
+    (ARRAY['full text search', 'inverted index structure']),
+    (ARRAY['postgres extensions', 'custom access methods']),
+    (ARRAY['information retrieval', 'relevance ranking']);
+-- BM25 search using explicit bm25query
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('database', 'docs_array_bm25_idx')
+LIMIT 3;
+ id |                     content                     
+----+-------------------------------------------------
+  2 | {"database system design","query optimization"}
+(1 row)
+
+-- Score equivalence: text[] scores should match scalar concatenation
+-- Create equivalent scalar table
+CREATE TABLE docs_scalar (
+    id SERIAL PRIMARY KEY,
+    content text
+);
+CREATE INDEX docs_scalar_bm25_idx ON docs_scalar
+    USING bm25(content) WITH (text_config='english');
+NOTICE:  BM25 index build started for relation docs_scalar_bm25_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+INSERT INTO docs_scalar (content) VALUES
+    ('the quick brown fox jumped over the lazy dog'),
+    ('database system design query optimization'),
+    ('full text search inverted index structure'),
+    ('postgres extensions custom access methods'),
+    ('information retrieval relevance ranking');
+-- Scores from text[] and text should match for same content
+SELECT
+    a.id,
+    a.content <@> to_bm25query('database',
+        'docs_array_bm25_idx') AS array_score,
+    s.content <@> to_bm25query('database',
+        'docs_scalar_bm25_idx') AS scalar_score
+FROM docs_array a
+JOIN docs_scalar s ON a.id = s.id
+WHERE a.id = 2
+ORDER BY a.id;
+ id |     array_score     |    scalar_score     
+----+---------------------+---------------------
+  2 | -1.4084553718566895 | -1.4084553718566895
+(1 row)
+
+-- NULL handling: NULL elements should be skipped
+INSERT INTO docs_array (content) VALUES
+    (ARRAY['hello world', NULL, 'test document']);
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('hello', 'docs_array_bm25_idx')
+LIMIT 1;
+ id |               content                
+----+--------------------------------------
+  6 | {"hello world",NULL,"test document"}
+(1 row)
+
+-- NULL array should be skipped (no crash)
+INSERT INTO docs_array (content) VALUES (NULL);
+-- Empty array should be handled gracefully
+INSERT INTO docs_array (content) VALUES (ARRAY[]::text[]);
+-- Search still works after NULLs and empties
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('database', 'docs_array_bm25_idx')
+LIMIT 1;
+ id |                     content                     
+----+-------------------------------------------------
+  2 | {"database system design","query optimization"}
+(1 row)
+
+-- UPDATE a text[] row and verify search picks up changes
+UPDATE docs_array SET content = ARRAY['updated database', 'new content']
+WHERE id = 1;
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('updated', 'docs_array_bm25_idx')
+LIMIT 1;
+ id |              content               
+----+------------------------------------
+  1 | {"updated database","new content"}
+(1 row)
+
+-- DELETE and verify
+DELETE FROM docs_array WHERE id = 2;
+SELECT count(*) FROM docs_array
+WHERE id = 2;
+ count 
+-------
+     0
+(1 row)
+
+-- Implicit text[] <@> text resolution
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> 'postgres'
+LIMIT 1;
+ id |                     content                     
+----+-------------------------------------------------
+  4 | {"postgres extensions","custom access methods"}
+(1 row)
+
+-- Clean up
+DROP TABLE docs_array CASCADE;
+DROP TABLE docs_scalar CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/text_array.sql
+++ b/test/sql/text_array.sql
@@ -1,0 +1,100 @@
+-- Test BM25 index on text[] columns
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+-- Basic text array table and index
+CREATE TABLE docs_array (
+    id SERIAL PRIMARY KEY,
+    content text[]
+);
+
+CREATE INDEX docs_array_bm25_idx ON docs_array
+    USING bm25(content) WITH (text_config='english');
+
+INSERT INTO docs_array (content) VALUES
+    (ARRAY['the quick brown fox', 'jumped over the lazy dog']),
+    (ARRAY['database system design', 'query optimization']),
+    (ARRAY['full text search', 'inverted index structure']),
+    (ARRAY['postgres extensions', 'custom access methods']),
+    (ARRAY['information retrieval', 'relevance ranking']);
+
+-- BM25 search using explicit bm25query
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('database', 'docs_array_bm25_idx')
+LIMIT 3;
+
+-- Score equivalence: text[] scores should match scalar concatenation
+-- Create equivalent scalar table
+CREATE TABLE docs_scalar (
+    id SERIAL PRIMARY KEY,
+    content text
+);
+
+CREATE INDEX docs_scalar_bm25_idx ON docs_scalar
+    USING bm25(content) WITH (text_config='english');
+
+INSERT INTO docs_scalar (content) VALUES
+    ('the quick brown fox jumped over the lazy dog'),
+    ('database system design query optimization'),
+    ('full text search inverted index structure'),
+    ('postgres extensions custom access methods'),
+    ('information retrieval relevance ranking');
+
+-- Scores from text[] and text should match for same content
+SELECT
+    a.id,
+    a.content <@> to_bm25query('database',
+        'docs_array_bm25_idx') AS array_score,
+    s.content <@> to_bm25query('database',
+        'docs_scalar_bm25_idx') AS scalar_score
+FROM docs_array a
+JOIN docs_scalar s ON a.id = s.id
+WHERE a.id = 2
+ORDER BY a.id;
+
+-- NULL handling: NULL elements should be skipped
+INSERT INTO docs_array (content) VALUES
+    (ARRAY['hello world', NULL, 'test document']);
+
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('hello', 'docs_array_bm25_idx')
+LIMIT 1;
+
+-- NULL array should be skipped (no crash)
+INSERT INTO docs_array (content) VALUES (NULL);
+
+-- Empty array should be handled gracefully
+INSERT INTO docs_array (content) VALUES (ARRAY[]::text[]);
+
+-- Search still works after NULLs and empties
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('database', 'docs_array_bm25_idx')
+LIMIT 1;
+
+-- UPDATE a text[] row and verify search picks up changes
+UPDATE docs_array SET content = ARRAY['updated database', 'new content']
+WHERE id = 1;
+
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> to_bm25query('updated', 'docs_array_bm25_idx')
+LIMIT 1;
+
+-- DELETE and verify
+DELETE FROM docs_array WHERE id = 2;
+
+SELECT count(*) FROM docs_array
+WHERE id = 2;
+
+-- Implicit text[] <@> text resolution
+SELECT id, content
+FROM docs_array
+ORDER BY content <@> 'postgres'
+LIMIT 1;
+
+-- Clean up
+DROP TABLE docs_array CASCADE;
+DROP TABLE docs_scalar CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Summary

- Add native support for indexing `text[]` (and `varchar[]`, `bpchar[]`) columns with BM25 indexes
- Array elements are concatenated with spaces into a single text value before tokenization, which is correct for BM25's bag-of-words scoring model
- Scores from `text[]` indexes match equivalent scalar text indexes exactly

Closes #199

## Changes

- **SQL**: new operator class `text_array_bm25_ops`, operators `<@>(text[], bm25query)` and `<@>(text[], text)`, scoring functions
- **Type validation**: `tp_validate()` accepts `text[]`, `varchar[]`, `bpchar[]` column types
- **Build paths**: `tp_flatten_text_array()` helper wired into serial build, parallel build, and insert
- **Standalone scoring**: `bm25_textarray_bm25query_score()` flattens then delegates to scalar scorer
- **Planner hooks**: `text[] <@> text` implicit resolution rewrites to `text[] <@> bm25query`

## Testing

- New `text_array` regression test covering:
  - CREATE INDEX on text[] column
  - Search with ORDER BY using explicit and implicit operators
  - Score equivalence between text[] and scalar text
  - NULL element skipping, NULL arrays, empty arrays
  - UPDATE and DELETE on indexed text[] rows
- All 54 regression tests pass