### PR TITLE
chore: bump version to 1.1.0-dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ ranking. (Internal name: Tapir) It implements a memtable-based architecture
 similar to LSM trees, with in-memory structures that spill to disk segments
 for scalability.
 
-**Current Version**: 1.0.0-dev
+**Current Version**: 1.1.0-dev
 
 **Postgres Version Support**: 17, 18 (tested in CI)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXTENSION = pg_textsearch
 EXTVERSION = $(shell awk -F"'" '/default_version/ {print $$2}' pg_textsearch.control)
-DATA = sql/pg_textsearch--1.0.0-dev.sql \
+DATA = sql/pg_textsearch--1.1.0-dev.sql \
        sql/pg_textsearch--0.0.1--0.0.2.sql \
        sql/pg_textsearch--0.0.2--0.0.3.sql \
        sql/pg_textsearch--0.0.3--0.0.4.sql \
@@ -16,7 +16,7 @@ DATA = sql/pg_textsearch--1.0.0-dev.sql \
        sql/pg_textsearch--0.5.1--0.6.0.sql \
        sql/pg_textsearch--0.6.0--0.6.1.sql \
        sql/pg_textsearch--0.6.1--1.0.0.sql \
-       sql/pg_textsearch--1.0.0--1.0.0-dev.sql
+       sql/pg_textsearch--1.0.0--1.1.0-dev.sql
 
 # Source files organized by directory
 OBJS = \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -126,13 +126,7 @@ starting "Release v" merges to main. It:
 2. Builds release artifacts for PG17/PG18 on Linux/macOS (amd64/arm64)
 3. Creates a GitHub release with the artifacts
 
