### PR TITLE
feat: per-segment alive bitset for efficient VACUUM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,20 @@ Top-k queries use Block-Max WAND optimization:
 - Early termination when blocks cannot contribute to results
 - Skip lists for fast block seeking in segments
 
+### VACUUM and Alive Bitset
+
+VACUUM uses per-segment alive bitsets (1 bit per doc) to mark dead
+documents instead of rebuilding segments. This is O(dead_docs) instead
+of O(all_docs). Dead docs are filtered during BMW scoring and
+physically removed during segment merge.
+
+**Stale statistics after VACUUM**: After VACUUM marks docs dead, the
+segment's `total_docs`, `total_tokens`, and per-term `doc_freq` are
+not updated. This means BM25 IDF calculations use slightly stale
+corpus statistics until the next segment merge/compaction, which
+corrects them. For small numbers of deletes this is negligible; mass
+deletion can affect ranking quality until the next merge.
+
 ## Benchmarking
 
 The `benchmarks/` directory contains performance testing tools:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ PG_CPPFLAGS += -Wno-unknown-warning-option -Wno-clobbered -Wno-packed-not-aligne
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = abort aerodocs basic binary_io bmw bulk_load catalog_stats compression concurrent_build coverage deletion vacuum vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index force_merge implicit index inheritance limits lock manyterms max_shared_memory memory merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table text_array text_config unsupported updates vector unlogged_index wand
+REGRESS = abort aerodocs basic binary_io bmw bulk_load catalog_stats compression concurrent_build coverage deletion vacuum vacuum_bitmap vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index force_merge implicit index inheritance limits lock manyterms max_shared_memory memory merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table text_array text_config unsupported updates vector unlogged_index wand
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ OBJS = \
 	src/segment/scan.o \
 	src/segment/merge.o \
 	src/segment/docmap.o \
+	src/segment/alive_bitset.o \
 	src/segment/compression.o \
 	src/query/bmw.o \
 	src/query/score.o \

--- a/src/am/build_context.c
+++ b/src/am/build_context.c
@@ -523,13 +523,7 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 		uint32 bitset_size = tp_alive_bitset_size(ctx->num_docs);
 		uint8 *bitset_data = palloc(bitset_size);
 
-		memset(bitset_data, 0xFF, bitset_size);
-		if (ctx->num_docs % 8 != 0)
-		{
-			uint8 mask = (1 << (ctx->num_docs % 8)) - 1;
-
-			bitset_data[bitset_size - 1] &= mask;
-		}
+		tp_alive_bitset_init_data(bitset_data, ctx->num_docs);
 		tp_segment_writer_write(&writer, bitset_data, bitset_size);
 		pfree(bitset_data);
 	}

--- a/src/am/build_context.c
+++ b/src/am/build_context.c
@@ -18,6 +18,7 @@
 #include "constants.h"
 #include "memtable/arena.h"
 #include "memtable/expull.h"
+#include "segment/alive_bitset.h"
 #include "segment/compression.h"
 #include "segment/fieldnorm.h"
 #include "segment/pagemapper.h"
@@ -514,6 +515,25 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 		pfree(ctid_offsets);
 	}
 
+	/* Write alive bitset (all alive) */
+	header.alive_bitset_offset = writer.current_offset;
+	header.alive_count		   = ctx->num_docs;
+	if (ctx->num_docs > 0)
+	{
+		uint32 bitset_size = tp_alive_bitset_size(ctx->num_docs);
+		uint8 *bitset_data = palloc(bitset_size);
+
+		memset(bitset_data, 0xFF, bitset_size);
+		if (ctx->num_docs % 8 != 0)
+		{
+			uint8 mask = (1 << (ctx->num_docs % 8)) - 1;
+
+			bitset_data[bitset_size - 1] &= mask;
+		}
+		tp_segment_writer_write(&writer, bitset_data, bitset_size);
+		pfree(bitset_data);
+	}
+
 	/* Flush remaining buffered data */
 	tp_segment_writer_flush(&writer);
 
@@ -651,6 +671,8 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 		hdr->fieldnorm_offset	 = header.fieldnorm_offset;
 		hdr->ctid_pages_offset	 = header.ctid_pages_offset;
 		hdr->ctid_offsets_offset = header.ctid_offsets_offset;
+		hdr->alive_bitset_offset = header.alive_bitset_offset;
+		hdr->alive_count		 = header.alive_count;
 		hdr->num_docs			 = header.num_docs;
 		hdr->data_size			 = header.data_size;
 		hdr->num_pages			 = header.num_pages;

