### PR TITLE
ci: make codecov patch check informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,7 +13,7 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: 85%
+        informational: true
 
 # Ignore test files in coverage reports
 ignore:


### PR DESCRIPTION
## Summary

- Change codecov patch coverage status from required to informational
- The project-level check (85% target) still guards overall coverage
- Prevents misleading red X on PRs with high patch coverage (e.g.,
  97.5%) that happen to have a few uncovered lines

## Testing

Config-only change, no code impact.