-### 10. Update timescaledb-docker-ha
-
-Create a PR in the [timescaledb-docker-ha](https://github.com/timescale/timescaledb-docker-ha)
-repo to update the pg_textsearch version. This ensures the new release is included
-in Timescale's Docker images.
-
-### 11. Post-Release: Bump to Next Dev Version
+### 10. Post-Release: Bump to Next Dev Version
 
 After the release is published, create a PR to bump to the next dev version:
 
@@ -155,7 +149,7 @@ to exactly one next version — no shortcuts that skip intermediate steps.
 This keeps the number of upgrade scripts minimal and the path predictable.
 
 ```
-... → 0.5.0 → 0.5.1 → 0.6.0 → 0.6.1 → 1.0.0 → 1.0.0-dev
+... → 0.5.0 → 0.5.1 → 0.6.0 → 0.6.1 → 1.0.0 → 1.1.0-dev
 ```
 
 Every release must have an upgrade path from the previous stable release

--- a/pg_textsearch.control
+++ b/pg_textsearch.control
@@ -1,5 +1,5 @@
 # pg_textsearch extension
 comment = 'Full-text search with BM25 ranking'
-default_version = '1.0.0-dev'
+default_version = '1.1.0-dev'
 module_pathname = '$libdir/pg_textsearch'
 relocatable = false

--- a/sql/pg_textsearch--1.0.0--1.1.0-dev.sql
+++ b/sql/pg_textsearch--1.0.0--1.1.0-dev.sql
@@ -1,4 +1,4 @@
--- Upgrade from 1.0.0 to 1.0.0-dev
+-- Upgrade from 1.0.0 to 1.1.0-dev
 -- No schema changes
 
 -- Verify loaded library matches this SQL script version
@@ -12,16 +12,16 @@ BEGIN
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
     END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '1.0.0-dev' THEN
+    IF lib_ver OPERATOR(pg_catalog.<>) '1.1.0-dev' THEN
         RAISE EXCEPTION
             'pg_textsearch library version mismatch: loaded=%, expected=%. '
             'Restart the server after installing the new binary.',
-            lib_ver, '1.0.0-dev';
+            lib_ver, '1.1.0-dev';
     END IF;
 END $$;
 
 DO $$
 BEGIN
-    RAISE INFO 'pg_textsearch v1.0.0-dev';
+    RAISE INFO 'pg_textsearch v1.1.0-dev';
 END
 $$;

--- a/sql/pg_textsearch--1.1.0-dev.sql
+++ b/sql/pg_textsearch--1.1.0-dev.sql
@@ -1,4 +1,4 @@
--- pg_textsearch extension version 1.0.0-dev
+-- pg_textsearch extension version 1.1.0-dev
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_textsearch" to load this file. \quit
@@ -14,11 +14,11 @@ BEGIN
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
     END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '1.0.0-dev' THEN
+    IF lib_ver OPERATOR(pg_catalog.<>) '1.1.0-dev' THEN
         RAISE EXCEPTION
             'pg_textsearch library version mismatch: loaded=%, expected=%. '
             'Restart the server after installing the new binary.',
-            lib_ver, '1.0.0-dev';
+            lib_ver, '1.1.0-dev';
     END IF;
 END $$;
 
@@ -231,7 +231,7 @@ CREATE FUNCTION @extschema@.bm25_dump_index(text) RETURNS text
 -- Display version info
 DO $$
 BEGIN
-    RAISE INFO 'pg_textsearch v1.0.0-dev';
+    RAISE INFO 'pg_textsearch v1.1.0-dev';
 END
 $$;
 

--- a/src/mod.c
+++ b/src/mod.c
@@ -32,7 +32,7 @@
 #include "scoring/bm25.h"
 
 #if PG_VERSION_NUM >= 180000
-PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.0.0-dev");
+PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.1.0-dev");
 #else
 PG_MODULE_MAGIC;
 #endif

--- a/test/expected/abort.out
+++ b/test/expected/abort.out
@@ -7,7 +7,7 @@
 -- are forbidden, so the hook must skip its work.
 --
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Scenario 1: Basic abort with no pg_textsearch objects
 -- This is the original bug report (#247): ROLLBACK after an error in a
 -- transaction that has nothing to do with BM25 should not crash.

--- a/test/expected/aerodocs.out
+++ b/test/expected/aerodocs.out
@@ -4,7 +4,7 @@
 -- Tests both dataset loading and pg_textsearch scoring functionality with the <@> operator
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/aerodocs_1.out
+++ b/test/expected/aerodocs_1.out
@@ -4,7 +4,7 @@
 -- Tests both dataset loading and pg_textsearch scoring functionality with the <@> operator
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/basic.out
+++ b/test/expected/basic.out
@@ -1,7 +1,7 @@
 -- Basic functionality tests for pg_textsearch extension
 -- Test extension creation
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Verify library version GUC is set
 SELECT current_setting('pg_textsearch.library_version') IS NOT NULL AS has_version;
  has_version 

--- a/test/expected/binary_io.out
+++ b/test/expected/binary_io.out
@@ -1,6 +1,6 @@
 -- Test binary I/O for bm25query type (COPY BINARY)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create a table and index for testing
 CREATE TABLE binary_io_docs (id SERIAL PRIMARY KEY, content TEXT);
 INSERT INTO binary_io_docs (content) VALUES

--- a/test/expected/bmw.out
+++ b/test/expected/bmw.out
@@ -2,7 +2,7 @@
 -- Tests the top-k optimization for both single-term and multi-term queries
 -- Setup: Create extension
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Force index scan so ORDER BY uses the BM25 index (small tables
 -- would otherwise prefer seq scan, returning non-matching rows)
 SET enable_seqscan = off;

--- a/test/expected/bulk_load.out
+++ b/test/expected/bulk_load.out
@@ -1,7 +1,7 @@
 -- Test bulk load spill threshold
 -- Exercises state.c bulk_load_spill_check path
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Set a very low bulk load threshold to trigger automatic spill
 SET pg_textsearch.bulk_load_threshold = 100;
 -- Create table and index

--- a/test/expected/catalog_stats.out
+++ b/test/expected/catalog_stats.out
@@ -1,7 +1,7 @@
 -- Test that BM25 indexes report correct catalog statistics
 -- (pg_class.reltuples, pg_class.relpages, pg_stat_user_indexes)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- ============================================================
 -- heap_tuples vs index_tuples for partial indexes
 --

--- a/test/expected/compression.out
+++ b/test/expected/compression.out
@@ -1,7 +1,7 @@
 -- Test compression functionality
 -- Tests that compression (now default) produces correct results
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Compression is now on by default
 SHOW pg_textsearch.compress_segments;
  pg_textsearch.compress_segments 

--- a/test/expected/concurrent_build.out
+++ b/test/expected/concurrent_build.out
@@ -5,7 +5,7 @@
 -- function can determine which tuples are already indexed and avoid
 -- duplicating entries.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET enable_seqscan = off;
 --------------------------------------------------------------------------------
 -- Test 1: Basic CREATE INDEX CONCURRENTLY

--- a/test/expected/coverage.out
+++ b/test/expected/coverage.out
@@ -1,7 +1,7 @@
 -- Additional coverage tests for untested code paths
 -- Tests debug functions, segment dump, and text<@>text operator
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- =============================================================================
 -- Test 1: Basic debug functions with memtable-only data
 -- =============================================================================

--- a/test/expected/deletion.out
+++ b/test/expected/deletion.out
@@ -1,7 +1,7 @@
 -- Test handling of row deletions in indexed tables
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create test table
 CREATE TABLE deletion_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/dropped.out
+++ b/test/expected/dropped.out
@@ -1,7 +1,7 @@
 -- Test behavior when using a dropped index name in queries
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create test table
 CREATE TABLE dropped_idx_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/empty.out
+++ b/test/expected/empty.out
@@ -1,7 +1,7 @@
 -- Test handling of empty and whitespace-only documents
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create test table with various empty/whitespace content
 CREATE TABLE empty_docs (
     id SERIAL PRIMARY KEY,

--- a/test/expected/explicit_index.out
+++ b/test/expected/explicit_index.out
@@ -1,7 +1,7 @@
 -- Test explicit index name in to_bm25query
 -- Validates fixes for GitHub issues #183 and #194
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -----------------------------------------------------------------------
 -- Issue #194: to_bm25query with explicit index ignores index column
 -- Using an index on a different column should error

--- a/test/expected/expression_index.out
+++ b/test/expected/expression_index.out
@@ -1,6 +1,6 @@
 -- Expression index tests for pg_textsearch
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- ============================================================
 -- JSONB expression index
 -- ============================================================

--- a/test/expected/force_merge.out
+++ b/test/expected/force_merge.out
@@ -7,7 +7,7 @@
 -- 3. Queries return correct results after merge
 -- 4. Inserts work normally after force merge
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;

--- a/test/expected/implicit.out
+++ b/test/expected/implicit.out
@@ -1,7 +1,7 @@
 -- Test implicit index resolution via planner hook
 -- Tests that to_bm25query() without an index name automatically finds the BM25 index
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET enable_seqscan = off;
 -- Create test table with BM25 index
 CREATE TABLE implicit_docs (

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -1,7 +1,7 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Setup test table

--- a/test/expected/index_1.out
+++ b/test/expected/index_1.out
@@ -1,7 +1,7 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Setup test table

--- a/test/expected/inheritance.out
+++ b/test/expected/inheritance.out
@@ -1,7 +1,7 @@
 -- Test BM25 index behavior with table inheritance
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- =============================================================================
 -- Test 1: PostgreSQL native table inheritance
 -- BM25 indexes on parent tables only index direct rows (ONLY semantics),

--- a/test/expected/limits.out
+++ b/test/expected/limits.out
@@ -3,7 +3,7 @@
 SET log_duration = off;
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/limits_1.out
+++ b/test/expected/limits_1.out
@@ -3,7 +3,7 @@
 SET log_duration = off;
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/lock.out
+++ b/test/expected/lock.out
@@ -1,7 +1,7 @@
 -- Test lock upgrade from shared to exclusive within a single transaction
 -- This exercises the tp_acquire_index_lock upgrade path
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create test table and index
 CREATE TABLE lock_upgrade_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/manyterms.out
+++ b/test/expected/manyterms.out
@@ -2,7 +2,7 @@
 -- This test creates enough unique terms to trigger hash table resize
 -- and verifies the system continues to work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Create test table

--- a/test/expected/max_shared_memory.out
+++ b/test/expected/max_shared_memory.out
@@ -1,7 +1,7 @@
 -- Test pg_textsearch.memory_limit GUC
 -- Derives per-index (limit/8) and global (limit/2) soft limits internally.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Ensure clean GUC state from any prior test runs
 ALTER SYSTEM RESET pg_textsearch.memory_limit;
 ALTER SYSTEM RESET pg_textsearch.bulk_load_threshold;

--- a/test/expected/memory.out
+++ b/test/expected/memory.out
@@ -1,7 +1,7 @@
 -- Test bulk insert with auto-spill for pg_textsearch indexes
 -- Create extension if not exists
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create test table
 DROP TABLE IF EXISTS memory_test CASCADE;
 NOTICE:  table "memory_test" does not exist, skipping

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -6,7 +6,7 @@
 -- 2. L0 -> L1 merge triggered by segments_per_level = 2
 -- 3. Queries across multiple segment levels (L0, L1)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;

--- a/test/expected/mixed.out
+++ b/test/expected/mixed.out
@@ -2,7 +2,7 @@
 -- This test verifies that concurrent access to shared memory structures is safe
 -- and that operations like inserts, searches, and index building work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Clean up from any previous tests

--- a/test/expected/parallel_bmw.out
+++ b/test/expected/parallel_bmw.out
@@ -6,7 +6,7 @@
 -- causing BMW to underestimate block score upper bounds and incorrectly
 -- skip blocks containing high-scoring short documents.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET enable_seqscan = off;
 SET min_parallel_table_scan_size = 0;
 SET maintenance_work_mem = '256MB';

--- a/test/expected/parallel_build.out
+++ b/test/expected/parallel_build.out
@@ -1,7 +1,7 @@
 -- Test case: parallel_build
 -- Tests parallel index build with various worker counts and corner cases
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET enable_seqscan = off;
 -- Lower threshold so our test tables qualify for parallel build
 SET min_parallel_table_scan_size = 0;

--- a/test/expected/partial_index.out
+++ b/test/expected/partial_index.out
@@ -1,6 +1,6 @@
 -- Partial index tests for pg_textsearch
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- ============================================================
 -- Basic partial index
 -- ============================================================

--- a/test/expected/partitioned.out
+++ b/test/expected/partitioned.out
@@ -16,7 +16,7 @@
 -- partition-local statistics.
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Load validation functions
 \set ECHO none
 SET enable_seqscan = off;

--- a/test/expected/partitioned_1.out
+++ b/test/expected/partitioned_1.out
@@ -16,7 +16,7 @@
 -- partition-local statistics.
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Load validation functions
 \set ECHO none
 SET enable_seqscan = off;

--- a/test/expected/partitioned_many.out
+++ b/test/expected/partitioned_many.out
@@ -5,7 +5,7 @@
 -- The bug triggers during document processing when per-index locks accumulate.
 -- With 200 partitions and data, the old code would exceed MAX_SIMUL_LWLOCKS.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create a partitioned table with 200 partitions
 -- (200 is enough to trigger the bug - old limit was ~142 partitions)
 CREATE TABLE docs_many_parts (

--- a/test/expected/pgstats.out
+++ b/test/expected/pgstats.out
@@ -1,6 +1,6 @@
 -- Test that BM25 index scans report statistics to pg_stat_user_indexes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create a test table with BM25 index
 CREATE TABLE test_pgstats (id serial PRIMARY KEY, content text);
 CREATE INDEX test_pgstats_idx ON test_pgstats

--- a/test/expected/queries.out
+++ b/test/expected/queries.out
@@ -1,7 +1,7 @@
 -- This test demonstrates top-k pg_textsearch query patterns for efficient text search
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/quoted_identifiers.out
+++ b/test/expected/quoted_identifiers.out
@@ -3,7 +3,7 @@
 -- identifiers for both index names and schema names.
 -- Regression test for https://github.com/timescale/pg_textsearch/issues/285
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Test 1: Uppercase index name (the reported bug)
 CREATE TABLE qi_test1 (
     id SERIAL PRIMARY KEY,

--- a/test/expected/rescan.out
+++ b/test/expected/rescan.out
@@ -12,7 +12,7 @@
 -- (exponential backoff: 2x, 4x, ...) until enough rows are found.
 SET log_duration = off;
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET client_min_messages = NOTICE;
 SET enable_seqscan = false;
 ------------------------------------------------------------------------

--- a/test/expected/schema.out
+++ b/test/expected/schema.out
@@ -1,7 +1,7 @@
 -- Test case: schema
 -- Tests index operations with schema-qualified tables
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;
 -- Create a custom schema

--- a/test/expected/scoring1.out
+++ b/test/expected/scoring1.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring2.out
+++ b/test/expected/scoring2.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 5 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring3.out
+++ b/test/expected/scoring3.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 3 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring4.out
+++ b/test/expected/scoring4.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 1 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring5.out
+++ b/test/expected/scoring5.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 3 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring6.out
+++ b/test/expected/scoring6.out
@@ -2,7 +2,7 @@
 -- Generated BM25 test with 2 documents and 3 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/security.out
+++ b/test/expected/security.out
@@ -1,6 +1,6 @@
 -- Test security restrictions on debug and admin functions
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create test data
 CREATE TABLE security_test (id serial, content text);
 INSERT INTO security_test (content) VALUES ('test document');

--- a/test/expected/segment.out
+++ b/test/expected/segment.out
@@ -2,7 +2,7 @@
 -- Tests segment query functionality with multiple spill cycles and
 -- post-spill inserts
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;

--- a/test/expected/segment_integrity.out
+++ b/test/expected/segment_integrity.out
@@ -9,7 +9,7 @@
 -- - Document length encoding errors
 -- - Term frequency encoding errors
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;
 -- Create table with enough documents to be meaningful

--- a/test/expected/strings.out
+++ b/test/expected/strings.out
@@ -1,7 +1,7 @@
 -- Test long string handling including URLs, paths, and long terms
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/temp_table.out
+++ b/test/expected/temp_table.out
@@ -4,7 +4,7 @@
 -- scanning a BM25 index on a temp table.
 --
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Basic: create, populate, query, drop
 CREATE TEMP TABLE t_basic (id serial, body text);
 INSERT INTO t_basic VALUES (DEFAULT, 'hello world'), (DEFAULT, 'foo bar baz');

--- a/test/expected/text_array.out
+++ b/test/expected/text_array.out
@@ -1,6 +1,6 @@
 -- Test BM25 index on text[] columns
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Basic text array table and index
 CREATE TABLE docs_array (
     id SERIAL PRIMARY KEY,

--- a/test/expected/text_config.out
+++ b/test/expected/text_config.out
@@ -1,6 +1,6 @@
 -- Test parameter "text_config" accepts qualified names
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create table
 CREATE TABLE text_config_tbl (
     id SERIAL PRIMARY KEY,

--- a/test/expected/unlogged_index.out
+++ b/test/expected/unlogged_index.out
@@ -1,6 +1,6 @@
 -- Test unlogged index behavior and initialization fork creation
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create UNLOGGED table and index
 CREATE UNLOGGED TABLE unlogged_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/unsupported.out
+++ b/test/expected/unsupported.out
@@ -1,7 +1,7 @@
 -- Test cases for queries that are NOT YET fully supported
 -- These document known limitations of the current implicit index resolution
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Setup test tables
 CREATE TABLE docs (
     id SERIAL PRIMARY KEY,

--- a/test/expected/updates.out
+++ b/test/expected/updates.out
@@ -2,7 +2,7 @@
 -- This test reproduces the NULL index_state crash reported in production
 -- Install the extension if not already installed
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Test basic UPDATE operations
 CREATE TABLE update_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -1,7 +1,7 @@
 -- Test VACUUM behavior with BM25 indexes
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Create test table
 CREATE TABLE vacuum_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -1,6 +1,6 @@
 -- Test alive bitset tombstone tracking during VACUUM
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- =============================================================
 -- Test 1: Basic VACUUM with bitmap marking
 -- =============================================================

--- a/test/expected/vacuum_extended.out
+++ b/test/expected/vacuum_extended.out
@@ -1,7 +1,7 @@
 -- Extended vacuum tests for BM25 indexes
 -- Exercises vacuum paths with segments, bulk deletes, and empty indexes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- =============================================================================
 -- Test 1: Vacuum with segments present
 -- =============================================================================

--- a/test/expected/vacuum_rebuild.out
+++ b/test/expected/vacuum_rebuild.out
@@ -6,7 +6,7 @@
 -- the heap tuple and catch stale results. We use enable_seqscan=off
 -- to ensure the index scan is used even for small tables.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 SET enable_seqscan = off;
 -- ================================================================
 -- Test 1: Basic CTID reuse after VACUUM

--- a/test/expected/vector.out
+++ b/test/expected/vector.out
@@ -1,7 +1,7 @@
 -- Test bm25vector type and operators functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/wand.out
+++ b/test/expected/wand.out
@@ -5,7 +5,7 @@
 -- are correctly scored. Uses validation.sql to verify scores match
 -- the reference BM25 implementation.
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.0.0-dev
+INFO:  pg_textsearch v1.1.0-dev
 \set ECHO none
 -- ============================================================
 -- TEST: Multi-term documents score correctly across block boundaries

--- a/test/scripts/memory_accounting.sh
+++ b/test/scripts/memory_accounting.sh
@@ -66,7 +66,7 @@ EOF
     "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" "${TEST_DB}"
     "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
         -d "${TEST_DB}" \
-        -c "CREATE EXTENSION pg_textsearch VERSION '1.0.0-dev';" \
+        -c "CREATE EXTENSION pg_textsearch VERSION '1.1.0-dev';" \
         >/dev/null
 
     # Create a persistent probe table used to force DSA attachment

--- a/test/scripts/multi_index.sh
+++ b/test/scripts/multi_index.sh
@@ -94,7 +94,7 @@ EOF
         "${TEST_DB}"
 
     run_sql_quiet "CREATE EXTENSION pg_textsearch
-                       VERSION '1.0.0-dev';"
+                       VERSION '1.1.0-dev';"
 }
 
 run_sql() {

--- a/test/scripts/segment_wal_recovery.sh
+++ b/test/scripts/segment_wal_recovery.sh
@@ -147,7 +147,7 @@ EOF
 
 "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" \
     "${TEST_DB}"
-run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.0.0-dev';"
+run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.1.0-dev';"
 
 # -------------------------------------------------------
 # Part 1: WAL coverage check


### PR DESCRIPTION
## Summary
Post-1.0.0 release bump — we forgot to do this after the 1.0.0 release.

- Rename `pg_textsearch--1.0.0-dev.sql` → `pg_textsearch--1.1.0-dev.sql`
- Rename upgrade script `pg_textsearch--1.0.0--1.0.0-dev.sql` → `pg_textsearch--1.0.0--1.1.0-dev.sql`
- Update version strings in `pg_textsearch.control`, `src/mod.c`, `CLAUDE.md`, `Makefile`, test scripts, and expected outputs
- Drop the `timescaledb-docker-ha` step from `RELEASING.md`; that part of the release procedure now lives in internal docs

## Testing
- `make test` passes
- `make format-check` clean