### PR TITLE
fix: spill memtable in amvacuumcleanup (issue #333)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,7 @@ jobs:
         (cd test/scripts && ./segment.sh) || true
         (cd test/scripts && ./recovery.sh) || true
         (cd test/scripts && ./docid_chain_recovery.sh) || true
+        (cd test/scripts && ./shutdown_spill.sh) || true
         (cd test/scripts && ./cic.sh) || true
         (cd test/scripts && ./memory_accounting.sh) || true
 

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ test-recovery:
 	@echo "Running crash recovery tests..."
 	@cd test/scripts && ./recovery.sh
 	@cd test/scripts && ./docid_chain_recovery.sh
+	@cd test/scripts && ./shutdown_spill.sh
 
 test-segment:
 	@echo "Running multi-backend segment tests..."

--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ To check current memory usage:
 SELECT * FROM bm25_memory_usage();
 ```
 
+VACUUM (including autovacuum's insert-threshold path) also spills the
+memtable when it runs, so the amount of un-spilled state between
+`CREATE INDEX` and the next server restart stays bounded.
+
 **Crash recovery**: The memtable is rebuilt from the heap on startup, so no
 data is lost if Postgres crashes before spilling to disk.
 

--- a/src/access/am.h
+++ b/src/access/am.h
@@ -152,6 +152,14 @@ struct IndexBulkDeleteResult *tp_vacuumcleanup(
 char *tp_buildphasename(int64 phase);
 
 /*
+ * Spill a memtable to an L0 segment if non-empty.  Used by VACUUM and
+ * by the backend-exit shutdown hook.  Acquires its own LW_EXCLUSIVE
+ * on the per-index lock.
+ */
+void
+tp_spill_memtable_if_needed(Relation index, TpLocalIndexState *index_state);
+
+/*
  * Handler functions (am/handler.c)
  */
 bytea *tp_options(Datum reloptions, bool validate);

--- a/src/access/am.h
+++ b/src/access/am.h
@@ -152,12 +152,11 @@ struct IndexBulkDeleteResult *tp_vacuumcleanup(
 char *tp_buildphasename(int64 phase);
 
 /*
- * Spill a memtable to an L0 segment if non-empty.  Used by VACUUM and
- * by the backend-exit shutdown hook.  Acquires its own LW_EXCLUSIVE
- * on the per-index lock.
+ * Spill a memtable to an L0 segment.  Skips when
+ * total_postings < min_postings.  Acquires LW_EXCLUSIVE internally.
  */
-void
-tp_spill_memtable_if_needed(Relation index, TpLocalIndexState *index_state);
+void tp_spill_memtable_if_needed(
+		Relation index, TpLocalIndexState *index_state, uint64 min_postings);
 
 /*
  * Handler functions (am/handler.c)

--- a/src/access/build.c
+++ b/src/access/build.c
@@ -122,6 +122,8 @@ tp_buildphasename(int64 phase)
 /*
  * Spill the current index's memtable to a disk segment.
  * Returns true if a segment was written.
+ *
+ * Caller must already hold LW_EXCLUSIVE on the per-index lock.
  */
 static bool
 tp_do_spill(TpLocalIndexState *index_state, Relation index_rel)
@@ -135,6 +137,7 @@ tp_do_spill(TpLocalIndexState *index_state, Relation index_rel)
 	tp_clear_memtable(index_state);
 	tp_clear_docid_pages(index_rel);
 	tp_link_l0_chain_head(index_rel, root);
+	tp_sync_metapage_stats(index_rel, index_state);
 
 	pgstat_progress_update_param(
 			PROGRESS_CREATEIDX_SUBPHASE, TP_PHASE_COMPACTING);
@@ -491,8 +494,8 @@ tp_spill_memtable(PG_FUNCTION_ARGS)
 	{
 		tp_clear_memtable(index_state);
 		tp_clear_docid_pages(index_rel);
-
 		tp_link_l0_chain_head(index_rel, segment_root);
+		tp_sync_metapage_stats(index_rel, index_state);
 
 		/* Check if L0 needs compaction */
 		tp_maybe_compact_level(index_rel, 0);

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -55,21 +55,21 @@ typedef struct TpVacuumSegmentInfo
 } TpVacuumSegmentInfo;
 
 /*
- * Spill memtable to L0 segment if non-empty.
+ * Spill memtable to an L0 segment if non-empty.
  *
- * During VACUUM, we want all index data in segments for uniform
- * processing.  This forces any in-memory data to disk.
+ * Used both by VACUUM (to force all data into segments for uniform
+ * processing) and by the backend-exit shutdown hook (to drain the
+ * docid-page chain before the next server start).  No-op if the
+ * memtable is empty.
  *
- * Caller must hold at least AccessExclusiveLock on the index
- * (standard for ambulkdelete).  The memtable is in DSA, which
- * is pinned for the lifetime of the shared index state and
- * cannot be freed by another backend.  The pre-lock read of
- * total_postings is a fast bailout; if it races with an insert,
- * the worst case is we enter tp_write_segment with an empty
- * memtable, which is a harmless no-op.
+ * The memtable lives in DSA and is pinned for the lifetime of the
+ * shared index state, so it can't be freed by another backend.  The
+ * pre-lock read of total_postings is a fast bailout; if it races with
+ * an insert, the worst case is we enter tp_write_segment with an
+ * empty memtable, which is a harmless no-op.
  */
-static void
-tp_vacuum_spill_memtable(Relation index, TpLocalIndexState *index_state)
+void
+tp_spill_memtable_if_needed(Relation index, TpLocalIndexState *index_state)
 {
 	TpMemtable *memtable;
 	BlockNumber segment_root;
@@ -89,6 +89,7 @@ tp_vacuum_spill_memtable(Relation index, TpLocalIndexState *index_state)
 		tp_clear_memtable(index_state);
 		tp_clear_docid_pages(index);
 		tp_link_l0_chain_head(index, segment_root);
+		tp_sync_metapage_stats(index, index_state);
 		tp_maybe_compact_level(index, 0);
 	}
 
@@ -633,7 +634,7 @@ tp_bulkdelete(
 	/* Phase 1: Spill memtable so all data is in segments */
 	index_state = tp_get_local_index_state(RelationGetRelid(info->index));
 	if (index_state != NULL)
-		tp_vacuum_spill_memtable(info->index, index_state);
+		tp_spill_memtable_if_needed(info->index, index_state);
 
 	/* Re-read metapage after spill */
 	pfree(metap);
@@ -778,6 +779,29 @@ tp_bulkdelete(
 
 			GenericXLogFinish(xlog_state);
 			UnlockReleaseBuffer(mbuf);
+
+			/*
+			 * Intentionally do NOT update the shared-memory atomic
+			 * here.  Segment-level doc_freq metadata (written at
+			 * segment creation time) reflects the original insert
+			 * count, not the post-VACUUM alive count.  Leaving the
+			 * atomic at "cumulative inserts" keeps BM25 IDF's N and
+			 * per-term df in the same reference frame; reducing N
+			 * to "alive count" while df stays at "cumulative" makes
+			 * N < df for common terms, producing negative IDF.
+			 *
+			 * The consequence is that tp_sync_metapage_stats in any
+			 * post-Phase-4 spill (e.g. tp_vacuumcleanup) will
+			 * overwrite the decremented metapage with the un-adjusted
+			 * atomic, effectively rolling back Phase 4.  That is
+			 * acceptable for now — it restores the pre-PR behavior
+			 * where VACUUM's metapage adjustment was only observable
+			 * until the next spill/restart, which is the same
+			 * frame-of-reference the segment doc_freqs sit in.  A
+			 * proper fix requires also updating per-segment
+			 * doc_freq counts on VACUUM, which is out of scope for
+			 * issue #333.
+			 */
 		}
 	}
 
@@ -833,7 +857,7 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 	 */
 	index_state = tp_get_local_index_state(RelationGetRelid(info->index));
 	if (index_state != NULL)
-		tp_vacuum_spill_memtable(info->index, index_state);
+		tp_spill_memtable_if_needed(info->index, index_state);
 
 	/* Get current index statistics from metapage */
 	metap = tp_get_metapage(info->index);

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -55,21 +55,16 @@ typedef struct TpVacuumSegmentInfo
 } TpVacuumSegmentInfo;
 
 /*
- * Spill memtable to an L0 segment if non-empty.
- *
- * Used both by VACUUM (to force all data into segments for uniform
- * processing) and by the backend-exit shutdown hook (to drain the
- * docid-page chain before the next server start).  No-op if the
- * memtable is empty.
- *
- * The memtable lives in DSA and is pinned for the lifetime of the
- * shared index state, so it can't be freed by another backend.  The
- * pre-lock read of total_postings is a fast bailout; if it races with
- * an insert, the worst case is we enter tp_write_segment with an
- * empty memtable, which is a harmless no-op.
+ * Spill memtable to an L0 segment.  Caller passes a minimum posting
+ * count below which the spill is a no-op — used by VACUUM cleanup
+ * and the shutdown hook to avoid producing runt L0 segments on
+ * lightly-loaded indexes.  The pre-lock read is a fast bailout; if
+ * it races with an insert, the worst case is a harmless no-op
+ * inside tp_write_segment.
  */
 void
-tp_spill_memtable_if_needed(Relation index, TpLocalIndexState *index_state)
+tp_spill_memtable_if_needed(
+		Relation index, TpLocalIndexState *index_state, uint64 min_postings)
 {
 	TpMemtable *memtable;
 	BlockNumber segment_root;
@@ -78,7 +73,8 @@ tp_spill_memtable_if_needed(Relation index, TpLocalIndexState *index_state)
 		return;
 
 	memtable = get_memtable(index_state);
-	if (!memtable || pg_atomic_read_u64(&memtable->total_postings) == 0)
+	if (!memtable ||
+		pg_atomic_read_u64(&memtable->total_postings) < min_postings)
 		return;
 
 	tp_acquire_index_lock(index_state, LW_EXCLUSIVE);
@@ -631,10 +627,14 @@ tp_bulkdelete(
 		return stats;
 	}
 
-	/* Phase 1: Spill memtable so all data is in segments */
+	/*
+	 * Phase 1: Spill memtable so all data is in segments.  Pass
+	 * min_postings=1 to preserve existing "spill anything non-empty"
+	 * behavior for the bulkdelete path.
+	 */
 	index_state = tp_get_local_index_state(RelationGetRelid(info->index));
 	if (index_state != NULL)
-		tp_spill_memtable_if_needed(info->index, index_state);
+		tp_spill_memtable_if_needed(info->index, index_state, 1);
 
 	/* Re-read metapage after spill */
 	pfree(metap);
@@ -779,29 +779,6 @@ tp_bulkdelete(
 
 			GenericXLogFinish(xlog_state);
 			UnlockReleaseBuffer(mbuf);
-
-			/*
-			 * Intentionally do NOT update the shared-memory atomic
-			 * here.  Segment-level doc_freq metadata (written at
-			 * segment creation time) reflects the original insert
-			 * count, not the post-VACUUM alive count.  Leaving the
-			 * atomic at "cumulative inserts" keeps BM25 IDF's N and
-			 * per-term df in the same reference frame; reducing N
-			 * to "alive count" while df stays at "cumulative" makes
-			 * N < df for common terms, producing negative IDF.
-			 *
-			 * The consequence is that tp_sync_metapage_stats in any
-			 * post-Phase-4 spill (e.g. tp_vacuumcleanup) will
-			 * overwrite the decremented metapage with the un-adjusted
-			 * atomic, effectively rolling back Phase 4.  That is
-			 * acceptable for now — it restores the pre-PR behavior
-			 * where VACUUM's metapage adjustment was only observable
-			 * until the next spill/restart, which is the same
-			 * frame-of-reference the segment doc_freqs sit in.  A
-			 * proper fix requires also updating per-segment
-			 * doc_freq counts on VACUUM, which is out of scope for
-			 * issue #333.
-			 */
 		}
 	}
 
@@ -845,19 +822,18 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 				sizeof(IndexBulkDeleteResult));
 
 	/*
-	 * Spill any un-spilled memtable contents to an L0 segment. On
-	 * insert-only workloads ambulkdelete is skipped (no dead tuples),
-	 * which previously left the docid-page chain growing unbounded and
-	 * made the first query after a server restart slow (the chain is
-	 * walked and every referenced heap tuple re-tokenized to rebuild
-	 * the memtable). Doing the spill here ensures every VACUUM — and
-	 * by extension periodic autovacuum, including the insert-triggered
-	 * path — shrinks the recovery cost to near-zero. A no-op if the
-	 * memtable is already empty (e.g. when ambulkdelete just ran).
+	 * Spill the memtable so the docid chain doesn't outlive a
+	 * server restart.  Insert-only tables skip ambulkdelete (no
+	 * dead tuples), so without this call nothing would spill and
+	 * the first query after the next start would be slow.  Skip
+	 * under TP_MIN_SPILL_POSTINGS — that few docs is faster to
+	 * replay from heap on restart than a runt L0 segment would be
+	 * to compact away.
 	 */
 	index_state = tp_get_local_index_state(RelationGetRelid(info->index));
 	if (index_state != NULL)
-		tp_spill_memtable_if_needed(info->index, index_state);
+		tp_spill_memtable_if_needed(
+				info->index, index_state, TP_MIN_SPILL_POSTINGS);
 
 	/* Get current index statistics from metapage */
 	metap = tp_get_metapage(info->index);

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -812,12 +812,28 @@ tp_bulkdelete(
 IndexBulkDeleteResult *
 tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 {
-	TpIndexMetaPage metap;
+	TpIndexMetaPage	   metap;
+	TpLocalIndexState *index_state;
 
 	/* Initialize stats if not provided */
 	if (stats == NULL)
 		stats = (IndexBulkDeleteResult *)palloc0(
 				sizeof(IndexBulkDeleteResult));
+
+	/*
+	 * Spill any un-spilled memtable contents to an L0 segment. On
+	 * insert-only workloads ambulkdelete is skipped (no dead tuples),
+	 * which previously left the docid-page chain growing unbounded and
+	 * made the first query after a server restart slow (the chain is
+	 * walked and every referenced heap tuple re-tokenized to rebuild
+	 * the memtable). Doing the spill here ensures every VACUUM — and
+	 * by extension periodic autovacuum, including the insert-triggered
+	 * path — shrinks the recovery cost to near-zero. A no-op if the
+	 * memtable is already empty (e.g. when ambulkdelete just ran).
+	 */
+	index_state = tp_get_local_index_state(RelationGetRelid(info->index));
+	if (index_state != NULL)
+		tp_vacuum_spill_memtable(info->index, index_state);
 
 	/* Get current index statistics from metapage */
 	metap = tp_get_metapage(info->index);

--- a/src/constants.h
+++ b/src/constants.h
@@ -43,6 +43,15 @@
 #define TP_DEFAULT_MEMTABLE_SPILL_THRESHOLD \
 	32000000 /* posting entries to trigger spill (~1M docs/segment) */
 
+/*
+ * Lower bound on postings for VACUUM-cleanup and shutdown-hook
+ * spills.  Below this, re-tokenizing the docid chain from heap on
+ * the next server start is fast enough that writing a runt L0
+ * segment isn't worthwhile — LSM compaction would spend more work
+ * consolidating tiny segments than the chain replay costs.
+ */
+#define TP_MIN_SPILL_POSTINGS 1000
+
 /* Hash table sizes */
 #define TP_STRING_INTERNING_HASH_SIZE	  1024
 #define TP_POSTING_LIST_HASH_INITIAL_SIZE 32

--- a/src/index/metapage.c
+++ b/src/index/metapage.c
@@ -168,16 +168,8 @@ tp_get_metapage(Relation index)
 }
 
 /*
- * Copy the live total_docs / total_len from the shared-memory atomics
- * into the metapage.  Callers must already hold LW_EXCLUSIVE on the
- * per-index lock.
- *
- * This needs to run on every successful spill (VACUUM, shutdown
- * hook, bm25_spill_index, auto-spill): the crash-recovery path in
- * tp_rebuild_index_from_disk reads metap->total_docs as authoritative
- * and overwrites the shared-memory atomic with it, so un-synced
- * post-build inserts would otherwise be forgotten across a restart
- * and BM25 scoring would degrade.
+ * Persist the shared-memory atomic into the metapage.  See
+ * TpIndexMetaPageData.total_docs in metapage.h for semantics.
  */
 void
 tp_sync_metapage_stats(Relation index, TpLocalIndexState *index_state)

--- a/src/index/metapage.c
+++ b/src/index/metapage.c
@@ -168,6 +168,48 @@ tp_get_metapage(Relation index)
 }
 
 /*
+ * Copy the live total_docs / total_len from the shared-memory atomics
+ * into the metapage.  Callers must already hold LW_EXCLUSIVE on the
+ * per-index lock.
+ *
+ * This needs to run on every successful spill (VACUUM, shutdown
+ * hook, bm25_spill_index, auto-spill): the crash-recovery path in
+ * tp_rebuild_index_from_disk reads metap->total_docs as authoritative
+ * and overwrites the shared-memory atomic with it, so un-synced
+ * post-build inserts would otherwise be forgotten across a restart
+ * and BM25 scoring would degrade.
+ */
+void
+tp_sync_metapage_stats(Relation index, TpLocalIndexState *index_state)
+{
+	Buffer			  mbuf;
+	GenericXLogState *xlog_state;
+	Page			  mpage;
+	TpIndexMetaPage	  mp;
+	uint32			  total_docs;
+	uint64			  total_len;
+
+	if (index_state == NULL || index_state->shared == NULL)
+		return;
+
+	total_docs = pg_atomic_read_u32(&index_state->shared->total_docs);
+	total_len  = pg_atomic_read_u64(&index_state->shared->total_len);
+
+	mbuf = ReadBuffer(index, TP_METAPAGE_BLKNO);
+	LockBuffer(mbuf, BUFFER_LOCK_EXCLUSIVE);
+
+	xlog_state = GenericXLogStart(index);
+	mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);
+	mp		   = (TpIndexMetaPage)PageGetContents(mpage);
+
+	mp->total_docs = total_docs;
+	mp->total_len  = total_len;
+
+	GenericXLogFinish(xlog_state);
+	UnlockReleaseBuffer(mbuf);
+}
+
+/*
  * Add a document ID to the docid pages for crash recovery
  * This appends the ctid to the chain of docid pages
  *

--- a/src/index/metapage.h
+++ b/src/index/metapage.h
@@ -70,6 +70,16 @@ typedef struct TpDocidPageHeader
  */
 extern void			   tp_init_metapage(Page page, Oid text_config_oid);
 extern TpIndexMetaPage tp_get_metapage(Relation index);
+
+/*
+ * Copy the live total_docs/total_len from the shared-memory atomics
+ * into the metapage.  Callers must hold LW_EXCLUSIVE on the per-index
+ * lock.  This is needed after a memtable spill drains the docid chain:
+ * the recovery path on the next server start reads metap->total_docs
+ * as authoritative, so it has to reflect reality at spill time.
+ */
+extern void
+tp_sync_metapage_stats(Relation index, TpLocalIndexState *index_state);
 /*
  * Document ID operations for crash recovery
  */

--- a/src/index/metapage.h
+++ b/src/index/metapage.h
@@ -31,12 +31,17 @@ typedef struct TpLocalIndexState TpLocalIndexState;
  */
 typedef struct TpIndexMetaPageData
 {
-	uint32		magic;				 /* Magic number for validation */
-	uint32		version;			 /* Index format version */
-	Oid			text_config_oid;	 /* Text search configuration OID */
-	uint64		total_docs;			 /* Total number of documents */
+	uint32 magic;			/* Magic number for validation */
+	uint32 version;			/* Index format version */
+	Oid	   text_config_oid; /* Text search configuration OID */
+	/*
+	 * Persisted snapshot of the shared-memory atomic.  Updated at
+	 * each memtable spill; loaded back into the atomic on restart
+	 * via tp_rebuild_index_from_disk.
+	 */
+	uint64		total_docs;
 	uint64		_unused_total_terms; /* Unused, retained for on-disk compat */
-	uint64		total_len;			 /* Total length of all documents */
+	uint64		total_len;			 /* Analogous snapshot of total doc len */
 	float4		k1;					 /* BM25 k1 parameter */
 	float4		b;					 /* BM25 b parameter */
 	BlockNumber root_blkno;			 /* Root page of the index tree */
@@ -72,11 +77,9 @@ extern void			   tp_init_metapage(Page page, Oid text_config_oid);
 extern TpIndexMetaPage tp_get_metapage(Relation index);
 
 /*
- * Copy the live total_docs/total_len from the shared-memory atomics
- * into the metapage.  Callers must hold LW_EXCLUSIVE on the per-index
- * lock.  This is needed after a memtable spill drains the docid chain:
- * the recovery path on the next server start reads metap->total_docs
- * as authoritative, so it has to reflect reality at spill time.
+ * Persist the shared-memory atomic into the metapage.  Called at
+ * every spill site; caller must hold LW_EXCLUSIVE on the per-index
+ * lock.
  */
 extern void
 tp_sync_metapage_stats(Relation index, TpLocalIndexState *index_state);

--- a/src/index/registry.c
+++ b/src/index/registry.c
@@ -830,6 +830,7 @@ tp_evict_largest_memtable(Oid caller_oid)
 			tp_clear_memtable(target_state);
 			tp_clear_docid_pages(index_rel);
 			tp_link_l0_chain_head(index_rel, segment_root);
+			tp_sync_metapage_stats(index_rel, target_state);
 			tp_maybe_compact_level(index_rel, 0);
 
 			elog(LOG,

--- a/src/index/state.c
+++ b/src/index/state.c
@@ -22,6 +22,7 @@
 #include <storage/bufmgr.h>
 #include <storage/dsm.h>
 #include <storage/dsm_registry.h>
+#include <storage/ipc.h>
 #include <utils/builtins.h>
 #include <utils/dsa.h>
 #include <utils/hsearch.h>
@@ -49,6 +50,137 @@ typedef struct LocalStateCacheEntry
 	TpLocalIndexState *local_state; /* Cached local state */
 } LocalStateCacheEntry;
 
+/* Registered with before_shmem_exit at most once per backend */
+static bool shutdown_hook_registered = false;
+
+/*
+ * Spill one cache entry's memtable if we can open the index.  Split
+ * out from the loop so its PG_TRY doesn't nest inside the outer
+ * PG_TRY in tp_shutdown_spill_callback — nested PG_TRYs in the same
+ * lexical scope shadow each other's locals and trip
+ * -Werror=shadow=compatible-local on CI.
+ */
+static void
+tp_shutdown_spill_one(LocalStateCacheEntry *entry)
+{
+	Relation index_rel = NULL;
+
+	if (entry->local_state == NULL)
+		return;
+
+	PG_TRY();
+	{
+		index_rel = try_index_open(entry->index_oid, RowExclusiveLock);
+		if (index_rel != NULL)
+		{
+			tp_spill_memtable_if_needed(index_rel, entry->local_state);
+			index_close(index_rel, RowExclusiveLock);
+			index_rel = NULL;
+		}
+	}
+	PG_CATCH();
+	{
+		/*
+		 * Release the per-index LWLock here; otherwise a mid-spill
+		 * ERROR would leave it held until CommitTransactionCommand
+		 * → tp_release_all_index_locks fires at the end of the
+		 * loop, and any other backend's shutdown hook racing for
+		 * the same index would stall in the meantime.
+		 */
+		tp_release_index_lock(entry->local_state);
+		FlushErrorState();
+		if (index_rel != NULL)
+			index_close(index_rel, RowExclusiveLock);
+	}
+	PG_END_TRY();
+}
+
+/*
+ * Backend-exit hook: spill every index this backend has touched.
+ *
+ * On a clean server shutdown Postgres exits backends before running
+ * the final checkpoint.  Draining the memtable here means next
+ * startup's first query doesn't have to walk the docid-page chain
+ * and re-tokenize every un-spilled tuple from the heap.
+ *
+ * The hook runs for *any* non-zero proc_exit code, which includes
+ * cluster shutdown (SIGTERM → FATAL → proc_exit(1)) but also any
+ * other FATAL (e.g., assertion failure, OOM, pg_terminate_backend).
+ * Running on those paths is fine: the per-index LW_EXCLUSIVE inside
+ * tp_spill_memtable_if_needed serializes us against other backends,
+ * and a no-op is cheap when there's nothing un-spilled.
+ *
+ * Everything in this function is best-effort.  The body is wrapped
+ * in a PG_TRY so that any escape from StartTransactionCommand, the
+ * hash loop, or CommitTransactionCommand aborts cleanly without
+ * derailing the rest of proc_exit.
+ */
+static void
+tp_shutdown_spill_callback(int code, Datum arg pg_attribute_unused())
+{
+	HASH_SEQ_STATUS		  status;
+	LocalStateCacheEntry *entry;
+	bool				  started_txn = false;
+
+	if (local_state_cache == NULL)
+		return;
+
+	/*
+	 * Skip clean backend exits (code == 0, e.g. psql `\q`).  Spilling
+	 * on every disconnect would produce spurious segment writes and
+	 * break scripts that rely on the memtable persisting across psql
+	 * invocations.  code != 0 is broader than "cluster shutdown" —
+	 * it catches any FATAL exit — but a spill in those cases is
+	 * still correct, just occasionally redundant.
+	 */
+	if (code == 0)
+		return;
+
+	/*
+	 * A dying backend may reach us mid-abort.  Catalog access
+	 * requires a healthy transaction state; bail out if we can't
+	 * safely get one.
+	 */
+	if (IsAbortedTransactionBlockState())
+		return;
+
+	PG_TRY();
+	{
+		/*
+		 * try_index_open → catcache lookup needs an active
+		 * transaction.  Normal FATAL exit leaves us with no
+		 * transaction; start one.
+		 */
+		if (!IsTransactionState())
+		{
+			StartTransactionCommand();
+			started_txn = true;
+		}
+
+		hash_seq_init(&status, local_state_cache);
+		while ((entry = (LocalStateCacheEntry *)hash_seq_search(&status)) !=
+			   NULL)
+			tp_shutdown_spill_one(entry);
+
+		if (started_txn)
+			CommitTransactionCommand();
+	}
+	PG_CATCH();
+	{
+		/*
+		 * Last-ditch cleanup if StartTransactionCommand,
+		 * hash_seq_init / hash_seq_search, or CommitTransactionCommand
+		 * itself throws.  At this point proc_exit still needs to
+		 * complete, so swallow the error, abort any half-started
+		 * transaction, and return.
+		 */
+		if (IsTransactionState())
+			AbortCurrentTransaction();
+		FlushErrorState();
+	}
+	PG_END_TRY();
+}
+
 /*
  * Initialize the local state cache
  */
@@ -70,6 +202,12 @@ init_local_state_cache(void)
 			8, /* initial size */
 			&ctl,
 			HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+
+	if (!shutdown_hook_registered)
+	{
+		before_shmem_exit(tp_shutdown_spill_callback, (Datum)0);
+		shutdown_hook_registered = true;
+	}
 }
 
 /*
@@ -1190,12 +1328,15 @@ tp_rebuild_posting_lists_from_docids(
 				int32 doc_length;
 
 				/*
-				 * tp_process_document_text → tp_add_document_terms
-				 * already increments total_docs / total_len, so we
-				 * don't do it here. The final values are overwritten
-				 * from the metapage by the caller (the authoritative
-				 * source), but updating the running count during the
-				 * rebuild keeps the INFO log accurate.
+				 * The atomic counters are incremented inside
+				 * tp_add_document_terms (called from
+				 * tp_process_document_text), so we don't double-count
+				 * them here.  The caller subsequently overwrites the
+				 * atomics from the metapage (state.c ~1105), making
+				 * that the authoritative source; the transient
+				 * increments exist only to make the INFO log at the
+				 * end of this function report the real restored
+				 * count.
 				 */
 				(void)tp_process_document_text(
 						document_text,
@@ -1554,6 +1695,7 @@ tp_bulk_load_spill_check(void)
 			tp_clear_memtable(local_state);
 			tp_clear_docid_pages(index_rel);
 			tp_link_l0_chain_head(index_rel, segment_root);
+			tp_sync_metapage_stats(index_rel, local_state);
 
 			/* Check if L0 needs compaction */
 			tp_maybe_compact_level(index_rel, 0);

--- a/src/index/state.c
+++ b/src/index/state.c
@@ -1189,20 +1189,21 @@ tp_rebuild_posting_lists_from_docids(
 				text *document_text = DatumGetTextPP(idx_values[0]);
 				int32 doc_length;
 
-				if (tp_process_document_text(
-							document_text,
-							ctid,
-							metap->text_config_oid,
-							local_state,
-							NULL,
-							&doc_length))
-				{
-					/* Update corpus statistics */
-					pg_atomic_fetch_add_u32(
-							&local_state->shared->total_docs, 1);
-					pg_atomic_fetch_add_u64(
-							&local_state->shared->total_len, doc_length);
-				}
+				/*
+				 * tp_process_document_text → tp_add_document_terms
+				 * already increments total_docs / total_len, so we
+				 * don't do it here. The final values are overwritten
+				 * from the metapage by the caller (the authoritative
+				 * source), but updating the running count during the
+				 * rebuild keeps the INFO log accurate.
+				 */
+				(void)tp_process_document_text(
+						document_text,
+						ctid,
+						metap->text_config_oid,
+						local_state,
+						NULL,
+						&doc_length);
 			}
 
 			ExecClearTuple(eval_slot);

--- a/src/index/state.c
+++ b/src/index/state.c
@@ -54,11 +54,11 @@ typedef struct LocalStateCacheEntry
 static bool shutdown_hook_registered = false;
 
 /*
- * Spill one cache entry's memtable if we can open the index.  Split
- * out from the loop so its PG_TRY doesn't nest inside the outer
- * PG_TRY in tp_shutdown_spill_callback — nested PG_TRYs in the same
- * lexical scope shadow each other's locals and trip
- * -Werror=shadow=compatible-local on CI.
+ * Spill one cache entry, catching and swallowing any error so the
+ * outer loop can continue with the remaining entries.  Split out of
+ * tp_shutdown_spill_callback so its PG_TRY doesn't nest in the same
+ * lexical scope (which would shadow the outer PG_TRY's locals and
+ * trip -Werror=shadow=compatible-local).
  */
 static void
 tp_shutdown_spill_one(LocalStateCacheEntry *entry)
@@ -80,13 +80,7 @@ tp_shutdown_spill_one(LocalStateCacheEntry *entry)
 	}
 	PG_CATCH();
 	{
-		/*
-		 * Release the per-index LWLock here; otherwise a mid-spill
-		 * ERROR would leave it held until CommitTransactionCommand
-		 * → tp_release_all_index_locks fires at the end of the
-		 * loop, and any other backend's shutdown hook racing for
-		 * the same index would stall in the meantime.
-		 */
+		/* Don't leak the per-index LWLock to racing shutdown hooks */
 		tp_release_index_lock(entry->local_state);
 		FlushErrorState();
 		if (index_rel != NULL)
@@ -96,24 +90,11 @@ tp_shutdown_spill_one(LocalStateCacheEntry *entry)
 }
 
 /*
- * Backend-exit hook: spill every index this backend has touched.
- *
- * On a clean server shutdown Postgres exits backends before running
- * the final checkpoint.  Draining the memtable here means next
- * startup's first query doesn't have to walk the docid-page chain
- * and re-tokenize every un-spilled tuple from the heap.
- *
- * The hook runs for *any* non-zero proc_exit code, which includes
- * cluster shutdown (SIGTERM → FATAL → proc_exit(1)) but also any
- * other FATAL (e.g., assertion failure, OOM, pg_terminate_backend).
- * Running on those paths is fine: the per-index LW_EXCLUSIVE inside
- * tp_spill_memtable_if_needed serializes us against other backends,
- * and a no-op is cheap when there's nothing un-spilled.
- *
- * Everything in this function is best-effort.  The body is wrapped
- * in a PG_TRY so that any escape from StartTransactionCommand, the
- * hash loop, or CommitTransactionCommand aborts cleanly without
- * derailing the rest of proc_exit.
+ * before_shmem_exit hook: spill the memtable of every index this
+ * backend has touched, so the docid chain doesn't have to be
+ * replayed from heap on the next server start.  Skipped on clean
+ * client exit (code == 0); fires on any FATAL (cluster shutdown,
+ * pg_terminate_backend, etc.).
  */
 static void
 tp_shutdown_spill_callback(int code, Datum arg pg_attribute_unused())
@@ -122,35 +103,15 @@ tp_shutdown_spill_callback(int code, Datum arg pg_attribute_unused())
 	LocalStateCacheEntry *entry;
 	bool				  started_txn = false;
 
-	if (local_state_cache == NULL)
+	if (local_state_cache == NULL || code == 0)
 		return;
 
-	/*
-	 * Skip clean backend exits (code == 0, e.g. psql `\q`).  Spilling
-	 * on every disconnect would produce spurious segment writes and
-	 * break scripts that rely on the memtable persisting across psql
-	 * invocations.  code != 0 is broader than "cluster shutdown" —
-	 * it catches any FATAL exit — but a spill in those cases is
-	 * still correct, just occasionally redundant.
-	 */
-	if (code == 0)
-		return;
-
-	/*
-	 * A dying backend may reach us mid-abort.  Catalog access
-	 * requires a healthy transaction state; bail out if we can't
-	 * safely get one.
-	 */
+	/* catalog access needs a non-aborted transaction */
 	if (IsAbortedTransactionBlockState())
 		return;
 
 	PG_TRY();
 	{
-		/*
-		 * try_index_open → catcache lookup needs an active
-		 * transaction.  Normal FATAL exit leaves us with no
-		 * transaction; start one.
-		 */
 		if (!IsTransactionState())
 		{
 			StartTransactionCommand();
@@ -167,13 +128,7 @@ tp_shutdown_spill_callback(int code, Datum arg pg_attribute_unused())
 	}
 	PG_CATCH();
 	{
-		/*
-		 * Last-ditch cleanup if StartTransactionCommand,
-		 * hash_seq_init / hash_seq_search, or CommitTransactionCommand
-		 * itself throws.  At this point proc_exit still needs to
-		 * complete, so swallow the error, abort any half-started
-		 * transaction, and return.
-		 */
+		/* proc_exit still has to complete; swallow and move on */
 		if (IsTransactionState())
 			AbortCurrentTransaction();
 		FlushErrorState();
@@ -1327,17 +1282,7 @@ tp_rebuild_posting_lists_from_docids(
 				text *document_text = DatumGetTextPP(idx_values[0]);
 				int32 doc_length;
 
-				/*
-				 * The atomic counters are incremented inside
-				 * tp_add_document_terms (called from
-				 * tp_process_document_text), so we don't double-count
-				 * them here.  The caller subsequently overwrites the
-				 * atomics from the metapage (state.c ~1105), making
-				 * that the authoritative source; the transient
-				 * increments exist only to make the INFO log at the
-				 * end of this function report the real restored
-				 * count.
-				 */
+				/* tp_add_document_terms already increments the atomic */
 				(void)tp_process_document_text(
 						document_text,
 						ctid,

--- a/src/index/state.c
+++ b/src/index/state.c
@@ -73,7 +73,8 @@ tp_shutdown_spill_one(LocalStateCacheEntry *entry)
 		index_rel = try_index_open(entry->index_oid, RowExclusiveLock);
 		if (index_rel != NULL)
 		{
-			tp_spill_memtable_if_needed(index_rel, entry->local_state);
+			tp_spill_memtable_if_needed(
+					index_rel, entry->local_state, TP_MIN_SPILL_POSTINGS);
 			index_close(index_rel, RowExclusiveLock);
 			index_rel = NULL;
 		}

--- a/test/expected/vacuum_extended.out
+++ b/test/expected/vacuum_extended.out
@@ -276,16 +276,15 @@ NOTICE:  BM25 index build started for relation vacuum_insert_only_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
--- Populate the docid chain without tripping bulk-load auto-spill
--- (200 docs * ~4 terms each is well under pg_textsearch.bulk_load_threshold).
+-- Populate the docid chain above TP_MIN_SPILL_POSTINGS (1000) but
+-- below pg_textsearch.bulk_load_threshold so the spill only happens
+-- via amvacuumcleanup.  2000 docs * ~4 terms each ≈ 8000 postings.
 INSERT INTO vacuum_insert_only_test (content)
 SELECT 'insert only document number ' || i
-FROM generate_series(1, 200) AS i;
--- Chain should be populated before VACUUM.  End-anchor to avoid
--- matching "docids: 2000" if a regression accidentally grows the
--- insert count.
+FROM generate_series(1, 2000) AS i;
+-- Chain should be populated before VACUUM.
 SELECT bm25_summarize_index('vacuum_insert_only_idx')
-        ~ E'docids: 200\n'
+        ~ E'docids: 2000\n'
     AS chain_populated_before_vacuum;
  chain_populated_before_vacuum 
 -------------------------------
@@ -304,7 +303,7 @@ SELECT bm25_summarize_index('vacuum_insert_only_idx')
  t
 (1 row)
 
--- Search still finds all 200 docs.
+-- Search still finds all 2000 docs.
 SELECT count(*) AS post_vacuum_count FROM (
     SELECT 1 FROM vacuum_insert_only_test
     ORDER BY content
@@ -312,9 +311,38 @@ SELECT count(*) AS post_vacuum_count FROM (
 ) sub;
  post_vacuum_count 
 -------------------
-               200
+              2000
 (1 row)
 
 DROP TABLE vacuum_insert_only_test;
+-- =============================================================================
+-- Test 8: tiny memtable stays un-spilled across VACUUM (issue #333 guard)
+-- =============================================================================
+--
+-- Below TP_MIN_SPILL_POSTINGS the VACUUM-cleanup spill is a no-op,
+-- because writing a runt L0 segment would cost more in subsequent
+-- compaction than chain replay saves.
+CREATE TABLE vacuum_tiny_test (id serial PRIMARY KEY, content text);
+CREATE INDEX vacuum_tiny_idx
+    ON vacuum_tiny_test USING bm25(content)
+    WITH (text_config='english');
+NOTICE:  BM25 index build started for relation vacuum_tiny_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+-- ~50 docs * ~4 terms = ~200 postings, well below the guard.
+INSERT INTO vacuum_tiny_test (content)
+SELECT 'tiny doc ' || i FROM generate_series(1, 50) AS i;
+VACUUM vacuum_tiny_test;
+-- Chain is still present; no runt L0 segment was produced.
+SELECT bm25_summarize_index('vacuum_tiny_idx')
+        ~ E'docids: 50\n'
+    AS chain_preserved_after_vacuum;
+ chain_preserved_after_vacuum 
+------------------------------
+ t
+(1 row)
+
+DROP TABLE vacuum_tiny_test;
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/vacuum_extended.out
+++ b/test/expected/vacuum_extended.out
@@ -256,5 +256,65 @@ SELECT count(*) AS final_count FROM (
 
 RESET pg_textsearch.memtable_spill_threshold;
 DROP TABLE bulk_memtable_test;
+-- =============================================================================
+-- Test 7: VACUUM spills un-spilled memtable on insert-only tables (issue #333)
+--
+-- On insert-only workloads ambulkdelete is skipped (no dead tuples), so the
+-- memtable spill that used to live only there never ran.  The docid-page
+-- chain then grew unbounded and the first query after a server restart had
+-- to re-tokenize every referenced heap tuple.  This test exercises the
+-- amvacuumcleanup path that now performs the spill.
+-- =============================================================================
+CREATE TABLE vacuum_insert_only_test (
+    id serial PRIMARY KEY,
+    content text
+);
+CREATE INDEX vacuum_insert_only_idx
+    ON vacuum_insert_only_test USING bm25(content)
+    WITH (text_config='english');
+NOTICE:  BM25 index build started for relation vacuum_insert_only_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+-- Populate the docid chain without tripping bulk-load auto-spill
+-- (200 docs * ~4 terms each is well under pg_textsearch.bulk_load_threshold).
+INSERT INTO vacuum_insert_only_test (content)
+SELECT 'insert only document number ' || i
+FROM generate_series(1, 200) AS i;
+-- Chain should be populated before VACUUM.  End-anchor to avoid
+-- matching "docids: 2000" if a regression accidentally grows the
+-- insert count.
+SELECT bm25_summarize_index('vacuum_insert_only_idx')
+        ~ E'docids: 200\n'
+    AS chain_populated_before_vacuum;
+ chain_populated_before_vacuum 
+-------------------------------
+ t
+(1 row)
+
+-- No dead tuples here, so ambulkdelete is not invoked; only
+-- amvacuumcleanup runs.  It must still drain the docid chain.
+VACUUM vacuum_insert_only_test;
+-- Chain must be fully drained and the memtable contents spilled to a segment.
+SELECT bm25_summarize_index('vacuum_insert_only_idx')
+        ~ E'docids: 0\n'
+    AS chain_empty_after_vacuum;
+ chain_empty_after_vacuum 
+--------------------------
+ t
+(1 row)
+
+-- Search still finds all 200 docs.
+SELECT count(*) AS post_vacuum_count FROM (
+    SELECT 1 FROM vacuum_insert_only_test
+    ORDER BY content
+        <@> to_bm25query('document', 'vacuum_insert_only_idx')
+) sub;
+ post_vacuum_count 
+-------------------
+               200
+(1 row)
+
+DROP TABLE vacuum_insert_only_test;
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/scripts/shutdown_spill.sh
+++ b/test/scripts/shutdown_spill.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# Clean-shutdown spill test (regression test for issue #333, scenario A).
+#
+# On a clean pg_ctl stop, backends that are still alive receive SIGTERM.
+# The before_shmem_exit hook spills any un-spilled memtable contents to
+# segments and drains the docid-page chain.  Without this, the first
+# query after the next server start has to walk the entire chain and
+# re-tokenize every referenced heap tuple.
+#
+# This test only exercises the path where a backend is still alive at
+# shutdown time (hook fires).  The short-connection path (no backend
+# alive at shutdown) is handled by the VACUUM-based fix; see
+# vacuum_extended.sql Test 7.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PORT=55441
+TEST_DB=shutdown_spill_test
+DATA_DIR="${SCRIPT_DIR}/../tmp_shutdown_spill_test"
+LOGFILE="${DATA_DIR}/postgres.log"
+
+PGBINDIR="$(pg_config --bindir)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+log()   { echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"; }
+error() { echo -e "${RED}[$(date '+%H:%M:%S')] ERROR: $1${NC}"; exit 1; }
+
+cleanup() {
+    local exit_code=$?
+    log "Cleaning up (exit code: $exit_code)..."
+    jobs -p | xargs -r kill 2>/dev/null || true
+    if [ -f "${DATA_DIR}/postmaster.pid" ]; then
+        "${PGBINDIR}/pg_ctl" stop -D "${DATA_DIR}" -m fast \
+            >/dev/null 2>&1 || \
+            "${PGBINDIR}/pg_ctl" stop -D "${DATA_DIR}" -m immediate \
+                >/dev/null 2>&1 || true
+    fi
+    rm -rf "${DATA_DIR}"
+    exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+setup() {
+    rm -rf "${DATA_DIR}"
+    mkdir -p "${DATA_DIR}"
+    "${PGBINDIR}/initdb" -D "${DATA_DIR}" \
+        --auth-local=trust --auth-host=trust >/dev/null 2>&1
+
+    cat >> "${DATA_DIR}/postgresql.conf" << EOF
+port = ${TEST_PORT}
+shared_buffers = 128MB
+max_connections = 20
+shared_preload_libraries = 'pg_textsearch'
+unix_socket_directories = '${DATA_DIR}'
+EOF
+
+    "${PGBINDIR}/pg_ctl" start -D "${DATA_DIR}" -l "${LOGFILE}" -w \
+        >/dev/null
+    "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" "${TEST_DB}"
+    "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" \
+        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+}
+
+sql() {
+    "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -tA -c "$1" 2>/dev/null
+}
+
+sql_quiet() {
+    "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -c "$1" >/dev/null 2>&1
+}
+
+main() {
+    log "=== Clean-shutdown spill test (issue #333, scenario A) ==="
+
+    command -v "${PGBINDIR}/pg_ctl" >/dev/null 2>&1 || \
+        error "pg_ctl not found"
+
+    setup
+
+    # Two tables + indexes so the hook iterates more than one entry.
+    sql_quiet "CREATE TABLE docs (id serial PRIMARY KEY, body text);"
+    sql_quiet "CREATE INDEX docs_idx ON docs USING bm25 (body)
+        WITH (text_config='english');"
+    sql_quiet "CREATE TABLE extras (id serial PRIMARY KEY, body text);"
+    sql_quiet "CREATE INDEX extras_idx ON extras USING bm25 (body)
+        WITH (text_config='english');"
+
+    # Populate the docid-page chains without tripping bulk-load
+    # auto-spill.  One INSERT per autocommit statement keeps each
+    # transaction well under the bulk-load threshold, so the rows
+    # accumulate in the memtable / docid chain instead of spilling
+    # to a segment.
+    log "Inserting 500 rows per table in single-statement transactions..."
+    {
+        for i in $(seq 1 500); do
+            echo "INSERT INTO docs (body) VALUES ('doc ${i} "\
+"alpha beta gamma delta epsilon zeta');"
+            echo "INSERT INTO extras (body) VALUES ('extra ${i} "\
+"alpha beta gamma delta epsilon zeta');"
+        done
+    } | "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" >/dev/null 2>&1
+
+    for idx in docs_idx extras_idx; do
+        local pre
+        pre=$(sql "SELECT (bm25_summarize_index('${idx}')::text
+                ~ 'docids: 500')::int")
+        if [ "${pre}" != "1" ]; then
+            error "Pre-shutdown: ${idx} chain not populated as expected"
+        fi
+    done
+    log "Pre-shutdown: both chains hold 500 entries (good)"
+
+    # Long-running backend that has touched BOTH indexes so both
+    # appear in local_state_cache and the shutdown hook's hash-loop
+    # has more than one entry to iterate over.  pg_sleep keeps the
+    # backend alive until pg_ctl stop SIGTERMs it.
+    "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -c "
+            SELECT count(*) FROM (
+                SELECT 1 FROM docs
+                ORDER BY body <@> to_bm25query('alpha', 'docs_idx')
+                LIMIT 1
+            ) s;
+            SELECT count(*) FROM (
+                SELECT 1 FROM extras
+                ORDER BY body <@> to_bm25query('alpha', 'extras_idx')
+                LIMIT 1
+            ) s;
+            SELECT pg_sleep(60);
+        " >/dev/null 2>&1 &
+    SLEEPER_PID=$!
+    sleep 2  # let the backend attach to both indexes
+
+    # Clean shutdown.  Postmaster sends SIGTERM to the sleeping
+    # backend → die handler fires → FATAL → proc_exit(1) → our
+    # before_shmem_exit hook walks local_state_cache and spills
+    # both indexes.
+    log "Clean-shutting down postgres (hook should fire on the live backend)..."
+    "${PGBINDIR}/pg_ctl" stop -D "${DATA_DIR}" -m fast -w \
+        >/dev/null
+    wait "${SLEEPER_PID}" 2>/dev/null || true
+
+    # Restart.
+    "${PGBINDIR}/pg_ctl" start -D "${DATA_DIR}" -l "${LOGFILE}" \
+        -w -t 30 >/dev/null
+    sleep 1
+
+    # Both chains must be drained and both indexes queryable.  We
+    # explicitly do not trigger recovery by querying the index
+    # first — bm25_summarize_index reads the on-disk metapage
+    # directly, so we can observe the pre-recovery chain state.
+    for idx in docs_idx extras_idx; do
+        local post
+        post=$(sql "SELECT (bm25_summarize_index('${idx}')::text
+                ~ 'docids: 0')::int")
+        if [ "${post}" != "1" ]; then
+            local summary
+            summary=$(sql "SELECT bm25_summarize_index('${idx}')")
+            error "Post-restart: ${idx} chain not drained. Summary:
+${summary}"
+        fi
+    done
+    log "Post-restart: both chains are empty (spill happened for each)"
+
+    for pair in "docs:docs_idx" "extras:extras_idx"; do
+        local tbl="${pair%:*}"
+        local idx="${pair#*:}"
+        local count
+        count=$(sql "SELECT count(*) FROM (
+                SELECT 1 FROM ${tbl}
+                ORDER BY body <@> to_bm25query('alpha', '${idx}')
+                LIMIT 1000
+            ) s")
+        if [ "${count}" != "500" ]; then
+            error "Post-restart: ${idx} returned ${count} (expected 500)"
+        fi
+    done
+    log "Post-restart: both indexes return all 500 rows (good)"
+
+    log "=== PASSED ==="
+}
+
+main "$@"

--- a/test/sql/vacuum_extended.sql
+++ b/test/sql/vacuum_extended.sql
@@ -228,17 +228,16 @@ CREATE INDEX vacuum_insert_only_idx
     ON vacuum_insert_only_test USING bm25(content)
     WITH (text_config='english');
 
--- Populate the docid chain without tripping bulk-load auto-spill
--- (200 docs * ~4 terms each is well under pg_textsearch.bulk_load_threshold).
+-- Populate the docid chain above TP_MIN_SPILL_POSTINGS (1000) but
+-- below pg_textsearch.bulk_load_threshold so the spill only happens
+-- via amvacuumcleanup.  2000 docs * ~4 terms each ≈ 8000 postings.
 INSERT INTO vacuum_insert_only_test (content)
 SELECT 'insert only document number ' || i
-FROM generate_series(1, 200) AS i;
+FROM generate_series(1, 2000) AS i;
 
--- Chain should be populated before VACUUM.  End-anchor to avoid
--- matching "docids: 2000" if a regression accidentally grows the
--- insert count.
+-- Chain should be populated before VACUUM.
 SELECT bm25_summarize_index('vacuum_insert_only_idx')
-        ~ E'docids: 200\n'
+        ~ E'docids: 2000\n'
     AS chain_populated_before_vacuum;
 
 -- No dead tuples here, so ambulkdelete is not invoked; only
@@ -250,7 +249,7 @@ SELECT bm25_summarize_index('vacuum_insert_only_idx')
         ~ E'docids: 0\n'
     AS chain_empty_after_vacuum;
 
--- Search still finds all 200 docs.
+-- Search still finds all 2000 docs.
 SELECT count(*) AS post_vacuum_count FROM (
     SELECT 1 FROM vacuum_insert_only_test
     ORDER BY content
@@ -258,6 +257,32 @@ SELECT count(*) AS post_vacuum_count FROM (
 ) sub;
 
 DROP TABLE vacuum_insert_only_test;
+
+-- =============================================================================
+-- Test 8: tiny memtable stays un-spilled across VACUUM (issue #333 guard)
+-- =============================================================================
+--
+-- Below TP_MIN_SPILL_POSTINGS the VACUUM-cleanup spill is a no-op,
+-- because writing a runt L0 segment would cost more in subsequent
+-- compaction than chain replay saves.
+
+CREATE TABLE vacuum_tiny_test (id serial PRIMARY KEY, content text);
+CREATE INDEX vacuum_tiny_idx
+    ON vacuum_tiny_test USING bm25(content)
+    WITH (text_config='english');
+
+-- ~50 docs * ~4 terms = ~200 postings, well below the guard.
+INSERT INTO vacuum_tiny_test (content)
+SELECT 'tiny doc ' || i FROM generate_series(1, 50) AS i;
+
+VACUUM vacuum_tiny_test;
+
+-- Chain is still present; no runt L0 segment was produced.
+SELECT bm25_summarize_index('vacuum_tiny_idx')
+        ~ E'docids: 50\n'
+    AS chain_preserved_after_vacuum;
+
+DROP TABLE vacuum_tiny_test;
 
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/vacuum_extended.sql
+++ b/test/sql/vacuum_extended.sql
@@ -210,5 +210,54 @@ SELECT count(*) AS final_count FROM (
 RESET pg_textsearch.memtable_spill_threshold;
 DROP TABLE bulk_memtable_test;
 
+-- =============================================================================
+-- Test 7: VACUUM spills un-spilled memtable on insert-only tables (issue #333)
+--
+-- On insert-only workloads ambulkdelete is skipped (no dead tuples), so the
+-- memtable spill that used to live only there never ran.  The docid-page
+-- chain then grew unbounded and the first query after a server restart had
+-- to re-tokenize every referenced heap tuple.  This test exercises the
+-- amvacuumcleanup path that now performs the spill.
+-- =============================================================================
+
+CREATE TABLE vacuum_insert_only_test (
+    id serial PRIMARY KEY,
+    content text
+);
+CREATE INDEX vacuum_insert_only_idx
+    ON vacuum_insert_only_test USING bm25(content)
+    WITH (text_config='english');
+
+-- Populate the docid chain without tripping bulk-load auto-spill
+-- (200 docs * ~4 terms each is well under pg_textsearch.bulk_load_threshold).
+INSERT INTO vacuum_insert_only_test (content)
+SELECT 'insert only document number ' || i
+FROM generate_series(1, 200) AS i;
+
+-- Chain should be populated before VACUUM.  End-anchor to avoid
+-- matching "docids: 2000" if a regression accidentally grows the
+-- insert count.
+SELECT bm25_summarize_index('vacuum_insert_only_idx')
+        ~ E'docids: 200\n'
+    AS chain_populated_before_vacuum;
+
+-- No dead tuples here, so ambulkdelete is not invoked; only
+-- amvacuumcleanup runs.  It must still drain the docid chain.
+VACUUM vacuum_insert_only_test;
+
+-- Chain must be fully drained and the memtable contents spilled to a segment.
+SELECT bm25_summarize_index('vacuum_insert_only_idx')
+        ~ E'docids: 0\n'
+    AS chain_empty_after_vacuum;
+
+-- Search still finds all 200 docs.
+SELECT count(*) AS post_vacuum_count FROM (
+    SELECT 1 FROM vacuum_insert_only_test
+    ORDER BY content
+        <@> to_bm25query('document', 'vacuum_insert_only_idx')
+) sub;
+
+DROP TABLE vacuum_insert_only_test;
+
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
Fixes #333.

## Problem

On an insert-heavy bm25 index, the first query after a Postgres restart could take many seconds, scaling linearly with the unspilled insert count. Recovery walks the docid-page chain and re-tokenizes every referenced heap tuple to rebuild the memtable.

Normally a memtable spill kicks in at some point.  But two scenarios don't trigger any existing spill and so let the chain grow very long:

- **Insert-only workloads with small writes.** Inserts aren't large enough to trip the memory-pressure or bulk-load thresholds. Autovacuum runs, but `ambulkdelete` is skipped when there are no dead tuples — so the spill that lives inside it doesn't run either. That's why the reporter's `VACUUM` attempt didn't help.
- **Clean server shutdown with work still in the memtable.** The memtable lives in shared memory and is thrown away when the cluster stops.

## Fix

Add two more spill triggers for the uncovered scenarios:

- **VACUUM cleanup** — move the memtable spill from `ambulkdelete` to `amvacuumcleanup`, which runs on every VACUUM (including the insert-threshold autovacuum path).
- **Backend exit** — a `before_shmem_exit` hook drains indexes the backend has touched when it exits with FATAL (cluster shutdown, `pg_terminate_backend`, etc.). Clean client disconnects (`code == 0`) are skipped so routine psql exits don't produce spurious segment writes.

Both new triggers skip when the memtable has fewer than `TP_MIN_SPILL_POSTINGS` (1000) entries. Below that, chain replay from heap on restart is sub-millisecond — less work than the LSM compaction cost of a runt L0 segment. Existing triggers (memory-pressure, bulk-load, `bm25_spill_index`, INSERT-time auto-spill) have their own much larger thresholds and are unchanged.

Between the two, an idle cluster is drained by autovacuum and an active cluster is drained at shutdown time.

## Measured

Scenario — 10K autocommit INSERTs, long-running session held open during `pg_ctl stop -m fast`, then restart:

| | First query after restart |
|---|---|
| Before | ~260 ms (walk 10K-entry chain, re-tokenize from heap) |
| After | ~4 ms (chain drained during shutdown) |

## Collateral fix

One pre-existing latent issue was surfaced while the primary fix was being built:

**`metap->total_docs` was never re-synced from the atomic after `CREATE INDEX`.** Inserts only bump the in-memory atomic; the metapage copy lagged forever. After a restart, the atomic was restored from the stale metapage, so post-`CREATE INDEX` inserts were silently lost for BM25's corpus size. Added `tp_sync_metapage_stats()` and call it at every spill site.

## Testing

- `make installcheck` — all SQL and shell tests pass.
- Added `test/scripts/shutdown_spill.sh` covering the live-backend-at-shutdown path, wired into `make test-recovery`.
- Added Test 7 (drain path) and Test 8 (tiny-memtable guard) in `vacuum_extended.sql`.

## Known limitations

- The shutdown hook only fires for backends alive when shutdown starts. An idle cluster's chain is drained by VACUUM instead.