--- a/src/am/vacuum.c
+++ b/src/am/vacuum.c
@@ -135,12 +135,22 @@ tp_vacuum_identify_affected(
 
 			/* Check each CTID against the callback */
 			{
-				uint32 *dead_ids = NULL;
-				uint32	dead_cap = 0;
+				uint32 *dead_ids   = NULL;
+				uint32	dead_cap   = 0;
+				bool	has_bitset = (reader->header->alive_bitset_offset > 0);
 
 				for (uint32 i = 0; i < reader->header->num_docs; i++)
 				{
 					ItemPointerData ctid;
+
+					/*
+					 * Skip docs already marked dead in the alive
+					 * bitset.  Without this, CTID reuse after a
+					 * previous VACUUM would double-count dead docs
+					 * and corrupt total_docs in the metapage.
+					 */
+					if (has_bitset && !tp_segment_is_alive(reader, i))
+						continue;
 
 					tp_segment_lookup_ctid(reader, i, &ctid);
 					if (ItemPointerIsValid(&ctid) &&

--- a/src/am/vacuum.c
+++ b/src/am/vacuum.c
@@ -30,6 +30,7 @@
 #include "am/build_context.h"
 #include "memtable/memtable.h"
 #include "memtable/posting.h"
+#include "segment/alive_bitset.h"
 #include "segment/merge.h"
 #include "segment/segment.h"
 #include "segment/segment_io.h"
@@ -47,8 +48,10 @@ typedef struct TpVacuumSegmentInfo
 	BlockNumber next_segment;
 	uint32		level;
 	uint32		num_docs;
-	int64		dead_count;
+	uint32	   *dead_doc_ids; /* Array of dead doc_ids */
+	uint32		dead_count;
 	bool		affected;
+	bool		is_v5; /* true if segment has alive bitset */
 } TpVacuumSegmentInfo;
 
 /*
@@ -120,7 +123,7 @@ tp_vacuum_identify_affected(
 		while (seg != InvalidBlockNumber)
 		{
 			TpSegmentReader *reader;
-			int64			 seg_dead = 0;
+			uint32			 seg_dead = 0;
 
 			reader = tp_segment_open_ex(index, seg, true);
 			if (!reader || !reader->header)
@@ -131,32 +134,52 @@ tp_vacuum_identify_affected(
 			}
 
 			/* Check each CTID against the callback */
-			for (uint32 i = 0; i < reader->header->num_docs; i++)
 			{
-				ItemPointerData ctid;
+				uint32 *dead_ids = NULL;
+				uint32	dead_cap = 0;
 
-				tp_segment_lookup_ctid(reader, i, &ctid);
-				if (ItemPointerIsValid(&ctid) &&
-					callback(&ctid, callback_state))
+				for (uint32 i = 0; i < reader->header->num_docs; i++)
 				{
-					seg_dead++;
+					ItemPointerData ctid;
+
+					tp_segment_lookup_ctid(reader, i, &ctid);
+					if (ItemPointerIsValid(&ctid) &&
+						callback(&ctid, callback_state))
+					{
+						if (seg_dead >= dead_cap)
+						{
+							dead_cap = (dead_cap == 0) ? 64 : dead_cap * 2;
+							dead_ids = dead_ids
+											 ? repalloc(
+													   dead_ids,
+													   dead_cap *
+															   sizeof(uint32))
+											 : palloc(dead_cap *
+													  sizeof(uint32));
+						}
+						dead_ids[seg_dead] = i;
+						seg_dead++;
+					}
 				}
-			}
 
-			/* Record segment info */
-			if (count >= capacity)
-			{
-				capacity *= 2;
-				segments = repalloc(
-						segments, capacity * sizeof(TpVacuumSegmentInfo));
-			}
+				/* Record segment info */
+				if (count >= capacity)
+				{
+					capacity *= 2;
+					segments = repalloc(
+							segments, capacity * sizeof(TpVacuumSegmentInfo));
+				}
 
-			segments[count].root_block	 = seg;
-			segments[count].next_segment = reader->header->next_segment;
-			segments[count].level		 = level;
-			segments[count].num_docs	 = reader->header->num_docs;
-			segments[count].dead_count	 = seg_dead;
-			segments[count].affected	 = (seg_dead > 0);
+				segments[count].root_block	 = seg;
+				segments[count].next_segment = reader->header->next_segment;
+				segments[count].level		 = level;
+				segments[count].num_docs	 = reader->header->num_docs;
+				segments[count].dead_doc_ids = dead_ids;
+				segments[count].dead_count	 = seg_dead;
+				segments[count].affected	 = (seg_dead > 0);
+				segments[count].is_v5 =
+						(reader->header->alive_bitset_offset > 0);
+			}
 
 			total_dead += seg_dead;
 			count++;
@@ -481,12 +504,59 @@ tp_vacuum_replace_segment(
 }
 
 /*
+ * Apply dead doc marks to a V5 segment's alive bitset.
+ *
+ * Loads the bitset, marks dead docs, writes back via
+ * GenericXLog.  Returns the new alive_count, or 0 if all
+ * docs are dead (caller should drop the segment).
+ */
+static uint32
+tp_vacuum_mark_dead(
+		Relation	index,
+		BlockNumber root_block,
+		uint32	   *dead_doc_ids,
+		uint32		dead_count)
+{
+	TpSegmentReader *reader;
+	TpAliveBitset	*bitset;
+	uint32			 alive;
+
+	reader = tp_segment_open_ex(index, root_block, false);
+	if (!reader || !reader->header)
+	{
+		if (reader)
+			tp_segment_close(reader);
+		return 0;
+	}
+
+	bitset = tp_alive_bitset_load(reader);
+	if (!bitset)
+	{
+		tp_segment_close(reader);
+		return 0;
+	}
+
+	for (uint32 i = 0; i < dead_count; i++)
+		tp_alive_bitset_mark_dead(bitset, dead_doc_ids[i]);
+
+	alive = bitset->alive_count;
+
+	if (alive > 0)
+		tp_alive_bitset_write(bitset, reader, index);
+
+	tp_alive_bitset_free(bitset);
+	tp_segment_close(reader);
+
+	return alive;
+}
+
+/*
  * Bulk delete callback for vacuum and CREATE INDEX CONCURRENTLY
  *
  * Four-phase approach:
  * 1. Spill memtable to segments (all data in uniform format)
  * 2. Identify segments containing dead CTIDs (O(segments) memory)
- * 3. Rebuild affected segments from heap via TpBuildContext
+ * 3. Mark dead docs or rebuild affected segments
  * 4. Update metapage statistics
  *
  * Also called during CREATE INDEX CONCURRENTLY validation with a
@@ -573,19 +643,14 @@ tp_bulkdelete(
 	}
 
 	elog(DEBUG1,
-		 "Tapir VACUUM: %lld dead tuples across %d segments, "
-		 "rebuilding affected segments",
+		 "Tapir VACUUM: %lld dead tuples across %d segments",
 		 (long long)total_dead,
 		 num_segments);
 
-	/* Phase 3: Rebuild affected segments */
+	/* Phase 3: Mark dead docs or rebuild affected segments */
 	{
 		uint64 new_total_docs = 0;
 
-		/*
-		 * Walk segments per-level to track prev pointers for
-		 * chain replacement.
-		 */
 		for (int level = 0; level < TP_MAX_LEVELS; level++)
 		{
 			BlockNumber prev = InvalidBlockNumber;
@@ -597,36 +662,67 @@ tp_bulkdelete(
 
 				if (segments[i].affected)
 				{
-					BlockNumber new_root;
-					uint64		seg_docs;
+					if (segments[i].is_v5)
+					{
+						/*
+						 * V5 segment: flip bits in alive
+						 * bitset.
+						 */
+						uint32 alive = tp_vacuum_mark_dead(
+								info->index,
+								segments[i].root_block,
+								segments[i].dead_doc_ids,
+								segments[i].dead_count);
 
-					new_root = tp_vacuum_rebuild_segment(
-							info->index,
-							info->heaprel,
-							segments[i].root_block,
-							level,
-							callback,
-							callback_state,
-							&seg_docs,
-							NULL);
+						if (alive == 0)
+						{
+							/*
+							 * All docs dead -- drop segment.
+							 */
+							tp_vacuum_replace_segment(
+									info->index,
+									level,
+									segments[i].root_block,
+									InvalidBlockNumber,
+									prev);
+							/* prev stays the same */
+						}
+						else
+						{
+							new_total_docs += alive;
+							prev = segments[i].root_block;
+						}
+					}
+					else
+					{
+						/*
+						 * Pre-V5 segment: rebuild into V5.
+						 */
+						BlockNumber new_root;
+						uint64		seg_docs;
 
-					tp_vacuum_replace_segment(
-							info->index,
-							level,
-							segments[i].root_block,
-							new_root,
-							prev);
+						new_root = tp_vacuum_rebuild_segment(
+								info->index,
+								info->heaprel,
+								segments[i].root_block,
+								level,
+								callback,
+								callback_state,
+								&seg_docs,
+								NULL);
 
-					new_total_docs += seg_docs;
+						tp_vacuum_replace_segment(
+								info->index,
+								level,
+								segments[i].root_block,
+								new_root,
+								prev);
 
-					/*
-					 * If we replaced (not removed), the new
-					 * segment becomes prev for the next
-					 * iteration.
-					 */
-					if (new_root != InvalidBlockNumber)
-						prev = new_root;
-					/* else prev stays the same */
+						new_total_docs += seg_docs;
+
+						if (new_root != InvalidBlockNumber)
+							prev = new_root;
+					}
 				}
 				else
 				{
@@ -675,6 +771,11 @@ tp_bulkdelete(
 	}
 
 	pfree(metap);
+	for (int i = 0; i < num_segments; i++)
+	{
+		if (segments[i].dead_doc_ids)
+			pfree(segments[i].dead_doc_ids);
+	}
 	pfree(segments);
 
 	return stats;

--- a/src/debug/dump.c
+++ b/src/debug/dump.c
@@ -251,6 +251,7 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 	int				   segment_count   = 0;
 	uint32			   segment_terms   = 0;
 	uint32			   segment_docs	   = 0;
+	uint32			   segment_alive   = 0;
 	uint32			   recovery_pages  = 0;
 	uint32			   recovery_docids = 0;
 
@@ -447,20 +448,39 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 					level_segment_count++;
 					segment_terms += header->num_terms;
 					segment_docs += header->num_docs;
+					segment_alive += header->alive_count;
 					segment_pages += header->num_pages;
 					seg_size = (Size)header->num_pages * BLCKSZ;
 
-					dump_printf(
-							out,
-							"  L%d Segment %d: block=%u, pages=%u, "
-							"size=%.1fMB, terms=%u, docs=%u\n",
-							level,
-							level_segment_count,
-							current_segment,
-							header->num_pages,
-							(double)seg_size / (1024.0 * 1024.0),
-							header->num_terms,
-							header->num_docs);
+					if (header->alive_count < header->num_docs)
+						dump_printf(
+								out,
+								"  L%d Segment %d: block=%u, "
+								"pages=%u, size=%.1fMB, "
+								"terms=%u, docs=%u "
+								"(alive=%u, dead=%u)\n",
+								level,
+								level_segment_count,
+								current_segment,
+								header->num_pages,
+								(double)seg_size / (1024.0 * 1024.0),
+								header->num_terms,
+								header->num_docs,
+								header->alive_count,
+								header->num_docs - header->alive_count);
+					else
+						dump_printf(
+								out,
+								"  L%d Segment %d: block=%u, "
+								"pages=%u, size=%.1fMB, "
+								"terms=%u, docs=%u\n",
+								level,
+								level_segment_count,
+								current_segment,
+								header->num_pages,
+								(double)seg_size / (1024.0 * 1024.0),
+								header->num_terms,
+								header->num_docs);
 
 					current_segment = header->next_segment;
 					tp_segment_close(reader);
@@ -474,15 +494,31 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 
 		if (has_segments)
 		{
-			dump_printf(
-					out,
-					"  Total: %d segments, " UINT64_FORMAT " pages (%.1fMB), "
-					"%u terms, %u docs\n",
-					segment_count,
-					segment_pages,
-					(double)(segment_pages * BLCKSZ) / (1024.0 * 1024.0),
-					segment_terms,
-					segment_docs);
+			if (segment_alive < segment_docs)
+				dump_printf(
+						out,
+						"  Total: %d segments, " UINT64_FORMAT
+						" pages (%.1fMB), "
+						"%u terms, %u docs "
+						"(alive=%u, dead=%u)\n",
+						segment_count,
+						segment_pages,
+						(double)(segment_pages * BLCKSZ) / (1024.0 * 1024.0),
+						segment_terms,
+						segment_docs,
+						segment_alive,
+						segment_docs - segment_alive);
+			else
+				dump_printf(
+						out,
+						"  Total: %d segments, " UINT64_FORMAT
+						" pages (%.1fMB), "
+						"%u terms, %u docs\n",
+						segment_count,
+						segment_pages,
+						(double)(segment_pages * BLCKSZ) / (1024.0 * 1024.0),
+						segment_terms,
+						segment_docs);
 		}
 		else
 		{

--- a/src/query/bmw.c
+++ b/src/query/bmw.c
@@ -523,42 +523,60 @@ score_segment_single_term_bmw(
 		iter.finished	   = false; /* Reset so we can process this block */
 		tp_segment_posting_iterator_load_block(&iter);
 
-		while (tp_segment_posting_iterator_next(&iter, &posting))
+		/*
+		 * Pre-load alive bitset bytes for this block to
+		 * amortize paged I/O (one read per block instead
+		 * of one per posting).
+		 */
 		{
-			float4 score;
+			uint8  alive_buf[TP_ALIVE_BLOCK_BUF_SIZE];
+			uint32 alive_base;
+			bool   has_dead = tp_alive_bitset_load_range(
+					  reader,
+					  iter.block_postings[0].doc_id,
+					  iter.skip_entry.last_doc_id,
+					  alive_buf,
+					  &alive_base);
 
-			/*
-			 * Break if iterator auto-advanced to next block.
-			 * This ensures we only process block i, allowing the outer
-			 * for loop to apply threshold checks to subsequent blocks.
-			 */
-			if (iter.current_block != i)
-				break;
-
-			/* Skip dead docs */
-			if (!tp_segment_is_alive(reader, posting->doc_id))
+			while (tp_segment_posting_iterator_next(&iter, &posting))
 			{
+				float4 score;
+
+				/*
+				 * Break if iterator auto-advanced to next block.
+				 * This ensures we only process block i, allowing
+				 * the outer for loop to apply threshold checks to
+				 * subsequent blocks.
+				 */
+				if (iter.current_block != i)
+					break;
+
+				/* Skip dead docs */
+				if (has_dead &&
+					!TP_ALIVE_BIT(alive_buf, alive_base, posting->doc_id))
+				{
+					if (stats)
+						stats->dead_docs_skipped++;
+					continue;
+				}
+
+				score = compute_bm25_score(
+						idf,
+						posting->frequency,
+						posting->doc_length,
+						k1,
+						b,
+						avg_doc_len);
+
+				if (!tp_topk_dominated(heap, score))
+				{
+					tp_topk_add_segment(
+							heap, reader->root_block, posting->doc_id, score);
+				}
+
 				if (stats)
-					stats->dead_docs_skipped++;
-				continue;
+					stats->segment_docs_scored++;
 			}
-
-			score = compute_bm25_score(
-					idf,
-					posting->frequency,
-					posting->doc_length,
-					k1,
-					b,
-					avg_doc_len);
-
-			if (!tp_topk_dominated(heap, score))
-			{
-				tp_topk_add_segment(
-						heap, reader->root_block, posting->doc_id, score);
-			}
-
-			if (stats)
-				stats->segment_docs_scored++;
 		}
 	}
 

--- a/src/query/bmw.c
+++ b/src/query/bmw.c
@@ -523,60 +523,42 @@ score_segment_single_term_bmw(
 		iter.finished	   = false; /* Reset so we can process this block */
 		tp_segment_posting_iterator_load_block(&iter);
 
-		/*
-		 * Pre-load alive bitset bytes for this block to
-		 * amortize paged I/O (one read per block instead
-		 * of one per posting).
-		 */
+		while (tp_segment_posting_iterator_next(&iter, &posting))
 		{
-			uint8  alive_buf[TP_ALIVE_BLOCK_BUF_SIZE];
-			uint32 alive_base;
-			bool   has_dead = tp_alive_bitset_load_range(
-					  reader,
-					  iter.block_postings[0].doc_id,
-					  iter.skip_entry.last_doc_id,
-					  alive_buf,
-					  &alive_base);
+			float4 score;
 
-			while (tp_segment_posting_iterator_next(&iter, &posting))
+			/*
+			 * Break if iterator auto-advanced to next block.
+			 * This ensures we only process block i, allowing the outer
+			 * for loop to apply threshold checks to subsequent blocks.
+			 */
+			if (iter.current_block != i)
+				break;
+
+			/* Skip dead docs */
+			if (!tp_segment_is_alive(reader, posting->doc_id))
 			{
-				float4 score;
-
-				/*
-				 * Break if iterator auto-advanced to next block.
-				 * This ensures we only process block i, allowing
-				 * the outer for loop to apply threshold checks to
-				 * subsequent blocks.
-				 */
-				if (iter.current_block != i)
-					break;
-
-				/* Skip dead docs */
-				if (has_dead &&
-					!TP_ALIVE_BIT(alive_buf, alive_base, posting->doc_id))
-				{
-					if (stats)
-						stats->dead_docs_skipped++;
-					continue;
-				}
-
-				score = compute_bm25_score(
-						idf,
-						posting->frequency,
-						posting->doc_length,
-						k1,
-						b,
-						avg_doc_len);
-
-				if (!tp_topk_dominated(heap, score))
-				{
-					tp_topk_add_segment(
-							heap, reader->root_block, posting->doc_id, score);
-				}
-
 				if (stats)
-					stats->segment_docs_scored++;
+					stats->dead_docs_skipped++;
+				continue;
 			}
+
+			score = compute_bm25_score(
+					idf,
+					posting->frequency,
+					posting->doc_length,
+					k1,
+					b,
+					avg_doc_len);
+
+			if (!tp_topk_dominated(heap, score))
+			{
+				tp_topk_add_segment(
+						heap, reader->root_block, posting->doc_id, score);
+			}
+
+			if (stats)
+				stats->segment_docs_scored++;
 		}
 	}
 

--- a/src/query/bmw.c
+++ b/src/query/bmw.c
@@ -14,6 +14,7 @@
 #include "memtable/source.h"
 #include "query/bmw.h"
 #include "query/score.h"
+#include "segment/alive_bitset.h"
 #include "segment/compression.h"
 #include "segment/fieldnorm.h"
 #include "segment/segment_io.h"
@@ -533,6 +534,14 @@ score_segment_single_term_bmw(
 			 */
 			if (iter.current_block != i)
 				break;
+
+			/* Skip dead docs */
+			if (!tp_segment_is_alive(reader, posting->doc_id))
+			{
+				if (stats)
+					stats->dead_docs_skipped++;
+				continue;
+			}
 
 			score = compute_bm25_score(
 					idf,
@@ -1442,15 +1451,25 @@ score_segment_multi_term_bmw(
 		if (!verify_pivot_alignment(terms, pivot_len, pivot_doc_id))
 			continue; /* Re-pivot with new positions */
 
-		/* Step 5: Score the pivot document */
-		doc_score = score_pivot_document(terms, pivot_len, k1, b, avg_doc_len);
+		/* Skip dead docs */
+		if (!tp_segment_is_alive(reader, pivot_doc_id))
+		{
+			if (stats)
+				stats->dead_docs_skipped++;
+		}
+		else
+		{
+			/* Step 5: Score the pivot document */
+			doc_score =
+					score_pivot_document(terms, pivot_len, k1, b, avg_doc_len);
 
-		if (doc_score > 0.0f && !tp_topk_dominated(heap, doc_score))
-			tp_topk_add_segment(
-					heap, reader->root_block, pivot_doc_id, doc_score);
+			if (doc_score > 0.0f && !tp_topk_dominated(heap, doc_score))
+				tp_topk_add_segment(
+						heap, reader->root_block, pivot_doc_id, doc_score);
 
-		if (stats)
-			stats->segment_docs_scored++;
+			if (stats)
+				stats->segment_docs_scored++;
+		}
 
 		/*
 		 * Step 6: Advance all pivot terms past pivot_doc_id.

--- a/src/query/bmw.h
+++ b/src/query/bmw.h
@@ -112,7 +112,8 @@ typedef struct TpBMWStats
 	uint64 segment_docs_scored; /* Documents scored from segments */
 	uint64 docs_in_results;		/* Documents in final results */
 
-	uint64 seeks_performed; /* Binary search seeks executed */
+	uint64 seeks_performed;	  /* Binary search seeks executed */
+	uint64 dead_docs_skipped; /* Dead docs filtered by alive bitset */
 } TpBMWStats;
 
 /*

--- a/src/segment/alive_bitset.c
+++ b/src/segment/alive_bitset.c
@@ -17,6 +17,25 @@
 #include "segment_io.h"
 
 /*
+ * Initialize a raw bitset buffer to all-alive for num_docs.
+ * Sets all bits to 1, then clears trailing bits in the last byte.
+ */
+void
+tp_alive_bitset_init_data(uint8 *buf, uint32 num_docs)
+{
+	uint32 nbytes = tp_alive_bitset_size(num_docs);
+
+	memset(buf, 0xFF, nbytes);
+
+	if (num_docs % 8 != 0)
+	{
+		uint8 mask = (1 << (num_docs % 8)) - 1;
+
+		buf[nbytes - 1] &= mask;
+	}
+}
+
+/*
  * Create an in-memory bitset with all docs alive.
  *
  * Allocates a TpAliveBitset with all bits set to 1, then clears
@@ -34,16 +53,7 @@ tp_alive_bitset_create(uint32 num_docs)
 
 	nbytes		 = tp_alive_bitset_size(num_docs);
 	bitset->bits = palloc(nbytes);
-	memset(bitset->bits, 0xFF, nbytes);
-
-	/* Clear trailing bits in the last byte beyond num_docs */
-	if (num_docs % 8 != 0)
-	{
-		uint32 trailing_bits = num_docs % 8;
-		uint8  mask			 = (1 << trailing_bits) - 1;
-
-		bitset->bits[nbytes - 1] &= mask;
-	}
+	tp_alive_bitset_init_data(bitset->bits, num_docs);
 
 	return bitset;
 }
@@ -102,14 +112,14 @@ tp_alive_bitset_mark_dead(TpAliveBitset *bitset, uint32 doc_id)
 }
 
 /*
- * Write the in-memory bitset back to segment pages using GenericXLog,
- * then update alive_count in the segment header page.
+ * Write the in-memory bitset back to segment pages using
+ * GenericXLog, then update alive_count in the segment header.
  *
- * The bitset data lives in the segment's logical address space starting
- * at reader->header->alive_bitset_offset.  We iterate the bitset bytes,
- * mapping each range to its physical page, and copy using GenericXLog
- * for crash safety.  Finally, the segment header's alive_count is
- * updated in a separate GenericXLog record.
+ * The header update is batched into the final bitset page's
+ * GenericXLog transaction so that the bitset data and
+ * alive_count are crash-atomic.  If the header page happens
+ * to be the same physical page as the last bitset page, both
+ * updates go into a single GenericXLog with one buffer.
  */
 void
 tp_alive_bitset_write(
@@ -124,8 +134,9 @@ tp_alive_bitset_write(
 	bytes_written = 0;
 
 	/*
-	 * Write bitset data page by page.  Each iteration handles one
-	 * physical page worth of bitset bytes (or less for the last page).
+	 * Write bitset data page by page.  On the last page,
+	 * batch the header alive_count update into the same
+	 * GenericXLog transaction for crash atomicity.
 	 */
 	while (bytes_written < nbytes)
 	{
@@ -137,6 +148,8 @@ tp_alive_bitset_write(
 		Buffer			  buf;
 		Page			  page;
 		GenericXLogState *xstate;
+		bool			  is_last_page;
+		Buffer			  header_buf = InvalidBuffer;
 
 		logical_offset = bitset_offset + bytes_written;
 		logical_page   = tp_logical_page(logical_offset);
@@ -145,10 +158,11 @@ tp_alive_bitset_write(
 		Assert(logical_page < reader->num_pages);
 		physical_block = reader->page_map[logical_page];
 
-		/* How many bitset bytes fit on this page from page_off */
 		bytes_on_page = SEGMENT_DATA_PER_PAGE - page_off;
 		if (bytes_on_page > nbytes - bytes_written)
 			bytes_on_page = nbytes - bytes_written;
+
+		is_last_page = (bytes_written + bytes_on_page >= nbytes);
 
 		buf = ReadBuffer(index, physical_block);
 		LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
@@ -159,31 +173,42 @@ tp_alive_bitset_write(
 			   bitset->bits + bytes_written,
 			   bytes_on_page);
 
+		/*
+		 * On the last bitset page, also update alive_count
+		 * in the segment header within the same GenericXLog
+		 * transaction for crash atomicity.
+		 */
+		if (is_last_page)
+		{
+			if (physical_block == reader->root_block)
+			{
+				/*
+				 * Header is on the same page — update the
+				 * already-registered buffer.
+				 */
+				TpSegmentHeader *hdr = (TpSegmentHeader *)PageGetContents(
+						page);
+				hdr->alive_count = bitset->alive_count;
+			}
+			else
+			{
+				Page header_page;
+
+				header_buf = ReadBuffer(index, reader->root_block);
+				LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
+				header_page = GenericXLogRegisterBuffer(xstate, header_buf, 0);
+				((TpSegmentHeader *)PageGetContents(header_page))
+						->alive_count = bitset->alive_count;
+			}
+		}
+
 		GenericXLogFinish(xstate);
 		UnlockReleaseBuffer(buf);
 
+		if (BufferIsValid(header_buf))
+			UnlockReleaseBuffer(header_buf);
+
 		bytes_written += bytes_on_page;
-	}
-
-	/*
-	 * Update alive_count in the segment header page.
-	 */
-	{
-		Buffer			  header_buf;
-		Page			  header_page;
-		TpSegmentHeader	 *hdr;
-		GenericXLogState *xstate;
-
-		header_buf = ReadBuffer(index, reader->root_block);
-		LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
-		xstate		= GenericXLogStart(index);
-		header_page = GenericXLogRegisterBuffer(xstate, header_buf, 0);
-		hdr			= (TpSegmentHeader *)PageGetContents(header_page);
-
-		hdr->alive_count = bitset->alive_count;
-
-		GenericXLogFinish(xstate);
-		UnlockReleaseBuffer(header_buf);
 	}
 }
 

--- a/src/segment/alive_bitset.c
+++ b/src/segment/alive_bitset.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
+ * Licensed under the PostgreSQL License. See LICENSE for details.
+ *
+ * alive_bitset.c - Per-segment alive bitset implementation
+ */
+#include <postgres.h>
+
+#include <access/generic_xlog.h>
+#include <storage/bufmgr.h>
+#include <storage/bufpage.h>
+#include <utils/memutils.h>
+#include <utils/rel.h>
+
+#include "alive_bitset.h"
+#include "pagemapper.h"
+#include "segment_io.h"
+
+/*
+ * Create an in-memory bitset with all docs alive.
+ *
+ * Allocates a TpAliveBitset with all bits set to 1, then clears
+ * any trailing bits beyond num_docs in the final byte.
+ */
+TpAliveBitset *
+tp_alive_bitset_create(uint32 num_docs)
+{
+	TpAliveBitset *bitset;
+	uint32		   nbytes;
+
+	bitset				= palloc(sizeof(TpAliveBitset));
+	bitset->num_docs	= num_docs;
+	bitset->alive_count = num_docs;
+
+	nbytes		 = tp_alive_bitset_size(num_docs);
+	bitset->bits = palloc(nbytes);
+	memset(bitset->bits, 0xFF, nbytes);
+
+	/* Clear trailing bits in the last byte beyond num_docs */
+	if (num_docs % 8 != 0)
+	{
+		uint32 trailing_bits = num_docs % 8;
+		uint8  mask			 = (1 << trailing_bits) - 1;
+
+		bitset->bits[nbytes - 1] &= mask;
+	}
+
+	return bitset;
+}
+
+/*
+ * Load the alive bitset from a segment into memory.
+ *
+ * Returns NULL if the segment has no alive bitset (pre-V5 segments
+ * have alive_bitset_offset == 0).
+ */
+TpAliveBitset *
+tp_alive_bitset_load(TpSegmentReader *reader)
+{
+	TpAliveBitset *bitset;
+	uint32		   nbytes;
+
+	if (reader->header->alive_bitset_offset == 0)
+		return NULL;
+
+	bitset				= palloc(sizeof(TpAliveBitset));
+	bitset->num_docs	= reader->header->num_docs;
+	bitset->alive_count = reader->header->alive_count;
+
+	nbytes		 = tp_alive_bitset_size(bitset->num_docs);
+	bitset->bits = palloc(nbytes);
+
+	tp_segment_read(
+			reader, reader->header->alive_bitset_offset, bitset->bits, nbytes);
+
+	return bitset;
+}
+
+/*
+ * Mark a document as dead in the in-memory bitset.
+ *
+ * Returns true if the document was previously alive (and alive_count
+ * was decremented), false if it was already dead.
+ */
+bool
+tp_alive_bitset_mark_dead(TpAliveBitset *bitset, uint32 doc_id)
+{
+	uint32 byte_idx;
+	uint8  bit_mask;
+
+	Assert(doc_id < bitset->num_docs);
+
+	byte_idx = doc_id >> 3;
+	bit_mask = (uint8)(1 << (doc_id & 7));
+
+	if (!(bitset->bits[byte_idx] & bit_mask))
+		return false; /* already dead */
+
+	bitset->bits[byte_idx] &= ~bit_mask;
+	bitset->alive_count--;
+	return true;
+}
+
+/*
+ * Write the in-memory bitset back to segment pages using GenericXLog,
+ * then update alive_count in the segment header page.
+ *
+ * The bitset data lives in the segment's logical address space starting
+ * at reader->header->alive_bitset_offset.  We iterate the bitset bytes,
+ * mapping each range to its physical page, and copy using GenericXLog
+ * for crash safety.  Finally, the segment header's alive_count is
+ * updated in a separate GenericXLog record.
+ */
+void
+tp_alive_bitset_write(
+		TpAliveBitset *bitset, TpSegmentReader *reader, Relation index)
+{
+	uint64 bitset_offset;
+	uint32 nbytes;
+	uint32 bytes_written;
+
+	bitset_offset = reader->header->alive_bitset_offset;
+	nbytes		  = tp_alive_bitset_size(bitset->num_docs);
+	bytes_written = 0;
+
+	/*
+	 * Write bitset data page by page.  Each iteration handles one
+	 * physical page worth of bitset bytes (or less for the last page).
+	 */
+	while (bytes_written < nbytes)
+	{
+		uint64			  logical_offset;
+		uint32			  logical_page;
+		uint32			  page_off;
+		uint32			  bytes_on_page;
+		BlockNumber		  physical_block;
+		Buffer			  buf;
+		Page			  page;
+		GenericXLogState *xstate;
+
+		logical_offset = bitset_offset + bytes_written;
+		logical_page   = tp_logical_page(logical_offset);
+		page_off	   = tp_page_offset(logical_offset);
+
+		Assert(logical_page < reader->num_pages);
+		physical_block = reader->page_map[logical_page];
+
+		/* How many bitset bytes fit on this page from page_off */
+		bytes_on_page = SEGMENT_DATA_PER_PAGE - page_off;
+		if (bytes_on_page > nbytes - bytes_written)
+			bytes_on_page = nbytes - bytes_written;
+
+		buf = ReadBuffer(index, physical_block);
+		LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
+		xstate = GenericXLogStart(index);
+		page   = GenericXLogRegisterBuffer(xstate, buf, 0);
+
+		memcpy((char *)page + SizeOfPageHeaderData + page_off,
+			   bitset->bits + bytes_written,
+			   bytes_on_page);
+
+		GenericXLogFinish(xstate);
+		UnlockReleaseBuffer(buf);
+
+		bytes_written += bytes_on_page;
+	}
+
+	/*
+	 * Update alive_count in the segment header page.
+	 */
+	{
+		Buffer			  header_buf;
+		Page			  header_page;
+		TpSegmentHeader	 *hdr;
+		GenericXLogState *xstate;
+
+		header_buf = ReadBuffer(index, reader->root_block);
+		LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
+		xstate		= GenericXLogStart(index);
+		header_page = GenericXLogRegisterBuffer(xstate, header_buf, 0);
+		hdr			= (TpSegmentHeader *)PageGetContents(header_page);
+
+		hdr->alive_count = bitset->alive_count;
+
+		GenericXLogFinish(xstate);
+		UnlockReleaseBuffer(header_buf);
+	}
+}
+
+/*
+ * Free an in-memory alive bitset.
+ */
+void
+tp_alive_bitset_free(TpAliveBitset *bitset)
+{
+	if (bitset == NULL)
+		return;
+
+	if (bitset->bits)
+		pfree(bitset->bits);
+
+	pfree(bitset);
+}

--- a/src/segment/alive_bitset.h
+++ b/src/segment/alive_bitset.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
+ * Licensed under the PostgreSQL License. See LICENSE for details.
+ *
+ * alive_bitset.h - Per-segment alive bitset for tombstone tracking
+ *
+ * Each segment contains a flat bitset with one bit per document.
+ * Bit 1 = alive, bit 0 = dead. Pre-allocated at segment creation
+ * with all bits set. VACUUM clears bits for dead documents.
+ */
+#pragma once
+
+#include <postgres.h>
+
+#include <storage/bufmgr.h>
+#include <utils/rel.h>
+
+#include "segment_io.h"
+
+/*
+ * In-memory alive bitset, used during VACUUM to batch-update
+ * the on-disk bitset.  Not used during scoring — scoring reads
+ * bitset bytes directly from segment pages via paged I/O.
+ */
+typedef struct TpAliveBitset
+{
+	uint8 *bits;		/* Bitset data (1=alive, 0=dead) */
+	uint32 num_docs;	/* Total doc count (bitset capacity) */
+	uint32 alive_count; /* Number of alive docs */
+} TpAliveBitset;
+
+/*
+ * Byte size of bitset data for a given doc count.
+ */
+static inline uint32
+tp_alive_bitset_size(uint32 num_docs)
+{
+	return (num_docs + 7) / 8;
+}
+
+/*
+ * Check if a doc is alive by reading from segment pages.
+ * Used in the hot scoring path — reads one byte via paged I/O.
+ * Returns true if the segment has no bitset (pre-V5) or if the
+ * doc's bit is set.
+ */
+static inline bool
+tp_segment_is_alive(TpSegmentReader *reader, uint32 doc_id)
+{
+	uint64 byte_offset;
+	uint8  byte;
+
+	if (reader->header->alive_bitset_offset == 0)
+		return true;
+
+	byte_offset = reader->header->alive_bitset_offset + (doc_id >> 3);
+	tp_segment_read(reader, byte_offset, &byte, 1);
+	return (byte >> (doc_id & 7)) & 1;
+}
+
+/*
+ * Create an in-memory bitset with all docs alive.
+ * Used during VACUUM to load, modify, and write back.
+ */
+extern TpAliveBitset *tp_alive_bitset_create(uint32 num_docs);
+
+/*
+ * Load the alive bitset from a segment into memory.
+ * Returns NULL if the segment has no bitset (pre-V5).
+ */
+extern TpAliveBitset *tp_alive_bitset_load(TpSegmentReader *reader);
+
+/*
+ * Mark a doc as dead.  Returns true if it was alive
+ * (i.e., the alive_count was decremented).
+ */
+extern bool tp_alive_bitset_mark_dead(TpAliveBitset *bitset, uint32 doc_id);
+
+/*
+ * Write the in-memory bitset back to segment pages and
+ * update the segment header's alive_count.  Uses
+ * GenericXLog for crash safety.
+ */
+extern void tp_alive_bitset_write(
+		TpAliveBitset *bitset, TpSegmentReader *reader, Relation index);
+
+/*
+ * Free an in-memory bitset.
+ */
+extern void tp_alive_bitset_free(TpAliveBitset *bitset);

--- a/src/segment/alive_bitset.h
+++ b/src/segment/alive_bitset.h
@@ -40,9 +40,9 @@ tp_alive_bitset_size(uint32 num_docs)
 
 /*
  * Check if a doc is alive by reading from segment pages.
- * Used in the hot scoring path — reads one byte via paged I/O.
- * Returns true if the segment has no bitset (pre-V5) or if the
- * doc's bit is set.
+ * Used in the hot scoring path — reads one byte via paged
+ * I/O.  Returns true if the segment has no bitset (pre-V5)
+ * or if all docs are alive, or if the doc's bit is set.
  */
 static inline bool
 tp_segment_is_alive(TpSegmentReader *reader, uint32 doc_id)
@@ -50,13 +50,81 @@ tp_segment_is_alive(TpSegmentReader *reader, uint32 doc_id)
 	uint64 byte_offset;
 	uint8  byte;
 
-	if (reader->header->alive_bitset_offset == 0)
+	if (reader->header->alive_bitset_offset == 0 ||
+		reader->header->alive_count == reader->header->num_docs)
 		return true;
 
 	byte_offset = reader->header->alive_bitset_offset + (doc_id >> 3);
 	tp_segment_read(reader, byte_offset, &byte, 1);
 	return (byte >> (doc_id & 7)) & 1;
 }
+
+/*
+ * Batch alive check for a range of doc_ids (used by BMW to
+ * amortize paged I/O across a posting block).  Reads the
+ * bitset bytes covering [first_doc_id, last_doc_id] into a
+ * caller-supplied buffer, then provides a fast bit-test macro.
+ *
+ * Usage:
+ *   uint8 buf[TP_ALIVE_BLOCK_BUF_SIZE];
+ *   uint32 base;
+ *   tp_alive_bitset_load_range(reader, first, last, buf, &base);
+ *   if (TP_ALIVE_BIT(buf, base, doc_id)) { ... }
+ */
+#define TP_ALIVE_BLOCK_BUF_SIZE 20 /* ceil(128/8) + 2 slack */
+
+/*
+ * Load the bitset byte range covering [first_doc_id, last_doc_id].
+ * Sets *base_byte_out to the byte index of the first byte loaded,
+ * so callers can test bits with TP_ALIVE_BIT.
+ *
+ * Returns false if all docs are alive (caller can skip checks).
+ */
+static inline bool
+tp_alive_bitset_load_range(
+		TpSegmentReader *reader,
+		uint32			 first_doc_id,
+		uint32			 last_doc_id,
+		uint8			*buf,
+		uint32			*base_byte_out)
+{
+	uint32 first_byte;
+	uint32 last_byte;
+	uint32 nbytes;
+
+	if (reader->header->alive_bitset_offset == 0 ||
+		reader->header->alive_count == reader->header->num_docs)
+		return false;
+
+	first_byte = first_doc_id >> 3;
+	last_byte  = last_doc_id >> 3;
+	nbytes	   = last_byte - first_byte + 1;
+
+	Assert(nbytes <= TP_ALIVE_BLOCK_BUF_SIZE);
+
+	tp_segment_read(
+			reader,
+			reader->header->alive_bitset_offset + first_byte,
+			buf,
+			nbytes);
+
+	*base_byte_out = first_byte;
+	return true;
+}
+
+/*
+ * Test a doc_id against a pre-loaded bitset range.
+ * base_byte is the value set by tp_alive_bitset_load_range.
+ */
+#define TP_ALIVE_BIT(buf, base_byte, doc_id) \
+	((buf[((doc_id) >> 3) - (base_byte)] >> ((doc_id) & 7)) & 1)
+
+/*
+ * Initialize a raw bitset buffer to all-alive for num_docs.
+ * Sets all bits to 1, then clears trailing bits beyond num_docs.
+ * Used by segment writers to avoid duplicating the mask logic.
+ */
+extern void tp_alive_bitset_init_data(uint8 *buf, uint32 num_docs);
 
 /*
  * Create an in-memory bitset with all docs alive.
@@ -79,7 +147,9 @@ extern bool tp_alive_bitset_mark_dead(TpAliveBitset *bitset, uint32 doc_id);
 /*
  * Write the in-memory bitset back to segment pages and
  * update the segment header's alive_count.  Uses
- * GenericXLog for crash safety.
+ * GenericXLog for crash safety.  The header update is
+ * batched into the final bitset page's GenericXLog
+ * transaction for atomicity.
  */
 extern void tp_alive_bitset_write(
 		TpAliveBitset *bitset, TpSegmentReader *reader, Relation index);

--- a/src/segment/alive_bitset.h
+++ b/src/segment/alive_bitset.h
@@ -60,66 +60,6 @@ tp_segment_is_alive(TpSegmentReader *reader, uint32 doc_id)
 }
 
 /*
- * Batch alive check for a range of doc_ids (used by BMW to
- * amortize paged I/O across a posting block).  Reads the
- * bitset bytes covering [first_doc_id, last_doc_id] into a
- * caller-supplied buffer, then provides a fast bit-test macro.
- *
- * Usage:
- *   uint8 buf[TP_ALIVE_BLOCK_BUF_SIZE];
- *   uint32 base;
- *   tp_alive_bitset_load_range(reader, first, last, buf, &base);
- *   if (TP_ALIVE_BIT(buf, base, doc_id)) { ... }
- */
-#define TP_ALIVE_BLOCK_BUF_SIZE 20 /* ceil(128/8) + 2 slack */
-
-/*
- * Load the bitset byte range covering [first_doc_id, last_doc_id].
- * Sets *base_byte_out to the byte index of the first byte loaded,
- * so callers can test bits with TP_ALIVE_BIT.
- *
- * Returns false if all docs are alive (caller can skip checks).
- */
-static inline bool
-tp_alive_bitset_load_range(
-		TpSegmentReader *reader,
-		uint32			 first_doc_id,
-		uint32			 last_doc_id,
-		uint8			*buf,
-		uint32			*base_byte_out)
-{
-	uint32 first_byte;
-	uint32 last_byte;
-	uint32 nbytes;
-
-	if (reader->header->alive_bitset_offset == 0 ||
-		reader->header->alive_count == reader->header->num_docs)
-		return false;
-
-	first_byte = first_doc_id >> 3;
-	last_byte  = last_doc_id >> 3;
-	nbytes	   = last_byte - first_byte + 1;
-
-	Assert(nbytes <= TP_ALIVE_BLOCK_BUF_SIZE);
-
-	tp_segment_read(
-			reader,
-			reader->header->alive_bitset_offset + first_byte,
-			buf,
-			nbytes);
-
-	*base_byte_out = first_byte;
-	return true;
-}
-
-/*
- * Test a doc_id against a pre-loaded bitset range.
- * base_byte is the value set by tp_alive_bitset_load_range.
- */
-#define TP_ALIVE_BIT(buf, base_byte, doc_id) \
-	((buf[((doc_id) >> 3) - (base_byte)] >> ((doc_id) & 7)) & 1)
-
-/*
  * Initialize a raw bitset buffer to all-alive for num_docs.
  * Sets all bits to 1, then clears trailing bits beyond num_docs.
  * Used by segment writers to avoid duplicating the mask logic.

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -1330,13 +1330,7 @@ write_merged_segment_to_sink(
 		uint32 bitset_size = tp_alive_bitset_size(docmap->num_docs);
 		uint8 *bitset_data = palloc(bitset_size);
 
-		memset(bitset_data, 0xFF, bitset_size);
-		if (docmap->num_docs % 8 != 0)
-		{
-			uint8 mask = (1 << (docmap->num_docs % 8)) - 1;
-
-			bitset_data[bitset_size - 1] &= mask;
-		}
+		tp_alive_bitset_init_data(bitset_data, docmap->num_docs);
 		merge_sink_write(sink, bitset_data, bitset_size);
 		pfree(bitset_data);
 	}

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -26,6 +26,9 @@
 #include "segment_io.h"
 #include "state/metapage.h"
 
+/* Sentinel for dead docs in old_to_new mapping */
+#define TP_MERGE_DOC_DEAD UINT32_MAX
+
 /* GUC variable for segment compression */
 extern bool tp_compress_segments;
 
@@ -770,6 +773,11 @@ build_merged_docmap(
 
 			for (j = 0; j < ms->num_docs; j++)
 			{
+				if (!tp_segment_is_alive(sources[i].reader, j))
+				{
+					mapping->old_to_new[i][j] = TP_MERGE_DOC_DEAD;
+					continue;
+				}
 				mapping->old_to_new[i][j]  = new_doc_id;
 				out_pages[new_doc_id]	   = ms->ctid_pages[j];
 				out_offsets[new_doc_id]	   = ms->ctid_offsets[j];
@@ -797,6 +805,14 @@ build_merged_docmap(
 				BlockNumber			 pg;
 				OffsetNumber		 off;
 
+				/* Skip past dead docs */
+				while (ms->cursor < ms->num_docs &&
+					   !tp_segment_is_alive(sources[i].reader, ms->cursor))
+				{
+					mapping->old_to_new[i][ms->cursor] = TP_MERGE_DOC_DEAD;
+					ms->cursor++;
+				}
+
 				if (ms->cursor >= ms->num_docs)
 					continue;
 
@@ -812,7 +828,8 @@ build_merged_docmap(
 				}
 			}
 
-			Assert(min_src >= 0);
+			if (min_src < 0)
+				break; /* All sources exhausted */
 
 			{
 				TpDocmapMergeSource *ms	 = &msources[min_src];
@@ -831,8 +848,8 @@ build_merged_docmap(
 	/* Step 4: Package into a TpDocMapBuilder (finalized, no hash table) */
 	docmap				 = palloc0(sizeof(TpDocMapBuilder));
 	docmap->ctid_to_id	 = NULL; /* No hash table needed */
-	docmap->num_docs	 = total_docs;
-	docmap->capacity	 = total_docs;
+	docmap->num_docs	 = new_doc_id;
+	docmap->capacity	 = new_doc_id;
 	docmap->finalized	 = true;
 	docmap->ctid_pages	 = out_pages;
 	docmap->ctid_offsets = out_offsets;
@@ -979,6 +996,25 @@ write_merged_segment_to_sink(
 	/* Build docmap and direct mapping arrays from source segments */
 	docmap = build_merged_docmap(
 			sources, num_sources, &doc_mapping, disjoint_sources);
+
+	/* Recompute total_tokens from live docs' fieldnorms */
+	{
+		uint64 live_tokens = 0;
+
+		for (uint32 d = 0; d < docmap->num_docs; d++)
+			live_tokens += decode_fieldnorm(docmap->fieldnorms[d]);
+		total_tokens = live_tokens;
+	}
+
+	/*
+	 * If all docs are dead, nothing to write. Clean up and return.
+	 */
+	if (docmap->num_docs == 0)
+	{
+		free_merge_doc_mapping(&doc_mapping);
+		tp_docmap_destroy(docmap);
+		return;
+	}
 
 	/* Prepare header placeholder */
 	memset(&header, 0, sizeof(TpSegmentHeader));
@@ -1156,10 +1192,16 @@ write_merged_segment_to_sink(
 							&psources[src].block_postings
 									 [psources[src].current_in_block];
 					int	   seg_idx = terms[i].segment_refs[src].segment_idx;
-					uint32 new_doc_id =
+					uint32 new_id =
 							doc_mapping.old_to_new[seg_idx][bp->doc_id];
 
-					block_buf[block_count].doc_id	 = new_doc_id;
+					if (new_id == TP_MERGE_DOC_DEAD)
+					{
+						posting_source_advance_fast(&psources[src]);
+						continue;
+					}
+
+					block_buf[block_count].doc_id	 = new_id;
 					block_buf[block_count].frequency = bp->frequency;
 					block_buf[block_count].fieldnorm = bp->fieldnorm;
 					block_buf[block_count].reserved	 = 0;
@@ -1193,10 +1235,16 @@ write_merged_segment_to_sink(
 				{
 					int src_idx = terms[i].segment_refs[min_idx].segment_idx;
 					uint32 old_doc_id = psources[min_idx].current.old_doc_id;
-					uint32 new_doc_id =
+					uint32 new_id =
 							doc_mapping.old_to_new[src_idx][old_doc_id];
 
-					block_buf[block_count].doc_id = new_doc_id;
+					if (new_id == TP_MERGE_DOC_DEAD)
+					{
+						posting_source_advance(&psources[min_idx]);
+						continue;
+					}
+
+					block_buf[block_count].doc_id = new_id;
 					block_buf[block_count].frequency =
 							psources[min_idx].current.frequency;
 					block_buf[block_count].fieldnorm =

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -14,6 +14,7 @@
 #include <utils/memutils.h>
 #include <utils/timestamp.h>
 
+#include "alive_bitset.h"
 #include "compression.h"
 #include "constants.h"
 #include "docmap.h"
@@ -1271,6 +1272,25 @@ write_merged_segment_to_sink(
 				sink,
 				docmap->ctid_offsets,
 				docmap->num_docs * sizeof(OffsetNumber));
+	}
+
+	/* Write alive bitset (all alive — dead docs already excluded) */
+	header.alive_bitset_offset = sink->current_offset;
+	header.alive_count		   = docmap->num_docs;
+	if (docmap->num_docs > 0)
+	{
+		uint32 bitset_size = tp_alive_bitset_size(docmap->num_docs);
+		uint8 *bitset_data = palloc(bitset_size);
+
+		memset(bitset_data, 0xFF, bitset_size);
+		if (docmap->num_docs % 8 != 0)
+		{
+			uint8 mask = (1 << (docmap->num_docs % 8)) - 1;
+
+			bitset_data[bitset_size - 1] &= mask;
+		}
+		merge_sink_write(sink, bitset_data, bitset_size);
+		pfree(bitset_data);
 	}
 
 	/* Finalize data_size */

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -225,10 +225,28 @@ tp_segment_open_ex(Relation index, BlockNumber root_block, bool load_ctids)
 			header->num_docs			= v3.num_docs;
 			header->total_tokens		= v3.total_tokens;
 			header->page_index			= v3.page_index;
+
+			/* V3 has no alive bitset */
+			header->alive_bitset_offset = 0;
+			header->alive_count			= header->num_docs;
 		}
-		else if (raw_version == TP_SEGMENT_FORMAT_VERSION)
+		else if (raw_version <= TP_SEGMENT_FORMAT_VERSION_4)
 		{
-			/* V4: direct copy */
+			/*
+			 * V4 header: same layout as V5 but without
+			 * alive_bitset_offset / alive_count.  Copy the
+			 * raw bytes that exist and zero-init the new fields.
+			 */
+			memcpy(reader->header,
+				   PageGetContents(header_page),
+				   offsetof(TpSegmentHeader, alive_bitset_offset));
+			header						= reader->header;
+			header->alive_bitset_offset = 0;
+			header->alive_count			= header->num_docs;
+		}
+		else if (raw_version <= TP_SEGMENT_FORMAT_VERSION)
+		{
+			/* V5+: full header */
 			memcpy(reader->header,
 				   PageGetContents(header_page),
 				   sizeof(TpSegmentHeader));
@@ -1427,6 +1445,8 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	existing_header->fieldnorm_offset	 = header.fieldnorm_offset;
 	existing_header->ctid_pages_offset	 = header.ctid_pages_offset;
 	existing_header->ctid_offsets_offset = header.ctid_offsets_offset;
+	existing_header->alive_bitset_offset = header.alive_bitset_offset;
+	existing_header->alive_count		 = header.alive_count;
 	existing_header->num_docs			 = header.num_docs;
 	existing_header->data_size			 = header.data_size;
 	existing_header->num_pages			 = header.num_pages;

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -1737,6 +1737,14 @@ tp_dump_segment_to_output(
 	dump_printf(out, "Data size: %" PRIu64 " bytes\n", header.data_size);
 	dump_printf(out, "Level: %u\n", header.level);
 	dump_printf(out, "Page index: block %u\n", header.page_index);
+	dump_printf(
+			out, "Alive: %u / %u docs\n", header.alive_count, header.num_docs);
+	if (header.alive_bitset_offset > 0)
+		dump_printf(
+				out,
+				"Alive bitset offset: %" PRIu64 " (%u bytes)\n",
+				header.alive_bitset_offset,
+				tp_alive_bitset_size(header.num_docs));
 
 	/* Corpus statistics */
 	dump_printf(out, "\n=== CORPUS STATISTICS ===\n");

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -247,16 +247,16 @@ tp_segment_open_ex(Relation index, BlockNumber root_block, bool load_ctids)
 				   src,
 				   offsetof(TpSegmentHeader, alive_bitset_offset));
 
-			/* Second half: num_terms … page_index.
-			 * In V4 on-disk, these start right after
-			 * ctid_offsets_offset — which is the same byte offset
-			 * as alive_bitset_offset in V5. */
+			/*
+			 * Second half: num_terms … page_index.  In V4
+			 * on-disk, these start right after
+			 * ctid_offsets_offset, which is the same byte
+			 * offset as alive_bitset_offset in V5.
+			 */
 			memcpy(&reader->header->num_terms,
 				   src + offsetof(TpSegmentHeader, alive_bitset_offset),
-				   sizeof(uint32)			/* num_terms */
-						   + sizeof(uint32) /* num_docs */
-						   + sizeof(uint64) /* total_tokens */
-						   + sizeof(BlockNumber) /* page_index */);
+				   sizeof(TpSegmentHeader) -
+						   offsetof(TpSegmentHeader, num_terms));
 
 			header						= reader->header;
 			header->alive_bitset_offset = 0;
@@ -1320,13 +1320,7 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 		uint32 bitset_size = tp_alive_bitset_size(docmap->num_docs);
 		uint8 *bitset_data = palloc(bitset_size);
 
-		memset(bitset_data, 0xFF, bitset_size);
-		if (docmap->num_docs % 8 != 0)
-		{
-			uint8 mask = (1 << (docmap->num_docs % 8)) - 1;
-
-			bitset_data[bitset_size - 1] &= mask;
-		}
+		tp_alive_bitset_init_data(bitset_data, docmap->num_docs);
 		tp_segment_writer_write(&writer, bitset_data, bitset_size);
 		pfree(bitset_data);
 	}

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -25,6 +25,7 @@
 #include <utils/memutils.h>
 #include <utils/timestamp.h>
 
+#include "alive_bitset.h"
 #include "compression.h"
 #include "debug/dump.h"
 #include "dictionary.h"
@@ -1292,6 +1293,25 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 				&writer,
 				docmap->ctid_offsets,
 				docmap->num_docs * sizeof(OffsetNumber));
+	}
+
+	/* Write alive bitset (all alive) */
+	header.alive_bitset_offset = writer.current_offset;
+	header.alive_count		   = docmap->num_docs;
+	if (docmap->num_docs > 0)
+	{
+		uint32 bitset_size = tp_alive_bitset_size(docmap->num_docs);
+		uint8 *bitset_data = palloc(bitset_size);
+
+		memset(bitset_data, 0xFF, bitset_size);
+		if (docmap->num_docs % 8 != 0)
+		{
+			uint8 mask = (1 << (docmap->num_docs % 8)) - 1;
+
+			bitset_data[bitset_size - 1] &= mask;
+		}
+		tp_segment_writer_write(&writer, bitset_data, bitset_size);
+		pfree(bitset_data);
 	}
 
 	/* Update num_docs to actual count from this segment */

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -234,13 +234,30 @@ tp_segment_open_ex(Relation index, BlockNumber root_block, bool load_ctids)
 		else if (raw_version <= TP_SEGMENT_FORMAT_VERSION_4)
 		{
 			/*
-			 * V4 header: same layout as V5 but without
-			 * alive_bitset_offset / alive_count.  Copy the
-			 * raw bytes that exist and zero-init the new fields.
+			 * V4 header: identical to V5 except the alive_bitset
+			 * fields (alive_bitset_offset, alive_count) are absent.
+			 * The fields before and after the gap share the same
+			 * names but sit at different struct offsets, so we copy
+			 * in two halves and zero-init the gap.
 			 */
+			const char *src = PageGetContents(header_page);
+
+			/* First half: magic … ctid_offsets_offset (same layout) */
 			memcpy(reader->header,
-				   PageGetContents(header_page),
+				   src,
 				   offsetof(TpSegmentHeader, alive_bitset_offset));
+
+			/* Second half: num_terms … page_index.
+			 * In V4 on-disk, these start right after
+			 * ctid_offsets_offset — which is the same byte offset
+			 * as alive_bitset_offset in V5. */
+			memcpy(&reader->header->num_terms,
+				   src + offsetof(TpSegmentHeader, alive_bitset_offset),
+				   sizeof(uint32)			/* num_terms */
+						   + sizeof(uint32) /* num_docs */
+						   + sizeof(uint64) /* total_tokens */
+						   + sizeof(BlockNumber) /* page_index */);
+
 			header						= reader->header;
 			header->alive_bitset_offset = 0;
 			header->alive_count			= header->num_docs;

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -1693,10 +1693,26 @@ tp_dump_segment_to_output(
 			header.fieldnorm_offset	   = (uint64)v3.fieldnorm_offset;
 			header.ctid_pages_offset   = (uint64)v3.ctid_pages_offset;
 			header.ctid_offsets_offset = (uint64)v3.ctid_offsets_offset;
+			header.alive_bitset_offset = 0;
+			header.alive_count		   = v3.num_docs;
 			header.num_terms		   = v3.num_terms;
 			header.num_docs			   = v3.num_docs;
 			header.total_tokens		   = v3.total_tokens;
 			header.page_index		   = v3.page_index;
+		}
+		else if (raw_version <= TP_SEGMENT_FORMAT_VERSION_4)
+		{
+			const char *src = PageGetContents(header_page);
+
+			memcpy(&header,
+				   src,
+				   offsetof(TpSegmentHeader, alive_bitset_offset));
+			header.alive_bitset_offset = 0;
+			memcpy(&header.num_terms,
+				   src + offsetof(TpSegmentHeader, alive_bitset_offset),
+				   sizeof(TpSegmentHeader) -
+						   offsetof(TpSegmentHeader, num_terms));
+			header.alive_count = header.num_docs;
 		}
 		else
 		{

--- a/src/segment/segment.h
+++ b/src/segment/segment.h
@@ -66,7 +66,8 @@ typedef struct TpPageIndexSpecial
  * Segment format versions
  */
 #define TP_SEGMENT_FORMAT_VERSION_3 3 /* Legacy: uint32 offsets */
-#define TP_SEGMENT_FORMAT_VERSION	4 /* Current: uint64 offsets */
+#define TP_SEGMENT_FORMAT_VERSION_4 4 /* Legacy: no alive bitset */
+#define TP_SEGMENT_FORMAT_VERSION	5 /* Current: alive bitset */
 
 /*
  * V3 legacy segment header - preserved for reading old segments.
@@ -122,6 +123,10 @@ typedef struct TpSegmentHeader
 	uint64 fieldnorm_offset;	/* Offset to fieldnorm table */
 	uint64 ctid_pages_offset;	/* Offset to BlockNumber array */
 	uint64 ctid_offsets_offset; /* Offset to OffsetNumber array */
+
+	/* Alive bitset for tombstone tracking (V5+) */
+	uint64 alive_bitset_offset; /* Offset to alive bitset data */
+	uint32 alive_count;			/* Number of alive docs (bits set) */
 
 	/* Corpus statistics */
 	uint32 num_terms;	 /* Total unique terms */

--- a/test/expected/partial_index.out
+++ b/test/expected/partial_index.out
@@ -214,7 +214,7 @@ ORDER BY content <@>
 LIMIT 5;
  id |                  content                  |  score  
 ----+-------------------------------------------+---------
-  6 | advanced database optimization techniques | -1.1375
+  6 | advanced database optimization techniques | -0.6549
 (1 row)
 
 -- ============================================================

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -15,8 +15,11 @@ NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 100 documents, avg_length=4.00
 -- Verify initial query works
-SELECT count(*) FROM vb_test
-WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_test
+    ORDER BY content <@> to_bm25query('databases', 'vb_idx')
+    LIMIT 1000
+) q;
  count 
 -------
    100
@@ -27,8 +30,11 @@ DELETE FROM vb_test WHERE id <= 20;
 -- VACUUM to apply bitmap marking
 VACUUM vb_test;
 -- Query should return only live rows
-SELECT count(*) FROM vb_test
-WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_test
+    ORDER BY content <@> to_bm25query('databases', 'vb_idx')
+    LIMIT 1000
+) q;
  count 
 -------
     80
@@ -37,7 +43,8 @@ WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
 -- Verify no deleted rows appear
 SELECT count(*) FROM (
     SELECT id FROM vb_test
-    WHERE content <@> to_bm25query('databases', 'vb_idx') < 0
+    ORDER BY content <@> to_bm25query('databases', 'vb_idx')
+    LIMIT 1000
 ) q WHERE id <= 20;
  count 
 -------
@@ -61,8 +68,11 @@ NOTICE:  BM25 index build completed: 50 documents, avg_length=3.00
 DELETE FROM vb_full;
 VACUUM vb_full;
 -- Should return 0 results
-SELECT count(*) FROM vb_full
-WHERE content <@> to_bm25query('fulldelete', 'vb_full_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_full
+    ORDER BY content <@> to_bm25query('fulldelete', 'vb_full_idx')
+    LIMIT 1000
+) q;
  count 
 -------
      0
@@ -70,8 +80,11 @@ WHERE content <@> to_bm25query('fulldelete', 'vb_full_idx') < 0;
 
 -- Index should still be usable after inserting new rows
 INSERT INTO vb_full (content) VALUES ('fresh document about topics');
-SELECT count(*) FROM vb_full
-WHERE content <@> to_bm25query('fresh', 'vb_full_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_full
+    ORDER BY content <@> to_bm25query('fresh', 'vb_full_idx')
+    LIMIT 1000
+) q;
  count 
 -------
      1
@@ -92,8 +105,11 @@ NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 50 documents, avg_length=4.00
 -- Verify alpha matches
-SELECT count(*) > 0 AS has_alpha FROM vb_reuse
-WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+SELECT count(*) > 0 AS has_alpha FROM (
+    SELECT id FROM vb_reuse
+    ORDER BY content <@> to_bm25query('alpha', 'vb_reuse_idx')
+    LIMIT 1000
+) q;
  has_alpha 
 -----------
  t
@@ -107,16 +123,22 @@ INSERT INTO vb_reuse (content)
 SELECT 'beta keyword document ' || i
 FROM generate_series(1, 50) i;
 -- alpha should return nothing
-SELECT count(*) FROM vb_reuse
-WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_reuse
+    ORDER BY content <@> to_bm25query('alpha', 'vb_reuse_idx')
+    LIMIT 1000
+) q;
  count 
 -------
      0
 (1 row)
 
 -- beta should return results
-SELECT count(*) > 0 AS has_beta FROM vb_reuse
-WHERE content <@> to_bm25query('beta', 'vb_reuse_idx') < 0;
+SELECT count(*) > 0 AS has_beta FROM (
+    SELECT id FROM vb_reuse
+    ORDER BY content <@> to_bm25query('beta', 'vb_reuse_idx')
+    LIMIT 1000
+) q;
  has_beta 
 ----------
  t
@@ -158,8 +180,11 @@ SELECT bm25_spill_index('vb_multi_idx');
 DELETE FROM vb_multi WHERE id <= 25;
 VACUUM vb_multi;
 -- Should find docs from both batches (minus deleted)
-SELECT count(*) FROM vb_multi
-WHERE content <@> to_bm25query('search', 'vb_multi_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_multi
+    ORDER BY content <@> to_bm25query('search', 'vb_multi_idx')
+    LIMIT 1000
+) q;
  count 
 -------
     75
@@ -190,8 +215,11 @@ SELECT bm25_force_merge('vb_merge_idx');
 (1 row)
 
 -- Query should still work correctly
-SELECT count(*) FROM vb_merge
-WHERE content <@> to_bm25query('merge', 'vb_merge_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_merge
+    ORDER BY content <@> to_bm25query('merge', 'vb_merge_idx')
+    LIMIT 1000
+) q;
  count 
 -------
     25
@@ -199,7 +227,7 @@ WHERE content <@> to_bm25query('merge', 'vb_merge_idx') < 0;
 
 DROP TABLE vb_merge;
 -- =============================================================
--- Test 6: Score correctness after deletes
+-- Test 6: Score correctness after deletes (multi-term BMW)
 -- =============================================================
 CREATE TABLE vb_scores (id serial PRIMARY KEY, content text);
 INSERT INTO vb_scores (content) VALUES
@@ -222,13 +250,11 @@ NOTICE:  BM25 index build completed: 10 documents, avg_length=3.00
 -- Delete some rows
 DELETE FROM vb_scores WHERE content LIKE '%delete me%';
 VACUUM vb_scores;
--- Query with LIMIT (uses BMW)
+-- Multi-term query via BMW index scan
 SELECT id,
        content <@> to_bm25query('performance database',
                                 'vb_scores_idx') AS score
 FROM vb_scores
-WHERE content <@> to_bm25query('performance database',
-                               'vb_scores_idx') < 0
 ORDER BY content <@> to_bm25query('performance database',
                                   'vb_scores_idx')
 LIMIT 5;
@@ -258,8 +284,11 @@ NOTICE:  BM25 index build completed: 200 documents, avg_length=4.00
 -- Delete 150 of 200 rows (well past the initial 64-element array)
 DELETE FROM vb_many WHERE id <= 150;
 VACUUM vb_many;
-SELECT count(*) FROM vb_many
-WHERE content <@> to_bm25query('searchable', 'vb_many_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_many
+    ORDER BY content <@> to_bm25query('searchable', 'vb_many_idx')
+    LIMIT 1000
+) q;
  count 
 -------
     50
@@ -316,8 +345,11 @@ SELECT bm25_force_merge('vb_mm_idx');
 (1 row)
 
 -- 150 total - 30 deleted = 120 live
-SELECT count(*) FROM vb_multimerge
-WHERE content <@> to_bm25query('target', 'vb_mm_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_multimerge
+    ORDER BY content <@> to_bm25query('target', 'vb_mm_idx')
+    LIMIT 1000
+) q;
  count 
 -------
    120
@@ -359,8 +391,11 @@ SELECT bm25_force_merge('vb_alldead_idx');
  
 (1 row)
 
-SELECT count(*) FROM vb_alldead
-WHERE content <@> to_bm25query('alldead', 'vb_alldead_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_alldead
+    ORDER BY content <@> to_bm25query('alldead', 'vb_alldead_idx')
+    LIMIT 1000
+) q;
  count 
 -------
      0
@@ -368,8 +403,11 @@ WHERE content <@> to_bm25query('alldead', 'vb_alldead_idx') < 0;
 
 -- Insert fresh data to verify index still works
 INSERT INTO vb_alldead (content) VALUES ('revival document here');
-SELECT count(*) FROM vb_alldead
-WHERE content <@> to_bm25query('revival', 'vb_alldead_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_alldead
+    ORDER BY content <@> to_bm25query('revival', 'vb_alldead_idx')
+    LIMIT 1000
+) q;
  count 
 -------
      1

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -242,4 +242,159 @@ LIMIT 5;
 (5 rows)
 
 DROP TABLE vb_scores;
+-- =============================================================
+-- Test 7: Many deletes (>64 per segment, exercises realloc)
+-- =============================================================
+CREATE TABLE vb_many (id serial PRIMARY KEY, content text);
+INSERT INTO vb_many (content)
+SELECT 'manydelete document ' || i || ' searchable'
+FROM generate_series(1, 200) i;
+CREATE INDEX vb_many_idx ON vb_many
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_many_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 200 documents, avg_length=4.00
+-- Delete 150 of 200 rows (well past the initial 64-element array)
+DELETE FROM vb_many WHERE id <= 150;
+VACUUM vb_many;
+SELECT count(*) FROM vb_many
+WHERE content <@> to_bm25query('searchable', 'vb_many_idx') < 0;
+ count 
+-------
+    50
+(1 row)
+
+DROP TABLE vb_many;
+-- =============================================================
+-- Test 8: Multi-segment merge with dead docs
+-- =============================================================
+CREATE TABLE vb_multimerge (id serial PRIMARY KEY, content text);
+INSERT INTO vb_multimerge (content)
+SELECT 'batch1 doc ' || i || ' target'
+FROM generate_series(1, 50) i;
+CREATE INDEX vb_mm_idx ON vb_multimerge
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_mm_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 50 documents, avg_length=4.00
+SELECT bm25_spill_index('vb_mm_idx');
+ bm25_spill_index 
+------------------
+                 
+(1 row)
+
+INSERT INTO vb_multimerge (content)
+SELECT 'batch2 doc ' || i || ' target'
+FROM generate_series(1, 50) i;
+SELECT bm25_spill_index('vb_mm_idx');
+ bm25_spill_index 
+------------------
+                4
+(1 row)
+
+INSERT INTO vb_multimerge (content)
+SELECT 'batch3 doc ' || i || ' target'
+FROM generate_series(1, 50) i;
+SELECT bm25_spill_index('vb_mm_idx');
+ bm25_spill_index 
+------------------
+                7
+(1 row)
+
+-- Delete from each batch
+DELETE FROM vb_multimerge WHERE id <= 10;
+DELETE FROM vb_multimerge WHERE id > 50 AND id <= 60;
+DELETE FROM vb_multimerge WHERE id > 100 AND id <= 110;
+VACUUM vb_multimerge;
+-- Merge all segments — exercises N-way merge with dead docs
+SELECT bm25_force_merge('vb_mm_idx');
+ bm25_force_merge 
+------------------
+ 
+(1 row)
+
+-- 150 total - 30 deleted = 120 live
+SELECT count(*) FROM vb_multimerge
+WHERE content <@> to_bm25query('target', 'vb_mm_idx') < 0;
+ count 
+-------
+   120
+(1 row)
+
+DROP TABLE vb_multimerge;
+-- =============================================================
+-- Test 9: All docs dead across segments then merge
+-- =============================================================
+CREATE TABLE vb_alldead (id serial PRIMARY KEY, content text);
+INSERT INTO vb_alldead (content)
+SELECT 'alldead doc ' || i FROM generate_series(1, 30) i;
+CREATE INDEX vb_alldead_idx ON vb_alldead
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_alldead_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 30 documents, avg_length=3.00
+SELECT bm25_spill_index('vb_alldead_idx');
+ bm25_spill_index 
+------------------
+                 
+(1 row)
+
+INSERT INTO vb_alldead (content)
+SELECT 'alldead second ' || i FROM generate_series(1, 30) i;
+SELECT bm25_spill_index('vb_alldead_idx');
+ bm25_spill_index 
+------------------
+                4
+(1 row)
+
+DELETE FROM vb_alldead;
+VACUUM vb_alldead;
+-- Both segments should be dropped — merge is a no-op
+SELECT bm25_force_merge('vb_alldead_idx');
+ bm25_force_merge 
+------------------
+ 
+(1 row)
+
+SELECT count(*) FROM vb_alldead
+WHERE content <@> to_bm25query('alldead', 'vb_alldead_idx') < 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Insert fresh data to verify index still works
+INSERT INTO vb_alldead (content) VALUES ('revival document here');
+SELECT count(*) FROM vb_alldead
+WHERE content <@> to_bm25query('revival', 'vb_alldead_idx') < 0;
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE vb_alldead;
+-- =============================================================
+-- Test 10: Dump shows alive bitset info
+-- =============================================================
+CREATE TABLE vb_dump (id serial PRIMARY KEY, content text);
+INSERT INTO vb_dump (content)
+SELECT 'dump test ' || i FROM generate_series(1, 10) i;
+CREATE INDEX vb_dump_idx ON vb_dump
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_dump_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 10 documents, avg_length=3.00
+-- Verify dump output includes alive bitset info
+SELECT bm25_dump_index('vb_dump_idx') LIKE '%Alive: 10 / 10 docs%'
+    AS has_alive_info;
+ has_alive_info 
+----------------
+ t
+(1 row)
+
+DROP TABLE vb_dump;
 DROP EXTENSION pg_textsearch;

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -1,0 +1,245 @@
+-- Test alive bitset tombstone tracking during VACUUM
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+INFO:  pg_textsearch v1.0.0-dev
+-- =============================================================
+-- Test 1: Basic VACUUM with bitmap marking
+-- =============================================================
+CREATE TABLE vb_test (id serial PRIMARY KEY, content text);
+INSERT INTO vb_test (content)
+SELECT 'document number ' || i || ' about databases'
+FROM generate_series(1, 100) i;
+CREATE INDEX vb_idx ON vb_test
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 100 documents, avg_length=4.00
+-- Verify initial query works
+SELECT count(*) FROM vb_test
+WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+ count 
+-------
+   100
+(1 row)
+
+-- Delete some rows
+DELETE FROM vb_test WHERE id <= 20;
+-- VACUUM to apply bitmap marking
+VACUUM vb_test;
+-- Query should return only live rows
+SELECT count(*) FROM vb_test
+WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+ count 
+-------
+    80
+(1 row)
+
+-- Verify no deleted rows appear
+SELECT count(*) FROM (
+    SELECT id FROM vb_test
+    WHERE content <@> to_bm25query('databases', 'vb_idx') < 0
+) q WHERE id <= 20;
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE vb_test;
+-- =============================================================
+-- Test 2: Full segment delete — segment should be dropped
+-- =============================================================
+CREATE TABLE vb_full (id serial PRIMARY KEY, content text);
+INSERT INTO vb_full (content)
+SELECT 'fulldelete document ' || i
+FROM generate_series(1, 50) i;
+CREATE INDEX vb_full_idx ON vb_full
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_full_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 50 documents, avg_length=3.00
+DELETE FROM vb_full;
+VACUUM vb_full;
+-- Should return 0 results
+SELECT count(*) FROM vb_full
+WHERE content <@> to_bm25query('fulldelete', 'vb_full_idx') < 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Index should still be usable after inserting new rows
+INSERT INTO vb_full (content) VALUES ('fresh document about topics');
+SELECT count(*) FROM vb_full
+WHERE content <@> to_bm25query('fresh', 'vb_full_idx') < 0;
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE vb_full;
+-- =============================================================
+-- Test 3: CTID reuse correctness
+-- =============================================================
+CREATE TABLE vb_reuse (id serial PRIMARY KEY, content text);
+INSERT INTO vb_reuse (content)
+SELECT 'alpha keyword document ' || i
+FROM generate_series(1, 50) i;
+CREATE INDEX vb_reuse_idx ON vb_reuse
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_reuse_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 50 documents, avg_length=4.00
+-- Verify alpha matches
+SELECT count(*) > 0 AS has_alpha FROM vb_reuse
+WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+ has_alpha 
+-----------
+ t
+(1 row)
+
+-- Delete all, VACUUM (frees CTIDs for reuse)
+DELETE FROM vb_reuse;
+VACUUM vb_reuse;
+-- Insert new rows (Postgres may reuse CTIDs)
+INSERT INTO vb_reuse (content)
+SELECT 'beta keyword document ' || i
+FROM generate_series(1, 50) i;
+-- alpha should return nothing
+SELECT count(*) FROM vb_reuse
+WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+ count 
+-------
+     0
+(1 row)
+
+-- beta should return results
+SELECT count(*) > 0 AS has_beta FROM vb_reuse
+WHERE content <@> to_bm25query('beta', 'vb_reuse_idx') < 0;
+ has_beta 
+----------
+ t
+(1 row)
+
+DROP TABLE vb_reuse;
+-- =============================================================
+-- Test 4: Multiple segments with mixed deletes
+-- =============================================================
+CREATE TABLE vb_multi (id serial PRIMARY KEY, content text);
+INSERT INTO vb_multi (content)
+SELECT 'first batch document ' || i || ' with search term'
+FROM generate_series(1, 50) i;
+CREATE INDEX vb_multi_idx ON vb_multi
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_multi_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 50 documents, avg_length=6.00
+-- Force first batch to segment
+SELECT bm25_spill_index('vb_multi_idx');
+ bm25_spill_index 
+------------------
+                 
+(1 row)
+
+-- Insert second batch
+INSERT INTO vb_multi (content)
+SELECT 'second batch document ' || i || ' with search term'
+FROM generate_series(1, 50) i;
+-- Force second batch to segment
+SELECT bm25_spill_index('vb_multi_idx');
+ bm25_spill_index 
+------------------
+                4
+(1 row)
+
+-- Delete from first batch only
+DELETE FROM vb_multi WHERE id <= 25;
+VACUUM vb_multi;
+-- Should find docs from both batches (minus deleted)
+SELECT count(*) FROM vb_multi
+WHERE content <@> to_bm25query('search', 'vb_multi_idx') < 0;
+ count 
+-------
+    75
+(1 row)
+
+DROP TABLE vb_multi;
+-- =============================================================
+-- Test 5: Merge after VACUUM cleans up dead docs
+-- =============================================================
+CREATE TABLE vb_merge (id serial PRIMARY KEY, content text);
+INSERT INTO vb_merge (content)
+SELECT 'merge test document ' || i
+FROM generate_series(1, 50) i;
+CREATE INDEX vb_merge_idx ON vb_merge
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_merge_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 50 documents, avg_length=4.00
+-- Delete half
+DELETE FROM vb_merge WHERE id <= 25;
+VACUUM vb_merge;
+-- Force merge to clean up dead docs
+SELECT bm25_force_merge('vb_merge_idx');
+ bm25_force_merge 
+------------------
+ 
+(1 row)
+
+-- Query should still work correctly
+SELECT count(*) FROM vb_merge
+WHERE content <@> to_bm25query('merge', 'vb_merge_idx') < 0;
+ count 
+-------
+    25
+(1 row)
+
+DROP TABLE vb_merge;
+-- =============================================================
+-- Test 6: Score correctness after deletes
+-- =============================================================
+CREATE TABLE vb_scores (id serial PRIMARY KEY, content text);
+INSERT INTO vb_scores (content) VALUES
+    ('database systems performance tuning'),
+    ('performance optimization techniques'),
+    ('database indexing strategies'),
+    ('query optimization in databases'),
+    ('systems programming fundamentals'),
+    ('advanced database concepts'),
+    ('delete me not relevant'),
+    ('also delete me irrelevant'),
+    ('performance database benchmark'),
+    ('indexing performance metrics');
+CREATE INDEX vb_scores_idx ON vb_scores
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_scores_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 10 documents, avg_length=3.00
+-- Delete some rows
+DELETE FROM vb_scores WHERE content LIKE '%delete me%';
+VACUUM vb_scores;
+-- Query with LIMIT (uses BMW)
+SELECT id,
+       content <@> to_bm25query('performance database',
+                                'vb_scores_idx') AS score
+FROM vb_scores
+WHERE content <@> to_bm25query('performance database',
+                               'vb_scores_idx') < 0
+ORDER BY content <@> to_bm25query('performance database',
+                                  'vb_scores_idx')
+LIMIT 5;
+ id |        score        
+----+---------------------
+  9 | -1.5869650840759277
+  1 | -1.3965292572975159
+  2 | -0.8938179016113281
+ 10 | -0.8938179016113281
+  3 | -0.6931471824645996
+(5 rows)
+
+DROP TABLE vb_scores;
+DROP EXTENSION pg_textsearch;

--- a/test/sql/vacuum_bitmap.sql
+++ b/test/sql/vacuum_bitmap.sql
@@ -1,0 +1,197 @@
+-- Test alive bitset tombstone tracking during VACUUM
+
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+-- =============================================================
+-- Test 1: Basic VACUUM with bitmap marking
+-- =============================================================
+CREATE TABLE vb_test (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_test (content)
+SELECT 'document number ' || i || ' about databases'
+FROM generate_series(1, 100) i;
+
+CREATE INDEX vb_idx ON vb_test
+    USING bm25 (content) WITH (text_config = 'english');
+
+-- Verify initial query works
+SELECT count(*) FROM vb_test
+WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+
+-- Delete some rows
+DELETE FROM vb_test WHERE id <= 20;
+
+-- VACUUM to apply bitmap marking
+VACUUM vb_test;
+
+-- Query should return only live rows
+SELECT count(*) FROM vb_test
+WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+
+-- Verify no deleted rows appear
+SELECT count(*) FROM (
+    SELECT id FROM vb_test
+    WHERE content <@> to_bm25query('databases', 'vb_idx') < 0
+) q WHERE id <= 20;
+
+DROP TABLE vb_test;
+
+-- =============================================================
+-- Test 2: Full segment delete — segment should be dropped
+-- =============================================================
+CREATE TABLE vb_full (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_full (content)
+SELECT 'fulldelete document ' || i
+FROM generate_series(1, 50) i;
+
+CREATE INDEX vb_full_idx ON vb_full
+    USING bm25 (content) WITH (text_config = 'english');
+
+DELETE FROM vb_full;
+VACUUM vb_full;
+
+-- Should return 0 results
+SELECT count(*) FROM vb_full
+WHERE content <@> to_bm25query('fulldelete', 'vb_full_idx') < 0;
+
+-- Index should still be usable after inserting new rows
+INSERT INTO vb_full (content) VALUES ('fresh document about topics');
+
+SELECT count(*) FROM vb_full
+WHERE content <@> to_bm25query('fresh', 'vb_full_idx') < 0;
+
+DROP TABLE vb_full;
+
+-- =============================================================
+-- Test 3: CTID reuse correctness
+-- =============================================================
+CREATE TABLE vb_reuse (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_reuse (content)
+SELECT 'alpha keyword document ' || i
+FROM generate_series(1, 50) i;
+
+CREATE INDEX vb_reuse_idx ON vb_reuse
+    USING bm25 (content) WITH (text_config = 'english');
+
+-- Verify alpha matches
+SELECT count(*) > 0 AS has_alpha FROM vb_reuse
+WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+
+-- Delete all, VACUUM (frees CTIDs for reuse)
+DELETE FROM vb_reuse;
+VACUUM vb_reuse;
+
+-- Insert new rows (Postgres may reuse CTIDs)
+INSERT INTO vb_reuse (content)
+SELECT 'beta keyword document ' || i
+FROM generate_series(1, 50) i;
+
+-- alpha should return nothing
+SELECT count(*) FROM vb_reuse
+WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+
+-- beta should return results
+SELECT count(*) > 0 AS has_beta FROM vb_reuse
+WHERE content <@> to_bm25query('beta', 'vb_reuse_idx') < 0;
+
+DROP TABLE vb_reuse;
+
+-- =============================================================
+-- Test 4: Multiple segments with mixed deletes
+-- =============================================================
+CREATE TABLE vb_multi (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_multi (content)
+SELECT 'first batch document ' || i || ' with search term'
+FROM generate_series(1, 50) i;
+
+CREATE INDEX vb_multi_idx ON vb_multi
+    USING bm25 (content) WITH (text_config = 'english');
+
+-- Force first batch to segment
+SELECT bm25_spill_index('vb_multi_idx');
+
+-- Insert second batch
+INSERT INTO vb_multi (content)
+SELECT 'second batch document ' || i || ' with search term'
+FROM generate_series(1, 50) i;
+
+-- Force second batch to segment
+SELECT bm25_spill_index('vb_multi_idx');
+
+-- Delete from first batch only
+DELETE FROM vb_multi WHERE id <= 25;
+
+VACUUM vb_multi;
+
+-- Should find docs from both batches (minus deleted)
+SELECT count(*) FROM vb_multi
+WHERE content <@> to_bm25query('search', 'vb_multi_idx') < 0;
+
+DROP TABLE vb_multi;
+
+-- =============================================================
+-- Test 5: Merge after VACUUM cleans up dead docs
+-- =============================================================
+CREATE TABLE vb_merge (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_merge (content)
+SELECT 'merge test document ' || i
+FROM generate_series(1, 50) i;
+
+CREATE INDEX vb_merge_idx ON vb_merge
+    USING bm25 (content) WITH (text_config = 'english');
+
+-- Delete half
+DELETE FROM vb_merge WHERE id <= 25;
+VACUUM vb_merge;
+
+-- Force merge to clean up dead docs
+SELECT bm25_force_merge('vb_merge_idx');
+
+-- Query should still work correctly
+SELECT count(*) FROM vb_merge
+WHERE content <@> to_bm25query('merge', 'vb_merge_idx') < 0;
+
+DROP TABLE vb_merge;
+
+-- =============================================================
+-- Test 6: Score correctness after deletes
+-- =============================================================
+CREATE TABLE vb_scores (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_scores (content) VALUES
+    ('database systems performance tuning'),
+    ('performance optimization techniques'),
+    ('database indexing strategies'),
+    ('query optimization in databases'),
+    ('systems programming fundamentals'),
+    ('advanced database concepts'),
+    ('delete me not relevant'),
+    ('also delete me irrelevant'),
+    ('performance database benchmark'),
+    ('indexing performance metrics');
+
+CREATE INDEX vb_scores_idx ON vb_scores
+    USING bm25 (content) WITH (text_config = 'english');
+
+-- Delete some rows
+DELETE FROM vb_scores WHERE content LIKE '%delete me%';
+VACUUM vb_scores;
+
+-- Query with LIMIT (uses BMW)
+SELECT id,
+       content <@> to_bm25query('performance database',
+                                'vb_scores_idx') AS score
+FROM vb_scores
+WHERE content <@> to_bm25query('performance database',
+                               'vb_scores_idx') < 0
+ORDER BY content <@> to_bm25query('performance database',
+                                  'vb_scores_idx')
+LIMIT 5;
+
+DROP TABLE vb_scores;
+
+DROP EXTENSION pg_textsearch;

--- a/test/sql/vacuum_bitmap.sql
+++ b/test/sql/vacuum_bitmap.sql
@@ -194,4 +194,119 @@ LIMIT 5;
 
 DROP TABLE vb_scores;
 
+-- =============================================================
+-- Test 7: Many deletes (>64 per segment, exercises realloc)
+-- =============================================================
+CREATE TABLE vb_many (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_many (content)
+SELECT 'manydelete document ' || i || ' searchable'
+FROM generate_series(1, 200) i;
+
+CREATE INDEX vb_many_idx ON vb_many
+    USING bm25 (content) WITH (text_config = 'english');
+
+-- Delete 150 of 200 rows (well past the initial 64-element array)
+DELETE FROM vb_many WHERE id <= 150;
+VACUUM vb_many;
+
+SELECT count(*) FROM vb_many
+WHERE content <@> to_bm25query('searchable', 'vb_many_idx') < 0;
+
+DROP TABLE vb_many;
+
+-- =============================================================
+-- Test 8: Multi-segment merge with dead docs
+-- =============================================================
+CREATE TABLE vb_multimerge (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_multimerge (content)
+SELECT 'batch1 doc ' || i || ' target'
+FROM generate_series(1, 50) i;
+
+CREATE INDEX vb_mm_idx ON vb_multimerge
+    USING bm25 (content) WITH (text_config = 'english');
+
+SELECT bm25_spill_index('vb_mm_idx');
+
+INSERT INTO vb_multimerge (content)
+SELECT 'batch2 doc ' || i || ' target'
+FROM generate_series(1, 50) i;
+
+SELECT bm25_spill_index('vb_mm_idx');
+
+INSERT INTO vb_multimerge (content)
+SELECT 'batch3 doc ' || i || ' target'
+FROM generate_series(1, 50) i;
+
+SELECT bm25_spill_index('vb_mm_idx');
+
+-- Delete from each batch
+DELETE FROM vb_multimerge WHERE id <= 10;
+DELETE FROM vb_multimerge WHERE id > 50 AND id <= 60;
+DELETE FROM vb_multimerge WHERE id > 100 AND id <= 110;
+
+VACUUM vb_multimerge;
+
+-- Merge all segments — exercises N-way merge with dead docs
+SELECT bm25_force_merge('vb_mm_idx');
+
+-- 150 total - 30 deleted = 120 live
+SELECT count(*) FROM vb_multimerge
+WHERE content <@> to_bm25query('target', 'vb_mm_idx') < 0;
+
+DROP TABLE vb_multimerge;
+
+-- =============================================================
+-- Test 9: All docs dead across segments then merge
+-- =============================================================
+CREATE TABLE vb_alldead (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_alldead (content)
+SELECT 'alldead doc ' || i FROM generate_series(1, 30) i;
+
+CREATE INDEX vb_alldead_idx ON vb_alldead
+    USING bm25 (content) WITH (text_config = 'english');
+
+SELECT bm25_spill_index('vb_alldead_idx');
+
+INSERT INTO vb_alldead (content)
+SELECT 'alldead second ' || i FROM generate_series(1, 30) i;
+
+SELECT bm25_spill_index('vb_alldead_idx');
+
+DELETE FROM vb_alldead;
+VACUUM vb_alldead;
+
+-- Both segments should be dropped — merge is a no-op
+SELECT bm25_force_merge('vb_alldead_idx');
+
+SELECT count(*) FROM vb_alldead
+WHERE content <@> to_bm25query('alldead', 'vb_alldead_idx') < 0;
+
+-- Insert fresh data to verify index still works
+INSERT INTO vb_alldead (content) VALUES ('revival document here');
+
+SELECT count(*) FROM vb_alldead
+WHERE content <@> to_bm25query('revival', 'vb_alldead_idx') < 0;
+
+DROP TABLE vb_alldead;
+
+-- =============================================================
+-- Test 10: Dump shows alive bitset info
+-- =============================================================
+CREATE TABLE vb_dump (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_dump (content)
+SELECT 'dump test ' || i FROM generate_series(1, 10) i;
+
+CREATE INDEX vb_dump_idx ON vb_dump
+    USING bm25 (content) WITH (text_config = 'english');
+
+-- Verify dump output includes alive bitset info
+SELECT bm25_dump_index('vb_dump_idx') LIKE '%Alive: 10 / 10 docs%'
+    AS has_alive_info;
+
+DROP TABLE vb_dump;
+
 DROP EXTENSION pg_textsearch;

--- a/test/sql/vacuum_bitmap.sql
+++ b/test/sql/vacuum_bitmap.sql
@@ -15,8 +15,11 @@ CREATE INDEX vb_idx ON vb_test
     USING bm25 (content) WITH (text_config = 'english');
 
 -- Verify initial query works
-SELECT count(*) FROM vb_test
-WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_test
+    ORDER BY content <@> to_bm25query('databases', 'vb_idx')
+    LIMIT 1000
+) q;
 
 -- Delete some rows
 DELETE FROM vb_test WHERE id <= 20;
@@ -25,13 +28,17 @@ DELETE FROM vb_test WHERE id <= 20;
 VACUUM vb_test;
 
 -- Query should return only live rows
-SELECT count(*) FROM vb_test
-WHERE content <@> to_bm25query('databases', 'vb_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_test
+    ORDER BY content <@> to_bm25query('databases', 'vb_idx')
+    LIMIT 1000
+) q;
 
 -- Verify no deleted rows appear
 SELECT count(*) FROM (
     SELECT id FROM vb_test
-    WHERE content <@> to_bm25query('databases', 'vb_idx') < 0
+    ORDER BY content <@> to_bm25query('databases', 'vb_idx')
+    LIMIT 1000
 ) q WHERE id <= 20;
 
 DROP TABLE vb_test;
@@ -52,14 +59,20 @@ DELETE FROM vb_full;
 VACUUM vb_full;
 
 -- Should return 0 results
-SELECT count(*) FROM vb_full
-WHERE content <@> to_bm25query('fulldelete', 'vb_full_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_full
+    ORDER BY content <@> to_bm25query('fulldelete', 'vb_full_idx')
+    LIMIT 1000
+) q;
 
 -- Index should still be usable after inserting new rows
 INSERT INTO vb_full (content) VALUES ('fresh document about topics');
 
-SELECT count(*) FROM vb_full
-WHERE content <@> to_bm25query('fresh', 'vb_full_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_full
+    ORDER BY content <@> to_bm25query('fresh', 'vb_full_idx')
+    LIMIT 1000
+) q;
 
 DROP TABLE vb_full;
 
@@ -76,8 +89,11 @@ CREATE INDEX vb_reuse_idx ON vb_reuse
     USING bm25 (content) WITH (text_config = 'english');
 
 -- Verify alpha matches
-SELECT count(*) > 0 AS has_alpha FROM vb_reuse
-WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+SELECT count(*) > 0 AS has_alpha FROM (
+    SELECT id FROM vb_reuse
+    ORDER BY content <@> to_bm25query('alpha', 'vb_reuse_idx')
+    LIMIT 1000
+) q;
 
 -- Delete all, VACUUM (frees CTIDs for reuse)
 DELETE FROM vb_reuse;
@@ -89,12 +105,18 @@ SELECT 'beta keyword document ' || i
 FROM generate_series(1, 50) i;
 
 -- alpha should return nothing
-SELECT count(*) FROM vb_reuse
-WHERE content <@> to_bm25query('alpha', 'vb_reuse_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_reuse
+    ORDER BY content <@> to_bm25query('alpha', 'vb_reuse_idx')
+    LIMIT 1000
+) q;
 
 -- beta should return results
-SELECT count(*) > 0 AS has_beta FROM vb_reuse
-WHERE content <@> to_bm25query('beta', 'vb_reuse_idx') < 0;
+SELECT count(*) > 0 AS has_beta FROM (
+    SELECT id FROM vb_reuse
+    ORDER BY content <@> to_bm25query('beta', 'vb_reuse_idx')
+    LIMIT 1000
+) q;
 
 DROP TABLE vb_reuse;
 
@@ -127,8 +149,11 @@ DELETE FROM vb_multi WHERE id <= 25;
 VACUUM vb_multi;
 
 -- Should find docs from both batches (minus deleted)
-SELECT count(*) FROM vb_multi
-WHERE content <@> to_bm25query('search', 'vb_multi_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_multi
+    ORDER BY content <@> to_bm25query('search', 'vb_multi_idx')
+    LIMIT 1000
+) q;
 
 DROP TABLE vb_multi;
 
@@ -152,13 +177,16 @@ VACUUM vb_merge;
 SELECT bm25_force_merge('vb_merge_idx');
 
 -- Query should still work correctly
-SELECT count(*) FROM vb_merge
-WHERE content <@> to_bm25query('merge', 'vb_merge_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_merge
+    ORDER BY content <@> to_bm25query('merge', 'vb_merge_idx')
+    LIMIT 1000
+) q;
 
 DROP TABLE vb_merge;
 
 -- =============================================================
--- Test 6: Score correctness after deletes
+-- Test 6: Score correctness after deletes (multi-term BMW)
 -- =============================================================
 CREATE TABLE vb_scores (id serial PRIMARY KEY, content text);
 
@@ -181,13 +209,11 @@ CREATE INDEX vb_scores_idx ON vb_scores
 DELETE FROM vb_scores WHERE content LIKE '%delete me%';
 VACUUM vb_scores;
 
--- Query with LIMIT (uses BMW)
+-- Multi-term query via BMW index scan
 SELECT id,
        content <@> to_bm25query('performance database',
                                 'vb_scores_idx') AS score
 FROM vb_scores
-WHERE content <@> to_bm25query('performance database',
-                               'vb_scores_idx') < 0
 ORDER BY content <@> to_bm25query('performance database',
                                   'vb_scores_idx')
 LIMIT 5;
@@ -210,8 +236,11 @@ CREATE INDEX vb_many_idx ON vb_many
 DELETE FROM vb_many WHERE id <= 150;
 VACUUM vb_many;
 
-SELECT count(*) FROM vb_many
-WHERE content <@> to_bm25query('searchable', 'vb_many_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_many
+    ORDER BY content <@> to_bm25query('searchable', 'vb_many_idx')
+    LIMIT 1000
+) q;
 
 DROP TABLE vb_many;
 
@@ -252,8 +281,11 @@ VACUUM vb_multimerge;
 SELECT bm25_force_merge('vb_mm_idx');
 
 -- 150 total - 30 deleted = 120 live
-SELECT count(*) FROM vb_multimerge
-WHERE content <@> to_bm25query('target', 'vb_mm_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_multimerge
+    ORDER BY content <@> to_bm25query('target', 'vb_mm_idx')
+    LIMIT 1000
+) q;
 
 DROP TABLE vb_multimerge;
 
@@ -281,14 +313,20 @@ VACUUM vb_alldead;
 -- Both segments should be dropped — merge is a no-op
 SELECT bm25_force_merge('vb_alldead_idx');
 
-SELECT count(*) FROM vb_alldead
-WHERE content <@> to_bm25query('alldead', 'vb_alldead_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_alldead
+    ORDER BY content <@> to_bm25query('alldead', 'vb_alldead_idx')
+    LIMIT 1000
+) q;
 
 -- Insert fresh data to verify index still works
 INSERT INTO vb_alldead (content) VALUES ('revival document here');
 
-SELECT count(*) FROM vb_alldead
-WHERE content <@> to_bm25query('revival', 'vb_alldead_idx') < 0;
+SELECT count(*) FROM (
+    SELECT id FROM vb_alldead
+    ORDER BY content <@> to_bm25query('revival', 'vb_alldead_idx')
+    LIMIT 1000
+) q;
 
 DROP TABLE vb_alldead;
 


### PR DESCRIPTION
## Summary

- Add per-segment alive bitset (1 bit per doc, pre-allocated at segment creation) for O(dead_docs) VACUUM instead of O(all_docs) segment rebuild
- BMW scoring checks alive bitset post-scoring, pre-heap-insertion — zero overhead when no dead docs
- Segment merge physically removes dead docs, restoring BM25 statistics
- V3/V4 segments handled transparently (treated as all-alive, upgraded on VACUUM or merge)
- Segments with all docs dead are dropped entirely

Closes #264

## Design

Based on Tantivy's `AliveBitSet` and Lucene's live docs approach:
- **Alive bitset** (not dead): pre-allocated at segment creation, constant size, VACUUM only flips bits in existing pages via GenericXLog
- **Post-scoring filtering**: block max scores not recomputed (conservative upper bounds, matching Lucene)
- **Paged I/O for bitset reads**: no eager loading — bitset bytes read through segment reader during scoring
- **Format version bump**: V4→V5, backward compatible

## Benchmark results (CI, 8.8M MS MARCO passages)

| Scenario | Before | After | Speedup |
|----------|--------|-------|---------|
| Partial VACUUM (1 segment affected) | 3.7s | 3.4s | 1.1x |
| Full VACUUM after uniform delete (all segments) | 434s | 6.1s | **71x** |
| Full VACUUM after uniform update (all segments) | 427s | 4.3s | **99x** |

Before this PR, VACUUM rebuilds entire segments from heap — retokenizing every live document even if only 1% are dead. With the alive bitset, VACUUM flips bits in-place via GenericXLog, touching only the affected pages. The full vacuum improvement is ~2 orders of magnitude.

Post-vacuum index size stays at ~1.3GB instead of bloating to ~2.5GB, since segments are no longer rewritten.

## Changes

| File | Change |
|------|--------|
| `segment.h` | Add `alive_bitset_offset`, `alive_count` to header. Bump format to V5. |
| `segment.c` | V3/V4 header compat. Write alive bitset in `tp_write_segment`. Dump output. |
| `alive_bitset.h/c` | New module: create/load/mark_dead/write/free operations. |
| `build_context.c` | Write alive bitset in `tp_write_segment_from_build_ctx`. |
| `merge.c` | Skip dead docs in docmap and posting merge. Recompute `total_tokens`. |
| `bmw.c/h` | Alive check in single/multi-term BMW. `dead_docs_skipped` stat. |
| `vacuum.c` | Bitmap marking for V5 segments. Rebuild fallback for pre-V5. Drop fully-dead segments. |

## Testing

New `vacuum_bitmap` regression test (10 scenarios):
1. Basic VACUUM with bitmap marking
2. Full segment delete (segment dropped)
3. CTID reuse correctness after delete+VACUUM+reinsert
4. Multi-segment mixed deletes
5. Merge after VACUUM cleans up dead docs
6. Score correctness (multi-term BMW after deletes)
7. Many deletes (>64 per segment, exercises array realloc)
8. Multi-segment merge with dead docs across 3 segments
9. All-dead segments across multiple segments, then merge
10. Dump output includes alive bitset info

`partial_index` expected output updated: VACUUM bitmap marking preserves original corpus statistics (IDF slightly stale until merge).