### PR TITLE
fix: keep total_docs = Σ segment.num_docs invariant across VACUUM

### DIFF
--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -55,6 +55,45 @@ typedef struct TpVacuumSegmentInfo
 } TpVacuumSegmentInfo;
 
 /*
+ * Sum segment.alive_count across all on-disk segments.  Used by
+ * tp_vacuumcleanup to set stats->num_index_tuples; avoids the
+ * drift that would come from subtracting only new-this-round
+ * deletes from the (never-decremented) metap->total_docs.
+ *
+ * For V5 segments the count is in the header; pre-V5 segments
+ * have no alive-bitset so their alive count equals num_docs.
+ */
+static uint64
+tp_count_live_docs(Relation index, TpIndexMetaPage metap)
+{
+	uint64 alive = 0;
+
+	for (int level = 0; level < TP_MAX_LEVELS; level++)
+	{
+		BlockNumber seg = metap->level_heads[level];
+
+		while (seg != InvalidBlockNumber)
+		{
+			TpSegmentReader *reader = tp_segment_open(index, seg);
+
+			if (!reader || !reader->header)
+			{
+				if (reader)
+					tp_segment_close(reader);
+				break;
+			}
+
+			alive += (reader->header->alive_bitset_offset > 0)
+						   ? reader->header->alive_count
+						   : reader->header->num_docs;
+			seg = reader->header->next_segment;
+			tp_segment_close(reader);
+		}
+	}
+	return alive;
+}
+
+/*
  * Spill memtable to an L0 segment.  Caller passes a minimum posting
  * count below which the spill is a no-op — used by VACUUM cleanup
  * and the shutdown hook to avoid producing runt L0 segments on
@@ -675,8 +714,6 @@ tp_bulkdelete(
 
 	/* Phase 3: Mark dead docs or rebuild affected segments */
 	{
-		uint64 new_total_docs = 0;
-
 		for (int level = 0; level < TP_MAX_LEVELS; level++)
 		{
 			BlockNumber prev = InvalidBlockNumber;
@@ -715,7 +752,6 @@ tp_bulkdelete(
 						}
 						else
 						{
-							new_total_docs += alive;
 							prev = segments[i].root_block;
 						}
 					}
@@ -744,57 +780,30 @@ tp_bulkdelete(
 								new_root,
 								prev);
 
-						new_total_docs += seg_docs;
-
 						if (new_root != InvalidBlockNumber)
 							prev = new_root;
 					}
 				}
 				else
 				{
-					new_total_docs += segments[i].num_docs;
 					prev = segments[i].root_block;
 				}
 			}
 		}
 
-		/* Phase 4: Update metapage statistics */
-		{
-			Buffer			  mbuf;
-			GenericXLogState *xlog_state;
-			Page			  mpage;
-			TpIndexMetaPage	  mp;
-
-			mbuf = ReadBuffer(info->index, TP_METAPAGE_BLKNO);
-			LockBuffer(mbuf, BUFFER_LOCK_EXCLUSIVE);
-
-			xlog_state = GenericXLogStart(info->index);
-			mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);
-			mp		   = (TpIndexMetaPage)PageGetContents(mpage);
-
-			if (mp->total_docs >= (uint64)total_dead)
-				mp->total_docs -= total_dead;
-			else
-				mp->total_docs = new_total_docs;
-
-			GenericXLogFinish(xlog_state);
-			UnlockReleaseBuffer(mbuf);
-		}
+		/*
+		 * No metapage decrement here — see
+		 * TpIndexMetaPageData.total_docs in metapage.h for why.
+		 */
 	}
 
-	/* Fill in return stats */
-	{
-		TpIndexMetaPage mp = tp_get_metapage(info->index);
-
-		if (mp)
-		{
-			stats->num_pages		= 1;
-			stats->num_index_tuples = (double)mp->total_docs;
-			stats->tuples_removed	= (double)total_dead;
-			stats->pages_deleted	= 0;
-			pfree(mp);
-		}
-	}
+	/*
+	 * tp_vacuumcleanup will set num_index_tuples to the actual live
+	 * count; only tuples_removed needs to carry through from here.
+	 */
+	stats->num_pages	  = 1;
+	stats->tuples_removed = (double)total_dead;
+	stats->pages_deleted  = 0;
 
 	pfree(metap);
 	for (int i = 0; i < num_segments; i++)
@@ -839,15 +848,19 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 	metap = tp_get_metapage(info->index);
 	if (metap)
 	{
-		/* Update statistics with current values */
-		stats->num_pages		= 1;
-		stats->num_index_tuples = (double)metap->total_docs;
+		stats->num_pages = 1;
+		/*
+		 * Recompute live count from segments so pg_class.reltuples
+		 * reflects actual alive docs, not the (never-decremented)
+		 * metap->total_docs.  Works regardless of whether
+		 * tp_bulkdelete ran or this is a no-deletes maintenance
+		 * round.
+		 */
+		stats->num_index_tuples = (double)
+				tp_count_live_docs(info->index, metap);
 
-		/* Report current usage statistics */
 		if (stats->pages_deleted == 0 && stats->tuples_removed == 0)
-		{
 			stats->pages_free = 0;
-		}
 
 		pfree(metap);
 	}

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -872,9 +872,24 @@ tp_bulkdelete(
 								new_root,
 								prev);
 
-						docs_shrinkage += segments[i].num_docs - new_docs;
-						tokens_shrinkage += segments[i].total_tokens -
-											new_tokens;
+						/*
+						 * Clamp to zero: new_tokens is a raw
+						 * re-tokenization sum, while
+						 * segments[i].total_tokens comes from a
+						 * pre-V5 header that may have been written
+						 * with a quantized (merge) or cumulative
+						 * (pre-fix L0 spill) value.  Underflow here
+						 * would wrap into a huge positive shrinkage
+						 * before the tp_apply_vacuum_shrinkage clamp
+						 * sees it.  num_docs has no comparable
+						 * corruption path, but clamping both keeps
+						 * the code symmetric.
+						 */
+						if (segments[i].num_docs > new_docs)
+							docs_shrinkage += segments[i].num_docs - new_docs;
+						if (segments[i].total_tokens > new_tokens)
+							tokens_shrinkage += segments[i].total_tokens -
+												new_tokens;
 
 						if (new_root != InvalidBlockNumber)
 							prev = new_root;
@@ -950,9 +965,19 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 		 * alive_count across segments for an accurate live count
 		 * regardless of whether tp_bulkdelete ran or this is a
 		 * no-deletes maintenance round.
+		 *
+		 * Hold the per-index LWLock in shared mode across the walk
+		 * so concurrent spills / compactions (which take
+		 * LW_EXCLUSIVE to mutate level_heads and free segment
+		 * pages via the FSM) can't recycle a page we're about to
+		 * tp_segment_open.
 		 */
+		if (index_state != NULL)
+			tp_acquire_index_lock(index_state, LW_SHARED);
 		stats->num_index_tuples = (double)
 				tp_count_live_docs(info->index, metap);
+		if (index_state != NULL)
+			tp_release_index_lock(index_state);
 
 		if (stats->pages_deleted == 0 && stats->tuples_removed == 0)
 			stats->pages_free = 0;

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -99,9 +99,11 @@ tp_count_live_docs(Relation index, TpIndexMetaPage metap)
  * Apply the invariant total_docs = Σ segment.num_docs (and its
  * total_len counterpart) after Phase 3 has rebuilt or dropped
  * segments.  Decrements both the shared-memory atomic and the
