### PR TITLE
fix: vacuum writes next_segment at wrong offset for V3 segments

### DIFF
--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -476,24 +476,39 @@ tp_vacuum_replace_segment(
 		}
 		else
 		{
-			/* Update prev's next_segment */
-			Page			 prev_page;
-			TpSegmentHeader *prev_header;
+			/* Update prev's next_segment pointer. */
+			Page		prev_page;
+			char	   *prev_content;
+			uint32		prev_version;
+			BlockNumber new_next;
 
 			prev_buf = ReadBuffer(index, prev_root);
 			LockBuffer(prev_buf, BUFFER_LOCK_EXCLUSIVE);
 			prev_page = GenericXLogRegisterBuffer(xlog_state, prev_buf, 0);
 			/* Ensure pd_lower covers content for GenericXLog */
 			((PageHeader)prev_page)->pd_lower = BLCKSZ;
-			prev_header = (TpSegmentHeader *)PageGetContents(prev_page);
 
-			if (new_root != InvalidBlockNumber)
-				prev_header->next_segment = new_root;
+			new_next = (new_root != InvalidBlockNumber) ? new_root : old_next;
+
+			/*
+			 * The previous segment may still be on an older on-disk
+			 * format.  V3 uses uint32 offsets and places next_segment
+			 * at byte 28; V4/V5 use uint64 offsets with 4 bytes of
+			 * padding before data_size, placing next_segment at byte
+			 * 36.  Write at the offset matching the on-disk version
+			 * so we don't clobber adjacent fields.  magic/version
+			 * live at the same bytes in every version, so reading
+			 * version via the V5 struct is safe.
+			 */
+			prev_content = PageGetContents(prev_page);
+			prev_version = ((TpSegmentHeader *)prev_content)->version;
+			if (prev_version <= TP_SEGMENT_FORMAT_VERSION_3)
+				((TpSegmentHeaderV3 *)prev_content)->next_segment = new_next;
 			else
-			{
-				prev_header->next_segment = old_next;
+				((TpSegmentHeader *)prev_content)->next_segment = new_next;
+
+			if (new_root == InvalidBlockNumber)
 				meta_ptr->level_counts[level]--;
-			}
 		}
 
 		GenericXLogFinish(xlog_state);


### PR DESCRIPTION
Closes #328

## Summary

`tp_vacuum_replace_segment` cast the previous segment's page content to
`TpSegmentHeader *` (V5 layout) unconditionally when updating its
`next_segment` pointer. V3 headers place `next_segment` at byte 28
(uint32 offsets, no padding); V4/V5 place it at byte 36 (uint64 offsets
with 4 bytes of padding before `data_size`). On a V3 previous segment
the V5-offset write overwrote `strings_offset` with a block number,
causing "Invalid logical page" or "corrupt segment: term length exceeds
maximum" errors on subsequent queries.

Fix: read the prev segment's `version` (same byte location in every
format) and write through the correct struct. `new_header` writes go to
a freshly built V5 segment and were already correct; `build.c` and
`merge.c` only touch newly built segments, so they're unaffected.

## Testing

- `make installcheck` passes locally
- `make format-check` passes
- Full V3 VACUUM coverage lives in the upgrade-tests workflow extended
  by #327. That PR currently skips the VACUUM/merge phases for v0.5.1
  as a workaround for this bug; after this lands, the skip in #327
  should be dropped so CI exercises V3 VACUUM end-to-end.