### PR TITLE
refactor: deduplicate read_term_at_index into dictionary.c

### DIFF
--- a/src/segment/dictionary.c
+++ b/src/segment/dictionary.c
@@ -9,11 +9,13 @@
 #include <lib/dshash.h>
 #include <utils/memutils.h>
 
+#include "constants.h"
 #include "index/state.h"
 #include "memtable/memtable.h"
 #include "memtable/posting.h"
 #include "memtable/stringtable.h"
 #include "segment/dictionary.h"
+#include "segment/io.h"
 
 /*
  * Comparison function for qsort
@@ -128,4 +130,39 @@ tp_free_dictionary(TermInfo *terms, uint32 num_terms)
 	}
 
 	pfree(terms);
+}
+
+/*
+ * Read a term string from a segment's string pool at a given dictionary
+ * index. Returns a palloc'd string that must be freed by the caller.
+ */
+char *
+tp_segment_read_term_at_index(
+		TpSegmentReader *reader,
+		TpSegmentHeader *header,
+		uint32			*string_offsets,
+		uint32			 index)
+{
+	uint32 string_offset;
+	uint32 length;
+	char  *term;
+
+	string_offset = header->strings_offset + string_offsets[index];
+
+	/* Read string length */
+	tp_segment_read(reader, string_offset, &length, sizeof(uint32));
+
+	if (length > TP_MAX_TERM_LENGTH)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("corrupt segment: term length %u exceeds "
+						"maximum",
+						length)));
+
+	/* Allocate and read string */
+	term = palloc(length + 1);
+	tp_segment_read(reader, string_offset + sizeof(uint32), term, length);
+	term[length] = '\0';
+
+	return term;
 }

--- a/src/segment/dictionary.c
+++ b/src/segment/dictionary.c
@@ -143,7 +143,7 @@ tp_segment_read_term_at_index(
 		uint32			*string_offsets,
 		uint32			 index)
 {
-	uint32 string_offset;
+	uint64 string_offset;
 	uint32 length;
 	char  *term;
 

--- a/src/segment/dictionary.h
+++ b/src/segment/dictionary.h
@@ -11,6 +11,8 @@
 
 /* Forward declarations */
 struct TpLocalIndexState;
+struct TpSegmentReader;
+struct TpSegmentHeader;
 
 /*
  * Term info for building dictionary
@@ -27,3 +29,10 @@ typedef struct TermInfo
 extern TermInfo *
 tp_build_dictionary(struct TpLocalIndexState *state, uint32 *num_terms);
 extern void tp_free_dictionary(TermInfo *terms, uint32 num_terms);
+
+/* Shared term-reading helper */
+extern char *tp_segment_read_term_at_index(
+		struct TpSegmentReader *reader,
+		struct TpSegmentHeader *header,
+		uint32				   *string_offsets,
+		uint32					index);

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -18,6 +18,7 @@
 #include "index/metapage.h"
 #include "segment/alive_bitset.h"
 #include "segment/compression.h"
+#include "segment/dictionary.h"
 #include "segment/docmap.h"
 #include "segment/fieldnorm.h"
 #include "segment/io.h"
@@ -106,39 +107,6 @@ merge_sink_write_at(
  */
 
 /*
- * Read term at index from a segment's dictionary.
- * Returns palloc'd string that must be freed by caller.
- */
-static char *
-merge_read_term_at_index(TpMergeSource *source, uint32 index)
-{
-	TpSegmentHeader *header = source->reader->header;
-	uint32			 string_offset;
-	uint32			 length;
-	char			*term;
-
-	string_offset = header->strings_offset + source->string_offsets[index];
-
-	/* Read string length */
-	tp_segment_read(source->reader, string_offset, &length, sizeof(uint32));
-
-	if (length > TP_MAX_TERM_LENGTH)
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_CORRUPTED),
-				 errmsg("corrupt segment: term length %u exceeds "
-						"maximum",
-						length)));
-
-	/* Allocate and read string */
-	term = palloc(length + 1);
-	tp_segment_read(
-			source->reader, string_offset + sizeof(uint32), term, length);
-	term[length] = '\0';
-
-	return term;
-}
-
-/*
  * Advance a merge source to its next term.
  * Returns false if source is exhausted.
  */
@@ -168,8 +136,11 @@ merge_source_advance(TpMergeSource *source)
 	header = source->reader->header;
 
 	/* Read the term at current index */
-	source->current_term =
-			merge_read_term_at_index(source, source->current_idx);
+	source->current_term = tp_segment_read_term_at_index(
+			source->reader,
+			source->reader->header,
+			source->string_offsets,
+			source->current_idx);
 
 	/* Read the dictionary entry (version-aware) */
 	tp_segment_read_dict_entry(

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -51,46 +51,6 @@ extern bool tp_compress_segments;
  */
 
 /*
- * Helper function to read a term string at a given dictionary index.
- * Returns the allocated string which must be freed by caller.
- */
-static char *
-read_term_at_index(
-		TpSegmentReader *reader,
-		TpSegmentHeader *header,
-		uint32			 index,
-		uint32			*string_offsets)
-{
-	TpStringEntry string_entry;
-	char		 *term_text;
-	uint64		  string_offset;
-
-	string_offset = header->strings_offset + string_offsets[index];
-
-	/* Read string length */
-	tp_segment_read(
-			reader, string_offset, &string_entry.length, sizeof(uint32));
-
-	if (string_entry.length > TP_MAX_TERM_LENGTH)
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_CORRUPTED),
-				 errmsg("corrupt segment: term length %u exceeds "
-						"maximum",
-						string_entry.length)));
-
-	/* Allocate buffer and read term text */
-	term_text = palloc(string_entry.length + 1);
-	tp_segment_read(
-			reader,
-			string_offset + sizeof(uint32),
-			term_text,
-			string_entry.length);
-	term_text[string_entry.length] = '\0';
-
-	return term_text;
-}
-
-/*
  * Version-aware dictionary entry reader.
  * V3 segments have 12-byte TpDictEntryV3; V4 have 16-byte TpDictEntry.
  */
@@ -1880,7 +1840,8 @@ tp_dump_segment_to_output(
 		{
 			char *term_text;
 
-			term_text = read_term_at_index(reader, &header, i, string_offsets);
+			term_text = tp_segment_read_term_at_index(
+					reader, &header, string_offsets, i);
 
 			if (strlen(term_text) > 1024)
 			{


### PR DESCRIPTION
## Summary

- Extract shared term-reading logic from `segment.c` and `merge.c`
  into `dictionary.c` as `tp_segment_read_term_at_index()`
- Both files had nearly identical static functions for reading a term
  string from the segment string pool

## Testing

- Compiles cleanly on PG17 and PG18
- All regression tests pass (no behavioral change)