- * on-disk metapage so no subsequent sync re-inflates the metapage
- * from a stale atomic.  See TpIndexMetaPageData.total_docs in
- * metapage.h for the invariant.
+ * on-disk metapage under the metapage buffer exclusive lock so a
+ * concurrent tp_sync_metapage_stats (which acquires the same lock)
+ * cannot observe a half-applied state or re-inflate the metapage
+ * from the atomic between the two decrements.  See
+ * TpIndexMetaPageData.total_docs in metapage.h for the invariant.
  */
 static void
 tp_apply_vacuum_shrinkage(
@@ -118,6 +120,9 @@ tp_apply_vacuum_shrinkage(
 	if (docs_shrinkage == 0 && tokens_shrinkage == 0)
 		return;
 
+	mbuf = ReadBuffer(index, TP_METAPAGE_BLKNO);
+	LockBuffer(mbuf, BUFFER_LOCK_EXCLUSIVE);
+
 	if (index_state != NULL && index_state->shared != NULL)
 	{
 		if (docs_shrinkage > 0)
@@ -127,9 +132,6 @@ tp_apply_vacuum_shrinkage(
 			pg_atomic_fetch_sub_u64(
 					&index_state->shared->total_len, tokens_shrinkage);
 	}
-
-	mbuf = ReadBuffer(index, TP_METAPAGE_BLKNO);
-	LockBuffer(mbuf, BUFFER_LOCK_EXCLUSIVE);
 
 	xlog_state = GenericXLogStart(index);
 	mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -47,7 +47,8 @@ typedef struct TpVacuumSegmentInfo
 	BlockNumber root_block;
 	BlockNumber next_segment;
 	uint32		level;
-	uint32		num_docs;
+	uint32		num_docs;	  /* segment header num_docs */
+	uint64		total_tokens; /* segment header total_tokens */
 	uint32	   *dead_doc_ids; /* Array of dead doc_ids */
 	uint32		dead_count;
 	bool		affected;
@@ -56,9 +57,10 @@ typedef struct TpVacuumSegmentInfo
 
 /*
  * Sum segment.alive_count across all on-disk segments.  Used by
- * tp_vacuumcleanup to set stats->num_index_tuples; avoids the
- * drift that would come from subtracting only new-this-round
- * deletes from the (never-decremented) metap->total_docs.
+ * tp_vacuumcleanup to set stats->num_index_tuples: reltuples must
+ * reflect the live-doc count, which may be strictly less than
+ * metap->total_docs (that tracks Σ segment.num_docs, which for V5
+ * segments includes bitset-dead docs).
  *
  * For V5 segments the count is in the header; pre-V5 segments
  * have no alive-bitset so their alive count equals num_docs.
@@ -91,6 +93,57 @@ tp_count_live_docs(Relation index, TpIndexMetaPage metap)
 		}
 	}
 	return alive;
+}
+
+/*
+ * Apply the invariant total_docs = Σ segment.num_docs (and its
+ * total_len counterpart) after Phase 3 has rebuilt or dropped
+ * segments.  Decrements both the shared-memory atomic and the
+ * on-disk metapage so no subsequent sync re-inflates the metapage
+ * from a stale atomic.  See TpIndexMetaPageData.total_docs in
+ * metapage.h for the invariant.
+ */
+static void
+tp_apply_vacuum_shrinkage(
+		Relation		   index,
+		TpLocalIndexState *index_state,
+		uint64			   docs_shrinkage,
+		uint64			   tokens_shrinkage)
+{
+	Buffer			  mbuf;
+	GenericXLogState *xlog_state;
+	Page			  mpage;
+	TpIndexMetaPage	  mp;
+
+	if (docs_shrinkage == 0 && tokens_shrinkage == 0)
+		return;
+
+	if (index_state != NULL && index_state->shared != NULL)
+	{
+		if (docs_shrinkage > 0)
+			pg_atomic_fetch_sub_u32(
+					&index_state->shared->total_docs, (uint32)docs_shrinkage);
+		if (tokens_shrinkage > 0)
+			pg_atomic_fetch_sub_u64(
+					&index_state->shared->total_len, tokens_shrinkage);
+	}
+
+	mbuf = ReadBuffer(index, TP_METAPAGE_BLKNO);
+	LockBuffer(mbuf, BUFFER_LOCK_EXCLUSIVE);
+
+	xlog_state = GenericXLogStart(index);
+	mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);
+	mp		   = (TpIndexMetaPage)PageGetContents(mpage);
+
+	mp->total_docs = (mp->total_docs >= docs_shrinkage)
+						   ? mp->total_docs - docs_shrinkage
+						   : 0;
+	mp->total_len  = (mp->total_len >= tokens_shrinkage)
+						   ? mp->total_len - tokens_shrinkage
+						   : 0;
+
+	GenericXLogFinish(xlog_state);
+	UnlockReleaseBuffer(mbuf);
 }
 
 /*
@@ -220,6 +273,7 @@ tp_vacuum_identify_affected(
 				segments[count].next_segment = reader->header->next_segment;
 				segments[count].level		 = level;
 				segments[count].num_docs	 = reader->header->num_docs;
+				segments[count].total_tokens = reader->header->total_tokens;
 				segments[count].dead_doc_ids = dead_ids;
 				segments[count].dead_count	 = seg_dead;
 				segments[count].affected	 = (seg_dead > 0);
@@ -712,8 +766,17 @@ tp_bulkdelete(
 		 (long long)total_dead,
 		 num_segments);
 
-	/* Phase 3: Mark dead docs or rebuild affected segments */
+	/*
+	 * Phase 3: Mark dead docs or rebuild affected segments.  Track
+	 * segment-header shrinkage so we can restore the invariant
+	 * total_docs = Σ segment.num_docs (see metapage.h).  V5 bitset
+	 * flips that leave survivors do not change the segment header's
+	 * num_docs / total_tokens, so they contribute zero shrinkage.
+	 */
 	{
+		uint64 docs_shrinkage	= 0;
+		uint64 tokens_shrinkage = 0;
+
 		for (int level = 0; level < TP_MAX_LEVELS; level++)
 		{
 			BlockNumber prev = InvalidBlockNumber;
@@ -748,6 +811,8 @@ tp_bulkdelete(
 									segments[i].root_block,
 									InvalidBlockNumber,
 									prev);
+							docs_shrinkage += segments[i].num_docs;
+							tokens_shrinkage += segments[i].total_tokens;
 							/* prev stays the same */
 						}
 						else
@@ -761,7 +826,8 @@ tp_bulkdelete(
 						 * Pre-V5 segment: rebuild into V5.
 						 */
 						BlockNumber new_root;
-						uint64		seg_docs;
+						uint64		new_docs   = 0;
+						uint64		new_tokens = 0;
 
 						new_root = tp_vacuum_rebuild_segment(
 								info->index,
@@ -770,8 +836,8 @@ tp_bulkdelete(
 								level,
 								callback,
 								callback_state,
-								&seg_docs,
-								NULL);
+								&new_docs,
+								&new_tokens);
 
 						tp_vacuum_replace_segment(
 								info->index,
@@ -779,6 +845,10 @@ tp_bulkdelete(
 								segments[i].root_block,
 								new_root,
 								prev);
+
+						docs_shrinkage += segments[i].num_docs - new_docs;
+						tokens_shrinkage += segments[i].total_tokens -
+											new_tokens;
 
 						if (new_root != InvalidBlockNumber)
 							prev = new_root;
@@ -791,10 +861,8 @@ tp_bulkdelete(
 			}
 		}
 
-		/*
-		 * No metapage decrement here — see
-		 * TpIndexMetaPageData.total_docs in metapage.h for why.
-		 */
+		tp_apply_vacuum_shrinkage(
+				info->index, index_state, docs_shrinkage, tokens_shrinkage);
 	}
 
 	/*
@@ -850,11 +918,12 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 	{
 		stats->num_pages = 1;
 		/*
-		 * Recompute live count from segments so pg_class.reltuples
-		 * reflects actual alive docs, not the (never-decremented)
-		 * metap->total_docs.  Works regardless of whether
-		 * tp_bulkdelete ran or this is a no-deletes maintenance
-		 * round.
+		 * reltuples tracks live docs, which can be less than
+		 * metap->total_docs because V5 bitset flips with survivors
+		 * reduce alive_count without changing segment.num_docs.  Sum
+		 * alive_count across segments for an accurate live count
+		 * regardless of whether tp_bulkdelete ran or this is a
+		 * no-deletes maintenance round.
 		 */
 		stats->num_index_tuples = (double)
 				tp_count_live_docs(info->index, metap);

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -125,12 +125,36 @@ tp_apply_vacuum_shrinkage(
 
 	if (index_state != NULL && index_state->shared != NULL)
 	{
+		/*
+		 * Clamp symmetrically with the metapage write below so a
+		 * shrinkage that exceeds the current atomic (reachable via
+		 * pre-fix L0 headers carrying inflated total_tokens) can't
+		 * wrap the u64 atomic.  A wrap would propagate back to disk
+		 * on the next tp_sync_metapage_stats, which writes the
+		 * atomic into metap unconditionally.
+		 */
 		if (docs_shrinkage > 0)
-			pg_atomic_fetch_sub_u32(
-					&index_state->shared->total_docs, (uint32)docs_shrinkage);
+		{
+			uint32 cur_docs = pg_atomic_read_u32(
+					&index_state->shared->total_docs);
+			uint32 sub_docs = (docs_shrinkage > (uint64)cur_docs)
+									? cur_docs
+									: (uint32)docs_shrinkage;
+
+			if (sub_docs > 0)
+				pg_atomic_fetch_sub_u32(
+						&index_state->shared->total_docs, sub_docs);
+		}
 		if (tokens_shrinkage > 0)
-			pg_atomic_fetch_sub_u64(
-					&index_state->shared->total_len, tokens_shrinkage);
+		{
+			uint64 cur_len = pg_atomic_read_u64(
+					&index_state->shared->total_len);
+			uint64 sub_len = Min(cur_len, tokens_shrinkage);
+
+			if (sub_len > 0)
+				pg_atomic_fetch_sub_u64(
+						&index_state->shared->total_len, sub_len);
+		}
 	}
 
 	xlog_state = GenericXLogStart(index);

--- a/src/index/metapage.c
+++ b/src/index/metapage.c
@@ -170,6 +170,12 @@ tp_get_metapage(Relation index)
 /*
  * Persist the shared-memory atomic into the metapage.  See
  * TpIndexMetaPageData.total_docs in metapage.h for semantics.
+ *
+ * Read the atomic only after taking the metapage buffer exclusive
+ * lock so a concurrent VACUUM shrinkage (which also holds this lock
+ * during its atomic sub + metap write) cannot slip in between our
+ * read and our write and have its decrement clobbered by a stale
+ * atomic snapshot.
  */
 void
 tp_sync_metapage_stats(Relation index, TpLocalIndexState *index_state)
@@ -184,11 +190,11 @@ tp_sync_metapage_stats(Relation index, TpLocalIndexState *index_state)
 	if (index_state == NULL || index_state->shared == NULL)
 		return;
 
-	total_docs = pg_atomic_read_u32(&index_state->shared->total_docs);
-	total_len  = pg_atomic_read_u64(&index_state->shared->total_len);
-
 	mbuf = ReadBuffer(index, TP_METAPAGE_BLKNO);
 	LockBuffer(mbuf, BUFFER_LOCK_EXCLUSIVE);
+
+	total_docs = pg_atomic_read_u32(&index_state->shared->total_docs);
+	total_len  = pg_atomic_read_u64(&index_state->shared->total_len);
 
 	xlog_state = GenericXLogStart(index);
 	mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);

--- a/src/index/metapage.h
+++ b/src/index/metapage.h
@@ -35,32 +35,33 @@ typedef struct TpIndexMetaPageData
 	uint32 version;			/* Index format version */
 	Oid	   text_config_oid; /* Text search configuration OID */
 	/*
-	 * Running count of docs inserted into this index incarnation.
-	 * Upper-bounds the per-segment sum:
+	 * Corpus size for BM25 scoring.  Satisfies the exact invariant
 	 *
-	 *     total_docs ≥ Σ segment.num_docs
+	 *     total_docs = Σ segment.num_docs
 	 *
-	 * over all on-disk segments reachable from level_heads[], with
-	 * equality right after CREATE INDEX / REINDEX.  Slack appears
-	 * when VACUUM rebuilds a pre-V5 segment into a V5 segment
-	 * containing only alive docs: Σ segment.num_docs drops but
-	 * total_docs is never decremented.  (V5 segments aren't
-	 * rebuilt — VACUUM only flips alive bits, leaving num_docs
-	 * fixed.  The live shared-memory atomic additionally counts
-	 * memtable docs; this disk copy lags between spills.)
+	 * where the sum is over all on-disk segments reachable from
+	 * level_heads[] and num_docs is the segment header field (fixed
+	 * at segment creation).  VACUUM keeps the invariant by
+	 * decrementing total_docs whenever a segment's num_docs changes
+	 * or the segment leaves the chain: pre-V5 rebuild shrinks
+	 * num_docs from old to docs_added; a V5 segment dropped because
+	 * all docs are dead contributes zero.  V5 bitset flips that
+	 * leave survivors are invisible here — they shrink alive_count,
+	 * not num_docs.
 	 *
-	 * Per-segment dictionary doc_freq values likewise stay at
-	 * their segment-creation values; doc_freq(t) ≤ num_docs holds
-	 * within every segment by construction.  Chained together:
+	 * Per-segment dictionary doc_freq(t) ≤ segment.num_docs by
+	 * construction, so
 	 *
-	 *     total_docs ≥ Σ segment.num_docs
+	 *     total_docs = Σ segment.num_docs
 	 *              ≥ Σ segment.doc_freq(t)
 	 *              = doc_freq(t) globally
 	 *
-	 * so BM25's N ≥ df(t) invariant — which tp_calculate_idf
-	 * relies on (violating it yields negative IDF) — is preserved.
-	 * REINDEX rebuilds from the heap and resets total_docs to the
-	 * live count.
+	 * and BM25's N ≥ df(t) precondition for tp_calculate_idf holds.
+	 *
+	 * The shared-memory atomic additionally counts unflushed
+	 * memtable docs and is the source persisted at every spill;
+	 * this disk copy therefore lags between spills but is still in
+	 * sync with Σ segment.num_docs at spill/sync boundaries.
 	 */
 	uint64 total_docs;
 	uint64 _unused_total_terms;	  /* Unused, retained for on-disk compat */

--- a/src/index/metapage.h
+++ b/src/index/metapage.h
@@ -35,19 +35,43 @@ typedef struct TpIndexMetaPageData
 	uint32 version;			/* Index format version */
 	Oid	   text_config_oid; /* Text search configuration OID */
 	/*
-	 * Persisted snapshot of the shared-memory atomic.  Updated at
-	 * each memtable spill; loaded back into the atomic on restart
-	 * via tp_rebuild_index_from_disk.
+	 * Running count of docs inserted into this index incarnation.
+	 * Upper-bounds the per-segment sum:
+	 *
+	 *     total_docs ≥ Σ segment.num_docs
+	 *
+	 * over all on-disk segments reachable from level_heads[], with
+	 * equality right after CREATE INDEX / REINDEX.  Slack appears
+	 * when VACUUM rebuilds a pre-V5 segment into a V5 segment
+	 * containing only alive docs: Σ segment.num_docs drops but
+	 * total_docs is never decremented.  (V5 segments aren't
+	 * rebuilt — VACUUM only flips alive bits, leaving num_docs
+	 * fixed.  The live shared-memory atomic additionally counts
+	 * memtable docs; this disk copy lags between spills.)
+	 *
+	 * Per-segment dictionary doc_freq values likewise stay at
+	 * their segment-creation values; doc_freq(t) ≤ num_docs holds
+	 * within every segment by construction.  Chained together:
+	 *
+	 *     total_docs ≥ Σ segment.num_docs
+	 *              ≥ Σ segment.doc_freq(t)
+	 *              = doc_freq(t) globally
+	 *
+	 * so BM25's N ≥ df(t) invariant — which tp_calculate_idf
+	 * relies on (violating it yields negative IDF) — is preserved.
+	 * REINDEX rebuilds from the heap and resets total_docs to the
+	 * live count.
 	 */
-	uint64		total_docs;
-	uint64		_unused_total_terms; /* Unused, retained for on-disk compat */
-	uint64		total_len;			 /* Analogous snapshot of total doc len */
-	float4		k1;					 /* BM25 k1 parameter */
-	float4		b;					 /* BM25 b parameter */
-	BlockNumber root_blkno;			 /* Root page of the index tree */
-	BlockNumber term_stats_root;	 /* Root page of term statistics B-tree */
-	BlockNumber first_docid_page;	 /* First page of docid chain for crash
-									  * recovery */
+	uint64 total_docs;
+	uint64 _unused_total_terms;	  /* Unused, retained for on-disk compat */
+	uint64 total_len;			  /* Σ segment.total_len, same frame as
+									 total_docs */
+	float4		k1;				  /* BM25 k1 parameter */
+	float4		b;				  /* BM25 b parameter */
+	BlockNumber root_blkno;		  /* Root page of the index tree */
+	BlockNumber term_stats_root;  /* Root page of term statistics B-tree */
+	BlockNumber first_docid_page; /* First page of docid chain for crash
+								   * recovery */
 
 	/* Hierarchical segment storage (LSM-style) */
 	BlockNumber level_heads[TP_MAX_LEVELS]; /* Head of segment chain per level

--- a/src/segment/docmap.c
+++ b/src/segment/docmap.c
@@ -67,6 +67,7 @@ tp_docmap_create(void)
 	builder->ctid_pages	  = NULL;
 	builder->ctid_offsets = NULL;
 	builder->fieldnorms	  = NULL;
+	builder->total_tokens = 0;
 
 	return builder;
 }
@@ -100,6 +101,7 @@ tp_docmap_add(TpDocMapBuilder *builder, ItemPointer ctid, uint32 doc_length)
 	entry->doc_id	  = builder->num_docs;
 	entry->doc_length = doc_length;
 	builder->num_docs++;
+	builder->total_tokens += doc_length;
 
 	return entry->doc_id;
 }

--- a/src/segment/docmap.h
+++ b/src/segment/docmap.h
@@ -47,6 +47,9 @@ typedef struct TpDocMapBuilder
 	BlockNumber	 *ctid_pages;	/* doc_id → page number (4 bytes) */
 	OffsetNumber *ctid_offsets; /* doc_id → tuple offset (2 bytes) */
 	uint8		 *fieldnorms;	/* doc_id → encoded length (1 byte) */
+
+	/* Sum of per-doc token counts; used for segment.total_tokens. */
+	uint64 total_tokens;
 } TpDocMapBuilder;
 
 /*

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -826,6 +826,35 @@ build_merged_docmap(
 	docmap->ctid_offsets = out_offsets;
 	docmap->fieldnorms	 = out_fieldnorms;
 
+	/*
+	 * Compute merged total_tokens as Σ source.header.total_tokens
+	 * minus a fieldnorm-decoded approximation of dead-doc tokens.
+	 * For all-live sources the result is exact (matches the raw sum
+	 * maintained by the spill and build-context paths); for sources
+	 * with some dead docs the quantization error is bounded by the
+	 * dead contribution only, not by the whole segment.
+	 */
+	{
+		uint64 merged_total_tokens = 0;
+
+		for (i = 0; i < num_sources; i++)
+		{
+			TpDocmapMergeSource *ms = &msources[i];
+			uint64 src_total		= sources[i].reader->header->total_tokens;
+			uint64 dead_tokens		= 0;
+
+			for (uint32 d = 0; d < ms->num_docs; d++)
+			{
+				if (!tp_segment_is_alive(sources[i].reader, d))
+					dead_tokens += decode_fieldnorm(ms->fieldnorms[d]);
+			}
+			merged_total_tokens += (src_total > dead_tokens)
+										 ? (src_total - dead_tokens)
+										 : 0;
+		}
+		docmap->total_tokens = merged_total_tokens;
+	}
+
 	/* Free per-source arrays we allocated */
 	for (i = 0; i < num_sources; i++)
 	{
@@ -968,14 +997,13 @@ write_merged_segment_to_sink(
 	docmap = build_merged_docmap(
 			sources, num_sources, &doc_mapping, disjoint_sources);
 
-	/* Recompute total_tokens from live docs' fieldnorms */
-	{
-		uint64 live_tokens = 0;
-
-		for (uint32 d = 0; d < docmap->num_docs; d++)
-			live_tokens += decode_fieldnorm(docmap->fieldnorms[d]);
-		total_tokens = live_tokens;
-	}
+	/*
+	 * build_merged_docmap sets docmap->total_tokens from source
+	 * header.total_tokens minus dead-doc fieldnorm approximations;
+	 * see its comment for the exact-vs-approximate trade-off.  The
+	 * caller's total_tokens parameter is ignored.
+	 */
+	total_tokens = docmap->total_tokens;
 
 	/*
 	 * If all docs are dead, nothing to write. Clean up and return.

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -16,6 +16,7 @@
 
 #include "constants.h"
 #include "index/metapage.h"
+#include "index/state.h"
 #include "segment/alive_bitset.h"
 #include "segment/compression.h"
 #include "segment/dictionary.h"
@@ -1414,6 +1415,7 @@ tp_merge_level_segments(Relation index, uint32 level, uint32 max_merge)
 	uint32			num_merged_terms = 0;
 	uint32			merged_capacity	 = 0;
 	uint64			total_tokens	 = 0;
+	uint64			src_num_docs_sum = 0; /* Σ source header.num_docs */
 	BlockNumber		new_segment;
 	MemoryContext	merge_ctx;
 	MemoryContext	old_ctx;
@@ -1523,6 +1525,8 @@ tp_merge_level_segments(Relation index, uint32 level, uint32 max_merge)
 				if (merge_source_init(&sources[num_sources], index, current))
 				{
 					total_tokens += seg_tokens;
+					src_num_docs_sum +=
+							sources[num_sources].reader->header->num_docs;
 					num_sources++;
 				}
 
@@ -1728,18 +1732,73 @@ tp_merge_level_segments(Relation index, uint32 level, uint32 max_merge)
 	}
 
 	/*
-	 * Update metapage: clear source level, add to target level.
-	 * Use GenericXLog to WAL-log the metapage and (optionally)
-	 * the new segment header atomically.
+	 * Update metapage: clear source level, add to target level, and
+	 * apply shrinkage if the merged segment dropped V5-bitset-dead
+	 * docs.  See TpIndexMetaPageData.total_docs in metapage.h for
+	 * the invariant total_docs = Σ segment.num_docs.
 	 */
 	{
-		GenericXLogState *xlog_state;
-		Page			  meta_copy;
-		TpIndexMetaPage	  meta_ptr;
-		Buffer			  seg_buf = InvalidBuffer;
+		GenericXLogState  *xlog_state;
+		Page			   meta_copy;
+		TpIndexMetaPage	   meta_ptr;
+		Buffer			   seg_buf		 = InvalidBuffer;
+		uint32			   merged_docs	 = 0;
+		uint64			   merged_tokens = 0;
+		uint64			   docs_shrinkage;
+		uint64			   tokens_shrinkage;
+		TpLocalIndexState *st;
+
+		/* Read merged segment header for its num_docs / total_tokens. */
+		{
+			Buffer			 b = ReadBuffer(index, new_segment);
+			Page			 p;
+			TpSegmentHeader *h;
+
+			LockBuffer(b, BUFFER_LOCK_SHARE);
+			p			  = BufferGetPage(b);
+			h			  = (TpSegmentHeader *)PageGetContents(p);
+			merged_docs	  = h->num_docs;
+			merged_tokens = h->total_tokens;
+			UnlockReleaseBuffer(b);
+		}
+
+		docs_shrinkage	 = (src_num_docs_sum > (uint64)merged_docs)
+								 ? src_num_docs_sum - (uint64)merged_docs
+								 : 0;
+		tokens_shrinkage = (total_tokens > merged_tokens)
+								 ? total_tokens - merged_tokens
+								 : 0;
+
+		st = tp_get_local_index_state(RelationGetRelid(index));
 
 		metabuf = ReadBuffer(index, 0);
 		LockBuffer(metabuf, BUFFER_LOCK_EXCLUSIVE);
+
+		/*
+		 * Clamp atomic subs symmetrically with the metapage sub
+		 * below.  tp_sync_metapage_stats reads the atomic under the
+		 * same metapage lock, so this serializes against it.
+		 */
+		if (st != NULL && st->shared != NULL)
+		{
+			if (docs_shrinkage > 0)
+			{
+				uint32 cur = pg_atomic_read_u32(&st->shared->total_docs);
+				uint32 sub = (docs_shrinkage > (uint64)cur)
+								   ? cur
+								   : (uint32)docs_shrinkage;
+				if (sub > 0)
+					pg_atomic_fetch_sub_u32(&st->shared->total_docs, sub);
+			}
+			if (tokens_shrinkage > 0)
+			{
+				uint64 cur = pg_atomic_read_u64(&st->shared->total_len);
+				uint64 sub = Min(cur, tokens_shrinkage);
+
+				if (sub > 0)
+					pg_atomic_fetch_sub_u64(&st->shared->total_len, sub);
+			}
+		}
 
 		xlog_state = GenericXLogStart(index);
 		meta_copy  = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
@@ -1769,6 +1828,14 @@ tp_merge_level_segments(Relation index, uint32 level, uint32 max_merge)
 
 		meta_ptr->level_heads[level + 1] = new_segment;
 		meta_ptr->level_counts[level + 1]++;
+
+		/* Apply the same shrinkage to the on-disk copy. */
+		meta_ptr->total_docs = (meta_ptr->total_docs >= docs_shrinkage)
+									 ? meta_ptr->total_docs - docs_shrinkage
+									 : 0;
+		meta_ptr->total_len	 = (meta_ptr->total_len >= tokens_shrinkage)
+									 ? meta_ptr->total_len - tokens_shrinkage
+									 : 0;
 
 		GenericXLogFinish(xlog_state);
 		if (BufferIsValid(seg_buf))

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -1046,10 +1046,10 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	 * Placeholder per-segment counts; header.num_docs and
 	 * header.total_tokens are overwritten below with the docmap's
 	 * per-segment values (Σ raw doc_length) before the final on-disk
-	 * patch.  Build-context writes use the same raw sum; merge
-	 * recomputes from decoded fieldnorms and is therefore quantized,
-	 * which is a pre-existing lossy approximation — see
-	 * merge.c:975 — not something this write path should replicate.
+	 * patch.  Build-context writes use the same raw sum; merge uses
+	 * source headers plus a dead-only fieldnorm correction so all
+	 * three paths produce raw-equivalent totals for the common case
+	 * of all-live sources.
 	 */
 	header.num_docs		= 0;
 	header.total_tokens = 0;

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -1045,10 +1045,11 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	/*
 	 * Placeholder per-segment counts; header.num_docs and
 	 * header.total_tokens are overwritten below with the docmap's
-	 * per-segment values before the final on-disk patch, so the
-	 * invariant header.total_tokens = Σ per-doc fieldnorm holds for
-	 * L0 segments just as it does for merged / build-context
-	 * segments.
+	 * per-segment values (Σ raw doc_length) before the final on-disk
+	 * patch.  Build-context writes use the same raw sum; merge
+	 * recomputes from decoded fieldnorms and is therefore quantized,
+	 * which is a pre-existing lossy approximation — see
+	 * merge.c:975 — not something this write path should replicate.
 	 */
 	header.num_docs		= 0;
 	header.total_tokens = 0;

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -1042,9 +1042,16 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	/* Dictionary immediately follows header */
 	header.dictionary_offset = sizeof(TpSegmentHeader);
 
-	/* Get corpus statistics from shared state */
-	header.num_docs		= pg_atomic_read_u32(&state->shared->total_docs);
-	header.total_tokens = pg_atomic_read_u64(&state->shared->total_len);
+	/*
+	 * Placeholder per-segment counts; header.num_docs and
+	 * header.total_tokens are overwritten below with the docmap's
+	 * per-segment values before the final on-disk patch, so the
+	 * invariant header.total_tokens = Σ per-doc fieldnorm holds for
+	 * L0 segments just as it does for merged / build-context
+	 * segments.
+	 */
+	header.num_docs		= 0;
+	header.total_tokens = 0;
 
 	/* Write placeholder header */
 	tp_segment_writer_write(&writer, &header, sizeof(TpSegmentHeader));
@@ -1288,8 +1295,9 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 		pfree(bitset_data);
 	}
 
-	/* Update num_docs to actual count from this segment */
-	header.num_docs = docmap->num_docs;
+	/* Update num_docs and total_tokens to per-segment values */
+	header.num_docs		= docmap->num_docs;
+	header.total_tokens = docmap->total_tokens;
 
 	/* Write page index */
 	tp_segment_writer_flush(&writer);
@@ -1442,6 +1450,7 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	existing_header->alive_bitset_offset = header.alive_bitset_offset;
 	existing_header->alive_count		 = header.alive_count;
 	existing_header->num_docs			 = header.num_docs;
+	existing_header->total_tokens		 = header.total_tokens;
 	existing_header->data_size			 = header.data_size;
 	existing_header->num_pages			 = header.num_pages;
 	existing_header->page_index			 = header.page_index;

--- a/test/expected/catalog_stats.out
+++ b/test/expected/catalog_stats.out
@@ -206,6 +206,29 @@ FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
  t
 (1 row)
 
+-- Second delete + vacuum; reltuples must continue tracking the
+-- live count (regression test: reporting metap->total_docs - only
+-- this-round deaths would leave reltuples stuck at the first
+-- round's value).
+DELETE FROM stats_vacuum WHERE id > 25;
+VACUUM stats_vacuum;
+SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
+FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+ index_tuples_after_second_vacuum 
+----------------------------------
+ t
+(1 row)
+
+-- No-deletes maintenance round; reltuples must stay at the live
+-- count, not reset to the cumulative insert count.
+VACUUM stats_vacuum;
+SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
+FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+ index_tuples_after_noop_vacuum 
+--------------------------------
+ t
+(1 row)
+
 DROP TABLE stats_vacuum CASCADE;
 -- ============================================================
 -- Stats after REINDEX: should reflect current row count

--- a/test/expected/vacuum_extended.out
+++ b/test/expected/vacuum_extended.out
@@ -472,5 +472,70 @@ SELECT bm25_summarize_index('merge_long_idx') ~ E'total_len: 0\n'
 
 RESET pg_textsearch.segments_per_level;
 DROP TABLE merge_long_docs;
+-- =============================================================================
+-- Test 11: merge drops V5-bitset-dead docs and applies shrinkage
+-- =============================================================================
+--
+-- Regression test.  tp_merge_level_segments used to update
+-- level_heads/level_counts but leave metap->total_docs / total_len
+-- at the pre-merge value when the merged segment dropped docs that
+-- VACUUM had previously marked dead in the source bitsets.  After
+-- the merge, Σ segment.num_docs (= live count) was strictly less
+-- than metap->total_docs, violating the primary invariant.
+--
+-- Setup: two L0 spills below segments_per_level so no compaction
+-- fires yet, VACUUM to flip dead bits, then a third spill that
+-- triggers an L0→L1 compaction.  The merged L1 segment excludes the
+-- dead docs; metap must shrink to match.
+SET pg_textsearch.segments_per_level = 3;
+CREATE TABLE merge_drop_dead (id serial PRIMARY KEY, content text);
+CREATE INDEX merge_drop_idx ON merge_drop_dead USING bm25(content)
+    WITH (text_config='english');
+NOTICE:  BM25 index build started for relation merge_drop_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+-- Spills 1 and 2.
+INSERT INTO merge_drop_dead (content)
+SELECT 'one alpha common term doc ' || i FROM generate_series(1, 30) AS i;
+SELECT bm25_spill_index('merge_drop_idx');
+ bm25_spill_index 
+------------------
+                2
+(1 row)
+
+INSERT INTO merge_drop_dead (content)
+SELECT 'two beta common term doc ' || i FROM generate_series(31, 60) AS i;
+SELECT bm25_spill_index('merge_drop_idx');
+ bm25_spill_index 
+------------------
+                5
+(1 row)
+
+-- Delete half the rows and VACUUM to flip dead bits in the two L0s.
+DELETE FROM merge_drop_dead WHERE id % 2 = 0;
+VACUUM merge_drop_dead;
+-- Third spill triggers compaction (segments_per_level=3); merge
+-- drops the bitset-dead docs.
+INSERT INTO merge_drop_dead (content)
+SELECT 'three gamma common term doc ' || i FROM generate_series(61, 90) AS i;
+SELECT bm25_spill_index('merge_drop_idx');
+ bm25_spill_index 
+------------------
+                8
+(1 row)
+
+-- 30 + 30 + 30 = 90 inserted; 30 deleted; 60 live.  Pre-fix merge
+-- would leave metap->total_docs at 90 (summed sources' num_docs
+-- unchanged), which violates total_docs = Σ segment.num_docs.
+SELECT bm25_summarize_index('merge_drop_idx') ~ E'total_docs: 60\n'
+    AS metap_matches_live_count;
+ metap_matches_live_count 
+--------------------------
+ t
+(1 row)
+
+RESET pg_textsearch.segments_per_level;
+DROP TABLE merge_drop_dead;
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/vacuum_extended.out
+++ b/test/expected/vacuum_extended.out
@@ -344,5 +344,61 @@ SELECT bm25_summarize_index('vacuum_tiny_idx')
 (1 row)
 
 DROP TABLE vacuum_tiny_test;
+-- =============================================================================
+-- Test 9: dropping a memtable-spilled L0 segment keeps total_len sane
+-- =============================================================================
+--
+-- Regression test.  tp_write_segment used to leave header.total_tokens
+-- at the cumulative shared-atomic value instead of the per-segment
+-- sum.  When VACUUM later dropped that segment (all docs dead) the
+-- inflated header.total_tokens was subtracted from metap->total_len
+-- and the atomic, clamping them to 0 (or wrapping the atomic) and
+-- breaking avgdl in BM25 scoring for the surviving docs.
+--
+-- We populate two L0 segments with distinct id ranges, delete every
+-- row that landed in the second one, and then run VACUUM.  Afterwards
+-- a search over the surviving corpus must return real matches.
+CREATE TABLE l0_total_len_test (id serial PRIMARY KEY, content text);
+CREATE INDEX l0_total_len_idx ON l0_total_len_test USING bm25(content)
+    WITH (text_config='english');
+NOTICE:  BM25 index build started for relation l0_total_len_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+-- Segment 1: ids 1..50 (the survivors).
+INSERT INTO l0_total_len_test (content)
+SELECT 'alpha common term doc ' || i FROM generate_series(1, 50) AS i;
+SELECT bm25_spill_index('l0_total_len_idx');
+ bm25_spill_index 
+------------------
+                2
+(1 row)
+
+-- Segment 2: ids 51..100 (to be fully deleted).
+INSERT INTO l0_total_len_test (content)
+SELECT 'beta common term doc ' || i FROM generate_series(51, 100) AS i;
+SELECT bm25_spill_index('l0_total_len_idx');
+ bm25_spill_index 
+------------------
+                5
+(1 row)
+
+-- Wipe every row that went into segment 2, then VACUUM to drop it.
+DELETE FROM l0_total_len_test WHERE id > 50;
+VACUUM l0_total_len_test;
+-- total_len must reflect only the surviving segment's tokens.  The
+-- pre-fix path inflated header.total_tokens to the cumulative atomic
+-- so the subtraction clamped total_len to 0.  A healthy avg_doc_len
+-- is the sharpest regression signal.
+SELECT bm25_summarize_index('l0_total_len_idx') ~ E'total_len: 250\n'
+    AS total_len_matches_survivors,
+       bm25_summarize_index('l0_total_len_idx') ~ E'avg_doc_len: 5\\.00\n'
+    AS avgdl_sane;
+ total_len_matches_survivors | avgdl_sane 
+-----------------------------+------------
+ t                           | t
+(1 row)
+
+DROP TABLE l0_total_len_test;
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/vacuum_extended.out
+++ b/test/expected/vacuum_extended.out
@@ -400,5 +400,77 @@ SELECT bm25_summarize_index('l0_total_len_idx') ~ E'total_len: 250\n'
 (1 row)
 
 DROP TABLE l0_total_len_test;
+-- =============================================================================
+-- Test 10: merged segments carry raw total_tokens (long docs + VACUUM)
+-- =============================================================================
+--
+-- Regression test.  merge.c used to recompute header.total_tokens as
+-- Σ decode_fieldnorm(fieldnorms[d]), which is exponentially quantized
+-- for doc_length > 39 (e.g. 100→96).  metap->total_len stayed raw
+-- (set from the atomic), so the drift was latent until a VACUUM drop
+-- of the merged segment fed the quantized header value back into
+-- metap via tp_apply_vacuum_shrinkage, leaving phantom tokens.
+--
+-- Fix: merge starts from Σ source.header.total_tokens (raw) minus a
+-- dead-only fieldnorm approximation.  For all-live sources the merged
+-- total_tokens is exact, so the VACUUM subtraction cancels to zero.
+SET pg_textsearch.segments_per_level = 2;
+CREATE TABLE merge_long_docs (id serial PRIMARY KEY, content text);
+CREATE INDEX merge_long_idx ON merge_long_docs USING bm25(content)
+    WITH (text_config='english');
+NOTICE:  BM25 index build started for relation merge_long_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+-- Each doc has 100 unique tokens.  decode(encode(100)) = 96.
+INSERT INTO merge_long_docs (content)
+SELECT string_agg('term' || (j + i*1000), ' ')
+FROM generate_series(1, 30) i,
+     generate_series(1, 100) j
+GROUP BY i;
+SELECT bm25_spill_index('merge_long_idx');
+ bm25_spill_index 
+------------------
+                2
+(1 row)
+
+INSERT INTO merge_long_docs (content)
+SELECT string_agg('other' || (j + i*1000), ' ')
+FROM generate_series(1, 30) i,
+     generate_series(1, 100) j
+GROUP BY i;
+SELECT bm25_spill_index('merge_long_idx');
+ bm25_spill_index 
+------------------
+               27
+(1 row)
+
+-- Sanity: both batches merged into a single L1 segment.
+SELECT bm25_summarize_index('merge_long_idx') ~ E'L1 Segment'
+    AS has_l1_segment;
+ has_l1_segment 
+----------------
+ t
+(1 row)
+
+-- Delete every row so VACUUM drops the merged segment.  With the fix
+-- the L1 header carries raw 6000 tokens; subtracting that from the
+-- atomic/metapage total_len (also 6000) leaves 0.  Pre-fix the L1
+-- header was 60 × 96 = 5760 (quantized), leaving 240 phantom tokens
+-- that would bias avg_doc_len for any surviving docs and persist
+-- across the next tp_sync_metapage_stats.
+DELETE FROM merge_long_docs;
+VACUUM merge_long_docs;
+SELECT bm25_summarize_index('merge_long_idx') ~ E'total_len: 0\n'
+    AS total_len_zero_after_drop,
+       bm25_summarize_index('merge_long_idx') ~ E'total_docs: 0\n'
+    AS total_docs_zero_after_drop;
+ total_len_zero_after_drop | total_docs_zero_after_drop 
+---------------------------+----------------------------
+ t                         | t
+(1 row)
+
+RESET pg_textsearch.segments_per_level;
+DROP TABLE merge_long_docs;
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/catalog_stats.sql
+++ b/test/sql/catalog_stats.sql
@@ -169,6 +169,23 @@ VACUUM stats_vacuum;
 SELECT reltuples BETWEEN 40 AND 60 AS index_tuples_after_vacuum
 FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 
+-- Second delete + vacuum; reltuples must continue tracking the
+-- live count (regression test: reporting metap->total_docs - only
+-- this-round deaths would leave reltuples stuck at the first
+-- round's value).
+DELETE FROM stats_vacuum WHERE id > 25;
+VACUUM stats_vacuum;
+
+SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
+FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+
+-- No-deletes maintenance round; reltuples must stay at the live
+-- count, not reset to the cumulative insert count.
+VACUUM stats_vacuum;
+
+SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
+FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+
 DROP TABLE stats_vacuum CASCADE;
 
 -- ============================================================

--- a/test/sql/vacuum_extended.sql
+++ b/test/sql/vacuum_extended.sql
@@ -328,5 +328,62 @@ SELECT bm25_summarize_index('l0_total_len_idx') ~ E'total_len: 250\n'
 
 DROP TABLE l0_total_len_test;
 
+-- =============================================================================
+-- Test 10: merged segments carry raw total_tokens (long docs + VACUUM)
+-- =============================================================================
+--
+-- Regression test.  merge.c used to recompute header.total_tokens as
+-- Σ decode_fieldnorm(fieldnorms[d]), which is exponentially quantized
+-- for doc_length > 39 (e.g. 100→96).  metap->total_len stayed raw
+-- (set from the atomic), so the drift was latent until a VACUUM drop
+-- of the merged segment fed the quantized header value back into
+-- metap via tp_apply_vacuum_shrinkage, leaving phantom tokens.
+--
+-- Fix: merge starts from Σ source.header.total_tokens (raw) minus a
+-- dead-only fieldnorm approximation.  For all-live sources the merged
+-- total_tokens is exact, so the VACUUM subtraction cancels to zero.
+
+SET pg_textsearch.segments_per_level = 2;
+
+CREATE TABLE merge_long_docs (id serial PRIMARY KEY, content text);
+CREATE INDEX merge_long_idx ON merge_long_docs USING bm25(content)
+    WITH (text_config='english');
+
+-- Each doc has 100 unique tokens.  decode(encode(100)) = 96.
+INSERT INTO merge_long_docs (content)
+SELECT string_agg('term' || (j + i*1000), ' ')
+FROM generate_series(1, 30) i,
+     generate_series(1, 100) j
+GROUP BY i;
+SELECT bm25_spill_index('merge_long_idx');
+
+INSERT INTO merge_long_docs (content)
+SELECT string_agg('other' || (j + i*1000), ' ')
+FROM generate_series(1, 30) i,
+     generate_series(1, 100) j
+GROUP BY i;
+SELECT bm25_spill_index('merge_long_idx');
+
+-- Sanity: both batches merged into a single L1 segment.
+SELECT bm25_summarize_index('merge_long_idx') ~ E'L1 Segment'
+    AS has_l1_segment;
+
+-- Delete every row so VACUUM drops the merged segment.  With the fix
+-- the L1 header carries raw 6000 tokens; subtracting that from the
+-- atomic/metapage total_len (also 6000) leaves 0.  Pre-fix the L1
+-- header was 60 × 96 = 5760 (quantized), leaving 240 phantom tokens
+-- that would bias avg_doc_len for any surviving docs and persist
+-- across the next tp_sync_metapage_stats.
+DELETE FROM merge_long_docs;
+VACUUM merge_long_docs;
+
+SELECT bm25_summarize_index('merge_long_idx') ~ E'total_len: 0\n'
+    AS total_len_zero_after_drop,
+       bm25_summarize_index('merge_long_idx') ~ E'total_docs: 0\n'
+    AS total_docs_zero_after_drop;
+
+RESET pg_textsearch.segments_per_level;
+DROP TABLE merge_long_docs;
+
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/vacuum_extended.sql
+++ b/test/sql/vacuum_extended.sql
@@ -284,5 +284,49 @@ SELECT bm25_summarize_index('vacuum_tiny_idx')
 
 DROP TABLE vacuum_tiny_test;
 
+-- =============================================================================
+-- Test 9: dropping a memtable-spilled L0 segment keeps total_len sane
+-- =============================================================================
+--
+-- Regression test.  tp_write_segment used to leave header.total_tokens
+-- at the cumulative shared-atomic value instead of the per-segment
+-- sum.  When VACUUM later dropped that segment (all docs dead) the
+-- inflated header.total_tokens was subtracted from metap->total_len
+-- and the atomic, clamping them to 0 (or wrapping the atomic) and
+-- breaking avgdl in BM25 scoring for the surviving docs.
+--
+-- We populate two L0 segments with distinct id ranges, delete every
+-- row that landed in the second one, and then run VACUUM.  Afterwards
+-- a search over the surviving corpus must return real matches.
+
+CREATE TABLE l0_total_len_test (id serial PRIMARY KEY, content text);
+CREATE INDEX l0_total_len_idx ON l0_total_len_test USING bm25(content)
+    WITH (text_config='english');
+
+-- Segment 1: ids 1..50 (the survivors).
+INSERT INTO l0_total_len_test (content)
+SELECT 'alpha common term doc ' || i FROM generate_series(1, 50) AS i;
+SELECT bm25_spill_index('l0_total_len_idx');
+
+-- Segment 2: ids 51..100 (to be fully deleted).
+INSERT INTO l0_total_len_test (content)
+SELECT 'beta common term doc ' || i FROM generate_series(51, 100) AS i;
+SELECT bm25_spill_index('l0_total_len_idx');
+
+-- Wipe every row that went into segment 2, then VACUUM to drop it.
+DELETE FROM l0_total_len_test WHERE id > 50;
+VACUUM l0_total_len_test;
+
+-- total_len must reflect only the surviving segment's tokens.  The
+-- pre-fix path inflated header.total_tokens to the cumulative atomic
+-- so the subtraction clamped total_len to 0.  A healthy avg_doc_len
+-- is the sharpest regression signal.
+SELECT bm25_summarize_index('l0_total_len_idx') ~ E'total_len: 250\n'
+    AS total_len_matches_survivors,
+       bm25_summarize_index('l0_total_len_idx') ~ E'avg_doc_len: 5\\.00\n'
+    AS avgdl_sane;
+
+DROP TABLE l0_total_len_test;
+
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/vacuum_extended.sql
+++ b/test/sql/vacuum_extended.sql
@@ -385,5 +385,55 @@ SELECT bm25_summarize_index('merge_long_idx') ~ E'total_len: 0\n'
 RESET pg_textsearch.segments_per_level;
 DROP TABLE merge_long_docs;
 
+-- =============================================================================
+-- Test 11: merge drops V5-bitset-dead docs and applies shrinkage
+-- =============================================================================
+--
+-- Regression test.  tp_merge_level_segments used to update
+-- level_heads/level_counts but leave metap->total_docs / total_len
+-- at the pre-merge value when the merged segment dropped docs that
+-- VACUUM had previously marked dead in the source bitsets.  After
+-- the merge, Σ segment.num_docs (= live count) was strictly less
+-- than metap->total_docs, violating the primary invariant.
+--
+-- Setup: two L0 spills below segments_per_level so no compaction
+-- fires yet, VACUUM to flip dead bits, then a third spill that
+-- triggers an L0→L1 compaction.  The merged L1 segment excludes the
+-- dead docs; metap must shrink to match.
+
+SET pg_textsearch.segments_per_level = 3;
+
+CREATE TABLE merge_drop_dead (id serial PRIMARY KEY, content text);
+CREATE INDEX merge_drop_idx ON merge_drop_dead USING bm25(content)
+    WITH (text_config='english');
+
+-- Spills 1 and 2.
+INSERT INTO merge_drop_dead (content)
+SELECT 'one alpha common term doc ' || i FROM generate_series(1, 30) AS i;
+SELECT bm25_spill_index('merge_drop_idx');
+
+INSERT INTO merge_drop_dead (content)
+SELECT 'two beta common term doc ' || i FROM generate_series(31, 60) AS i;
+SELECT bm25_spill_index('merge_drop_idx');
+
+-- Delete half the rows and VACUUM to flip dead bits in the two L0s.
+DELETE FROM merge_drop_dead WHERE id % 2 = 0;
+VACUUM merge_drop_dead;
+
+-- Third spill triggers compaction (segments_per_level=3); merge
+-- drops the bitset-dead docs.
+INSERT INTO merge_drop_dead (content)
+SELECT 'three gamma common term doc ' || i FROM generate_series(61, 90) AS i;
+SELECT bm25_spill_index('merge_drop_idx');
+
+-- 30 + 30 + 30 = 90 inserted; 30 deleted; 60 live.  Pre-fix merge
+-- would leave metap->total_docs at 90 (summed sources' num_docs
+-- unchanged), which violates total_docs = Σ segment.num_docs.
+SELECT bm25_summarize_index('merge_drop_idx') ~ E'total_docs: 60\n'
+    AS metap_matches_live_count;
+
+RESET pg_textsearch.segments_per_level;
+DROP TABLE merge_drop_dead;
+
 -- Clean up
 DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## The invariant

`metap->total_docs` is defined as the sum of per-segment doc counts:

> `total_docs = Σ segment.num_docs`

over all on-disk segments reachable from `level_heads[]`, where `num_docs` is the segment-header field (fixed at segment creation). The shared-memory atomic additionally counts unflushed memtable docs and is persisted to the metapage at every spill; the disk copy therefore lags the atomic between spills but is in sync with `Σ segment.num_docs` at spill boundaries.

This is the primary invariant. The BM25 IDF requirement

> `total_docs ≥ doc_freq(t)` for every term `t`

follows from it: `doc_freq(t) = Σ segment.doc_freq(t)`, and within each segment `doc_freq(t) ≤ num_docs` by construction. `tp_calculate_idf` depends on it; violating it makes the numerator of `log(1 + (N − df + 0.5)/(df + 0.5))` negative → empty result sets on restart (the #333 failure mode).

`total_len` tracks `Σ segment.total_tokens` analogously, used for `avgdl = total_len / total_docs` in BM25's length normalization.

## What was broken

1. **Phase 4 decrement matched no consistent invariant.** `tp_bulkdelete` decremented `metap->total_docs` by `total_dead`, the count of newly-dead docs. That matched neither the V5 bitset-flip path (segment-header `num_docs` stays fixed), the V5 all-dead-drop path (drops by the whole segment's `num_docs`), nor the pre-V5 rebuild path (drops by `old_num_docs - docs_added`, which can differ from `total_dead` due to NULL keys, failed `heap_fetch`, or predicate failures).

2. **L0 segment headers carried cumulative `total_tokens`.** `tp_write_segment` (memtable spill path) initialized `header.total_tokens` from the cumulative shared atomic at spill time and never overwrote it with a per-segment value. Latent pre-PR because VACUUM never used the field; once VACUUM started decrementing `metap->total_len` by `segments[i].total_tokens`, dropping such an L0 segment wiped `metap->total_len`.

3. **Atomic sub / metapage sync race.** `tp_apply_vacuum_shrinkage` needed to serialize against the concurrent-spill `tp_sync_metapage_stats` call. The metapage buffer exclusive lock is the right serialization point, but `tp_sync_metapage_stats` read the atomic *before* taking it — letting a pre-shrinkage snapshot slip through and overwrite VACUUM's decrement. Fix: move the atomic reads in both sites under the lock.

4. **Atomic subs were not clamped.** `pg_atomic_fetch_sub_u{32,64}` wraps on underflow. Reachable via the upgrade path in (2) when multiple pre-fix L0 segments are dropped in a single VACUUM pass, or when a pre-V5 rebuild subtraction underflows a quantized old header against a raw new tokenization.

5. **Merge recomputed `total_tokens` from decoded fieldnorms.** `merge.c` summed `decode_fieldnorm(fieldnorms[d])` over live docs, which is exponentially bucketed for `doc_length > 39`. Latent pre-PR; once VACUUM dropped such a merged segment, the under-decrement against `metap->total_len` left phantom tokens.

6. **Merge didn't apply shrinkage to `metap`.** `tp_merge_level_segments` updated `level_heads` / `level_counts` but left `metap->total_docs` and `total_len` at their pre-merge values. When the merge dropped V5-bitset-dead docs, `Σ segment.num_docs` dropped but `metap` didn't, violating the primary invariant.

7. **`tp_count_live_docs` walked the segment chain without a lock.** A concurrent INSERT auto-spill + compaction frees merged source pages to the FSM, and another backend's `allocate_segment_page` can zero them in the same window, making the walker ERROR on the magic check or silently follow a recycled `next_segment` into a foreign chain.

## The fix

- **Phase 3 tracks per-segment shrinkage**: zero for V5 bitset flips with survivors, the full `num_docs` / `total_tokens` for an all-dead V5 drop, and `(old - new)` (clamped to zero) for a pre-V5 rebuild. `tp_apply_vacuum_shrinkage` applies that to the shared atomic and the metapage under the metapage buffer exclusive lock, with both sides clamped.
- **`tp_write_segment` patches `header.total_tokens`**: per-segment token sum tracked in the docmap builder (`tp_docmap_add` accumulates `doc_length`), copied into the header's on-disk patch.
- **Merge sums source header totals minus dead-only fieldnorm correction** for the new segment's `total_tokens`; for all-live sources the result is exact. Merge also now applies per-segment shrinkage to `metap` and the atomic under the existing metapage lock when the merged segment drops bitset-dead docs.
- **`tp_sync_metapage_stats` reads the atomic under the buffer lock**, so both sides of the VACUUM-vs-spill RMW serialize on the same lock.
- **`tp_count_live_docs` call wrapped in `LW_SHARED`** via `tp_acquire_index_lock`, matching the scan-path convention.
- **`pg_class.reltuples` uses live-doc count via `Σ segment.alive_count`**: `metap->total_docs` intentionally tracks `Σ segment.num_docs` (includes V5 bitset-dead docs), which is the wrong number for planner cardinality.

## Known limitation (upgrade)

Every released version through **`v1.0.0`** writes `header.total_tokens = state->shared->total_len` (the cumulative shared atomic) in `tp_write_segment` — confirmed across `v0.2.0`, `v0.4.0`, `v0.5.0`, `v0.6.0`, `v0.6.1`, `v1.0.0`. So any L0 segment on disk from those releases carries an inflated `total_tokens` in its header. (Merged V3/V4 segments from those same releases used `decode_fieldnorm` instead; those are mildly quantized, not inflated.)

When such a pre-fix L0 segment is picked up by VACUUM under this PR:
- **Pre-V5 L0 rebuilt into V5**: the rebuild-shrinkage subtraction (inflated old minus raw new) is clamped so it can't underflow, but `metap->total_len` can drop more than it should.
- **Pre-fix L0 feeds an L0→L1 compaction**: merge now sums raw source headers, so the merged L1 header inherits the cumulative value; a later VACUUM that drops the L1 hits the atomic clamp.

In both cases the atomic wrap is prevented and IDF stays non-negative, but `avgdl` can skew until pre-fix-descended segments rotate out. **`REINDEX` (which rebuilds from the heap via `tp_build`, bypassing `tp_write_segment`) is the only full remediation.** Installations that have only ever run this PR or later are not affected.

## Context

Spun off from #335 (the fix for #333), which surfaced the Phase 4 skew while testing new spill paths that added restart-path coverage. The downstream bugs (L0 `total_tokens`, lock race, atomic wrap, merge quantization, sync TOCTOU, count-live-docs lock, merge shrinkage) were each caught by successive AI reviews plus a self-review pass.

## Testing

`make installcheck`, with regression tests added in:
- `catalog_stats.sql`: multi-round VACUUM + no-delete cleanup confirms `reltuples` tracks the live count across rounds.
- `vacuum_extended.sql` Test 9: spills two L0 segments, drops one via VACUUM, asserts `metap->total_len` / `avg_doc_len` reflect only the survivors.
- `vacuum_extended.sql` Test 10: spills two L0 segments of 100-token docs, merges them, deletes all rows, VACUUMs; asserts `metap->total_len` / `total_docs` land at 0 rather than phantom tokens the pre-fix merge quantization would leave behind.
- `vacuum_extended.sql` Test 11: two L0 spills below threshold, VACUUM flips bits, third spill triggers L0→L1 compaction; asserts `metap->total_docs` lands at the live count after merge drops the dead docs.