### PR TITLE
chore: bump version to 1.2.0-dev (+ automate version bumps)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ ranking. (Internal name: Tapir) It implements a memtable-based architecture
 similar to LSM trees, with in-memory structures that spill to disk segments
 for scalability.
 
-**Current Version**: 1.1.0
+**Current Version**: 1.2.0-dev
 
 **Postgres Version Support**: 17, 18 (tested in CI)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXTENSION = pg_textsearch
 EXTVERSION = $(shell awk -F"'" '/default_version/ {print $$2}' pg_textsearch.control)
-DATA = sql/pg_textsearch--1.1.0.sql \
+DATA = sql/pg_textsearch--1.2.0-dev.sql \
        sql/pg_textsearch--0.0.1--0.0.2.sql \
        sql/pg_textsearch--0.0.2--0.0.3.sql \
        sql/pg_textsearch--0.0.3--0.0.4.sql \
@@ -16,7 +16,8 @@ DATA = sql/pg_textsearch--1.1.0.sql \
        sql/pg_textsearch--0.5.1--0.6.0.sql \
        sql/pg_textsearch--0.6.0--0.6.1.sql \
        sql/pg_textsearch--0.6.1--1.0.0.sql \
-       sql/pg_textsearch--1.0.0--1.1.0.sql
+       sql/pg_textsearch--1.0.0--1.1.0.sql \
+       sql/pg_textsearch--1.1.0--1.2.0-dev.sql
 
 # Source files organized by directory
 OBJS = \

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Modern ranked text search for Postgres.
 - Supports partitioned tables
 - Best in class performance and scalability
 
-🚀 **Status**: v1.1.0 - Production ready.
+🚀 **Status**: v1.2.0-dev - Production ready.
 
-![Tapir and Friends](images/tapir_and_friends_v1.1.0.png)
+![Tapir and Friends](images/tapir_and_friends_v1.2.0-dev.png)
 
 ## Historical note
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Modern ranked text search for Postgres.
 
 🚀 **Status**: v1.2.0-dev - Production ready.
 
-![Tapir and Friends](images/tapir_and_friends_v1.2.0-dev.png)
+![Tapir and Friends](images/tapir_and_friends_v1.1.0.png)
 
 ## Historical note
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,162 +4,129 @@ This document describes the release process for pg_textsearch.
 
 ## Version Scheme
 
-We use semantic versioning: `MAJOR.MINOR.PATCH`
+We use semantic versioning: `MAJOR.MINOR.PATCH`.
 
-- Development versions use `-dev` suffix (e.g., `0.3.0-dev`)
-- Release versions drop the suffix (e.g., `0.3.0`)
+- Development versions use `-dev` suffix (e.g., `1.2.0-dev`).
+- Release versions drop the suffix (e.g., `1.2.0`).
 
-## Release Checklist
+## Cutting a Release
 
-### 1. Update Version References
+### 1. Audit the upgrade SQL script
 
-Change version from `X.Y.Z-dev` to `X.Y.Z` in these files:
+This is the only piece of the release that cannot be automated, and the
+piece most likely to be wrong. Skim it carefully.
 
-| File | What to update |
-|------|----------------|
-| `pg_textsearch.control` | `default_version` |
-| `mod.c` | `.version` in `PG_MODULE_MAGIC_EXT` |
-| `Makefile` | `DATA` list (SQL filenames) |
-| `README.md` | Status line, image reference |
-| `CLAUDE.md` | `Current Version` |
-
-### 2. Update SQL Files
-
-**Rename the main SQL file:**
-```sh
-git mv sql/pg_textsearch--X.Y.Z-dev.sql sql/pg_textsearch--X.Y.Z.sql
-```
-
-**Rename the upgrade script:**
-```sh
-git mv sql/pg_textsearch--W.V.U--X.Y.Z-dev.sql sql/pg_textsearch--W.V.U--X.Y.Z.sql
-```
-
-**Update SQL file contents:**
-- In the main SQL file, update the version comment at the top
-- Update the `RAISE INFO` message (remove prerelease warnings for releases)
-
-### 3. Update Makefile DATA List
-
-Add the new upgrade script to the `DATA` list:
-```makefile
-DATA = sql/pg_textsearch--X.Y.Z.sql \
-       ... \
-       sql/pg_textsearch--W.V.U--X.Y.Z.sql
-```
-
-### 4. Rename Release Banner Image
+The upgrade script `sql/pg_textsearch--PREV--CURRENT-dev.sql` must
+recreate, for an installation still on `PREV`, every catalog object
+that exists in the current main SQL file but not in the previous
+release's main SQL file. To enumerate what the upgrade script must
+cover, diff the two main SQL files:
 
 ```sh
-git mv images/tapir_and_friends_vX.Y.Z-dev.png images/tapir_and_friends_vX.Y.Z.png
+git show vPREV:sql/pg_textsearch--PREV.sql > /tmp/prev.sql
+diff /tmp/prev.sql sql/pg_textsearch--CURRENT-dev.sql
 ```
 
-Update the image reference in README.md.
+For every statement that is new in the current main file, verify
+the upgrade script has a matching statement:
 
-### 5. Update README Status
+| New in main file              | Required in upgrade script        |
+|-------------------------------|-----------------------------------|
+| `CREATE FUNCTION`             | `CREATE FUNCTION`                 |
+| `CREATE OPERATOR`             | `CREATE OPERATOR`                 |
+| `CREATE OPERATOR CLASS`       | `CREATE OPERATOR CLASS`           |
+| `CREATE TYPE`                 | `CREATE TYPE`                     |
+| `CREATE CAST`                 | `CREATE CAST`                     |
+| `ALTER OPERATOR FAMILY`       | `ALTER OPERATOR FAMILY`           |
+| Catalog `UPDATE pg_catalog.*` | Same `UPDATE`                     |
 
-Update the status line with the new version number:
+Renamed, signature-changed, or removed objects need matching `DROP` /
+`ALTER` statements in the upgrade script.
 
-```markdown
-🚀 **Status**: vX.Y.Z - Production ready.
-```
+The `upgrade-tests` CI workflow exercises the upgrade against every
+version in its `old_version` matrix and is the primary safety net for
+gaps — but it can only catch what the regression suite touches. A new
+operator that has no test coverage will pass CI and ship broken. The
+audit catches what the workflow can't.
 
-### 6. Verify Paged Data Structure Versions
-
-If any on-disk format changed during this release cycle, bump the corresponding
-version constant in `src/constants.h`:
-
-| Constant | Purpose |
-|----------|---------|
-| `TP_METAPAGE_VERSION` | Index metapage format |
-| `TP_DOCID_PAGE_VERSION` | Document ID page format |
-| `TP_PAGE_INDEX_VERSION` | Page index format |
-| `TP_SEGMENT_FORMAT_VERSION` | Segment block storage format (in `segment.h`) |
-
-Also check `TPQUERY_VERSION` in `src/types/query.h` if bm25query format changed.
-
-**Important**: Version bumps break upgrade compatibility. If you bump a version,
-update the upgrade test workflow to exclude incompatible old versions, and
-document the breaking change in release notes.
-
-### 7. Run Tests and Update Expected Output
+### 2. Run the bump script
 
 ```sh
-make clean && make && make install
-make test
+./scripts/bump-version.sh CURRENT-dev CURRENT
 ```
 
-If INFO messages changed, regenerate expected outputs:
-```sh
-make expected
-```
+This renames the SQL files and updates every version reference across
+the tree. The script reports what's left for the human to do.
 
-Don't forget alternative expected files (`*_1.out`) which need manual updates.
+### 3. Update the release banner image
 
-Verify all tests pass:
-```sh
-make test  # Should show "All N tests passed"
-```
+Replace `images/tapir_and_friends_vCURRENT-dev.png` with the new
+release banner at `images/tapir_and_friends_vCURRENT.png`. (The
+README reference is already updated by the bump script.)
 
-### 8. Create PR
+### 4. Add the previous release to the upgrade-tests matrix
 
-```sh
-git checkout -b release-X.Y.Z
-git add -A
-git commit -m "Release vX.Y.Z"
-git push -u origin release-X.Y.Z
-gh pr create --title "Release vX.Y.Z" --body "## Summary
-- Update version from X.Y.Z-dev to X.Y.Z
-- [other changes]
-
-## Testing
-- \`make test\` passes
-- \`make format-check\` passes"
-```
-
-### 9. After PR Merges
-
-The release workflow (`release.yml`) triggers automatically when a PR with title
-starting "Release v" merges to main. It:
-
-1. Creates a git tag
-2. Builds release artifacts for PG17/PG18 on Linux/macOS (amd64/arm64)
-3. Creates a GitHub release with the artifacts
-
-### 10. Post-Release: Bump to Next Dev Version
-
-After the release is published, create a PR to bump to the next dev version:
-
-```sh
-# Example: after releasing 0.3.0, bump to 0.4.0-dev
-git checkout main && git pull
-git checkout -b bump-to-0.4.0-dev
-```
-
-Update files with `0.4.0-dev`, create new SQL files, etc.
-
-**Don't forget**: Add the just-released version to the `old_version` matrix in
-`.github/workflows/upgrade-tests.yml` so future releases are tested for upgrade
+In `.github/workflows/upgrade-tests.yml`, add `PREV` to the
+`old_version` matrix so future releases are tested for upgrade
 compatibility from this version.
+
+### 5. Open the PR
+
+```sh
+git checkout -b release-CURRENT
+git add -A
+git commit -m "Release vCURRENT"
+gh pr create --draft --title "Release vCURRENT"
+```
+
+CI runs the full test suite, including upgrade-tests against every
+matrix version.
+
+### 6. After PR merges
+
+The `release.yml` workflow triggers on merge of any PR titled
+`Release v*`. It tags the commit, builds release artifacts for
+PG17/PG18 on Linux/macOS (amd64/arm64), and publishes a GitHub
+release.
+
+## Bumping to the Next Dev Version
+
+After a release is published, open a follow-up PR:
+
+```sh
+git checkout main && git pull
+git checkout -b bump-to-NEXT-dev
+./scripts/bump-version.sh CURRENT NEXT-dev
+git add -A
+git commit -m "chore: bump version to NEXT-dev"
+gh pr create --draft --title "chore: bump version to NEXT-dev"
+```
+
+The script creates the new main SQL file (renamed from the previous
+release's), creates a stub upgrade file `sql/pg_textsearch--CURRENT--NEXT-dev.sql`
+containing only the library-version check, and updates every other
+version reference. Contributors then append to the upgrade file as
+features land in the dev cycle.
 
 ## SQL Upgrade Path Requirements
 
-**Upgrade scripts must form a single linear chain.** Every version connects
-to exactly one next version — no shortcuts that skip intermediate steps.
-This keeps the number of upgrade scripts minimal and the path predictable.
+**Upgrade scripts must form a single linear chain.** Every version
+connects to exactly one next version — no shortcuts that skip
+intermediate steps. This keeps the number of upgrade scripts minimal
+and the path predictable.
 
 ```
 ... → 0.5.0 → 0.5.1 → 0.6.0 → 0.6.1 → 1.0.0 → 1.1.0
 ```
 
-Every release must have an upgrade path from the previous stable release
-(e.g., `0.2.0--0.3.0.sql`). Dev versions are not supported for direct upgrades;
-users on dev versions should reinstall the extension.
+Every release must have an upgrade path from the previous stable
+release (e.g., `1.0.0--1.1.0.sql`). Dev versions are not supported for
+direct upgrades; users on dev versions should reinstall the extension.
 
 ## Upgrade Compatibility
 
-Not all version upgrades are compatible with `ALTER EXTENSION UPDATE`. Breaking
-changes that require index recreation or server restart:
+Not all version upgrades are compatible with `ALTER EXTENSION UPDATE`.
+Breaking changes that require index recreation or server restart:
 
 | Change Type | Impact | User Action Required |
 |-------------|--------|---------------------|
@@ -179,9 +146,27 @@ changes that require index recreation or server restart:
 | < 0.1.0 | 0.3.0 | ❌ No | Multiple breaking changes |
 
 When releasing a version with breaking changes:
-1. Update `.github/workflows/upgrade-tests.yml` to exclude incompatible versions
-2. Document in release notes that users must recreate indexes
-3. Consider providing a migration guide for major version bumps
+
+1. Update `.github/workflows/upgrade-tests.yml` to exclude incompatible versions.
+2. Document in release notes that users must recreate indexes.
+3. Consider providing a migration guide for major version bumps.
+
+## On-disk Format Versions
+
+If any on-disk format changed during a release cycle, bump the
+corresponding version constant:
+
+| Constant | Header | Purpose |
+|----------|--------|---------|
+| `TP_METAPAGE_VERSION` | `src/constants.h` | Index metapage format |
+| `TP_DOCID_PAGE_VERSION` | `src/constants.h` | Document ID page format |
+| `TP_PAGE_INDEX_VERSION` | `src/constants.h` | Page index format |
+| `TP_SEGMENT_FORMAT_VERSION` | `src/segment/segment.h` | Segment block storage format |
+| `TPQUERY_VERSION` | `src/types/query.h` | bm25query binary format |
+
+Version bumps break upgrade compatibility — exclude incompatible old
+versions from the upgrade-tests matrix and document the breaking
+change in release notes.
 
 ## Automated Workflows
 
@@ -194,14 +179,16 @@ When releasing a version with breaking changes:
 
 ## Troubleshooting
 
-### Old SQL files in Postgres share directory
+### Old SQL files in the Postgres share directory
 
 If tests fail with old version messages, check for stale files:
+
 ```sh
 ls ~/pg18/share/postgresql/extension/pg_textsearch*
 ```
 
 Remove old dev versions that shouldn't be installed:
+
 ```sh
 rm ~/pg18/share/postgresql/extension/pg_textsearch--X.Y.Z-dev.sql
 ```
@@ -209,6 +196,7 @@ rm ~/pg18/share/postgresql/extension/pg_textsearch--X.Y.Z-dev.sql
 ### Extension won't upgrade
 
 If `ALTER EXTENSION pg_textsearch UPDATE` fails, verify:
-1. The upgrade SQL file exists in the share directory
-2. The control file has the correct `default_version`
-3. The upgrade path exists (check `pg_extension_update_paths('pg_textsearch')`)
+
+1. The upgrade SQL file exists in the share directory.
+2. The control file has the correct `default_version`.
+3. The upgrade path exists (check `pg_extension_update_paths('pg_textsearch')`).

--- a/benchmarks/datasets/msmarco-v2/run_v2_benchmark.sh
+++ b/benchmarks/datasets/msmarco-v2/run_v2_benchmark.sh
@@ -63,8 +63,8 @@ check_tapir_version() {
     local ver
     ver=$(psql -t -c "SELECT default_version FROM pg_available_extensions WHERE name = 'pg_textsearch';" 2>/dev/null | tr -d ' ')
     echo "pg_textsearch version: $ver"
-    if [ "$ver" != "1.1.0" ]; then
-        echo "WARNING: Expected 1.1.0, got '$ver'"
+    if [ "$ver" != "1.2.0-dev" ]; then
+        echo "WARNING: Expected 1.2.0-dev, got '$ver'"
     fi
 }
 

--- a/pg_textsearch.control
+++ b/pg_textsearch.control
@@ -1,5 +1,5 @@
 # pg_textsearch extension
 comment = 'Full-text search with BM25 ranking'
-default_version = '1.1.0'
+default_version = '1.2.0-dev'
 module_pathname = '$libdir/pg_textsearch'
 relocatable = false

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -87,22 +87,18 @@ if [[ $MODE == dev ]]; then
     cat > "$NEW_UPGRADE" <<EOF
 -- Upgrade from $OLD to $NEW
 
--- Verify loaded library matches this SQL script version
+-- Verify the library is loaded. The version-equality check lives in
+-- the main install file (pg_textsearch--<default_version>.sql); upgrade
+-- scripts must accept any loaded version because they may run as
+-- intermediate steps in a chain that ends at default_version, not at
+-- the version named in this filename.
 DO \$\$
-DECLARE
-    lib_ver text;
 BEGIN
-    lib_ver := pg_catalog.current_setting('pg_textsearch.library_version', true);
-    IF lib_ver IS NULL THEN
+    IF pg_catalog.current_setting('pg_textsearch.library_version', true)
+       IS NULL THEN
         RAISE EXCEPTION
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
-    END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '$NEW' THEN
-        RAISE EXCEPTION
-            'pg_textsearch library version mismatch: loaded=%, expected=%. '
-            'Restart the server after installing the new binary.',
-            lib_ver, '$NEW';
     END IF;
 END \$\$;
 EOF

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -78,9 +78,8 @@ if [[ $MODE == dev ]]; then
         exit 2
     fi
 
-    # Rename the base SQL file and rewrite version strings inside.
+    # Rename the base SQL file. Body substitution happens below.
     git mv "$SRC_MAIN" "$DST_MAIN"
-    perl -i -pe "s/\Q$OLD\E/$NEW/g" "$DST_MAIN"
 
     # Create the upgrade-script stub. Authors append feature DDL as
     # work lands; release-time audit verifies completeness.
@@ -104,8 +103,10 @@ END \$\$;
 EOF
     git add "$NEW_UPGRADE"
 
-    # Makefile: rename the base-file entry and append the new
-    # upgrade entry as a continuation line.
+    # Makefile: rename the base-file DATA entry, then append the new
+    # upgrade entry. Use a targeted regex (`pg_textsearch--OLD.sql`)
+    # rather than a broad `OLD.sql` to avoid corrupting legacy
+    # upgrade-chain entries like `pg_textsearch--A--OLD.sql`.
     perl -i -pe "s|pg_textsearch--\Q$OLD\E\.sql|pg_textsearch--$NEW.sql|g" Makefile
     perl -i -pe '
         if (/^(\s+sql\/pg_textsearch--[0-9].*\.sql)$/) {
@@ -127,9 +128,27 @@ elif [[ $MODE == release ]]; then
     SRC_UPGRADE=${upgrades[0]}
     DST_UPGRADE=${SRC_UPGRADE//$OLD.sql/$NEW.sql}
 
+    # Extract PREV (last released version) from the upgrade filename
+    # `sql/pg_textsearch--PREV--OLD.sql`. Used for the README image-ref
+    # rewrite (the dev-cycle README points at the PREV banner image).
+    PREV=${SRC_UPGRADE#sql/pg_textsearch--}
+    PREV=${PREV%%--*}
+
     git mv "$SRC_MAIN" "$DST_MAIN"
     git mv "$SRC_UPGRADE" "$DST_UPGRADE"
+
+    # Makefile: update both DATA entries (main install + current upgrade
+    # file). Safe to use the broader `--OLD.sql` regex here because in
+    # release mode OLD=X.Y.Z-dev only appears in the current cycle's
+    # entries, never in legacy upgrade-chain filenames.
+    perl -i -pe "s|--\Q$OLD\E\.sql|--$NEW.sql|g" Makefile
 fi
+
+# Body substitutions for the renamed SQL files (both modes need these:
+# version-equality block in the main install file, version comments in
+# the upgrade file).
+perl -i -pe "s/\Q$OLD\E/$NEW/g" "$DST_MAIN"
+[[ $MODE == release ]] && perl -i -pe "s/\Q$OLD\E/$NEW/g" "$DST_UPGRADE"
 
 # --- common text substitutions -------------------------------------
 
@@ -137,7 +156,6 @@ fi
 common_files=(
     pg_textsearch.control
     src/mod.c
-    README.md
     CLAUDE.md
     test/scripts/memory_accounting.sh
     test/scripts/multi_index.sh
@@ -151,19 +169,42 @@ for f in "${common_files[@]}"; do
     fi
 done
 
+# README needs mode-aware handling for the banner-image ref.
+#
+# Dev mode skips the image line so README keeps pointing at the
+# last-released banner: dev cycles don't ship banner images, and
+# rewriting the line would 404 the README on GitHub for the entire
+# cycle.
+#
+# Release mode rewrites the image ref from PREV (the last-released
+# banner the dev cycle was pointing at) to NEW. The human drops in
+# the new image file as a follow-up; release-mode next-steps
+# reminds them.
+if [[ $MODE == release ]]; then
+    perl -i -pe "s/\Q$OLD\E/$NEW/g" README.md
+    perl -i -pe "s|tapir_and_friends_v\Q$PREV\E\.png|tapir_and_friends_v$NEW.png|g" README.md
+else
+    perl -i -pe "s/\Q$OLD\E/$NEW/g unless m{tapir_and_friends}" README.md
+fi
+
 # --- straggler check -----------------------------------------------
 
 # Find any remaining references to OLD outside known-safe locations.
 # Excluded: this script, expected outputs, older upgrade SQL files,
 # RELEASING.md (carries the historical upgrade chain), the
-# upgrade-tests workflow (carries phase-history comments).
-stragglers=$(git grep -l --fixed-strings "$OLD" -- \
+# upgrade-tests workflow (carries phase-history comments). The
+# `grep -v` drops the README banner-image line, which legitimately
+# retains OLD in dev mode (the dev cycle keeps pointing at the
+# last-released banner; release mode rewrites it via PREV above).
+stragglers=$(git grep --fixed-strings "$OLD" -- \
     ':!scripts/bump-version.sh' \
     ':!test/expected/' \
     ':!sql/pg_textsearch--*--*.sql' \
     ':!RELEASING.md' \
     ':!.github/workflows/upgrade-tests.yml' \
     ':!docs/' \
+    | grep -v "tapir_and_friends_v${OLD}\.png" \
+    | cut -d: -f1 | sort -u \
     || true)
 
 if [[ -n $stragglers ]]; then
@@ -179,12 +220,13 @@ echo "Version bump $OLD → $NEW complete."
 echo
 
 if [[ $MODE == release ]]; then
-    PREV=${SRC_UPGRADE#sql/pg_textsearch--}
-    PREV=${PREV%%--*}
     cat <<EOF
 Next steps (release):
   1. Add the new banner image at images/tapir_and_friends_v$NEW.png
-     and remove images/tapir_and_friends_v$OLD.png.
+     and remove images/tapir_and_friends_v$PREV.png. (The dev cycle
+     left the README pointing at v$PREV.png; the rename above
+     repointed it to v$NEW.png, but the file itself doesn't exist
+     yet.)
   2. Add $OLD to the old_version matrix in
      .github/workflows/upgrade-tests.yml.
   3. Audit sql/pg_textsearch--$PREV--$NEW.sql against the diff:

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# bump-version.sh OLD NEW
+#
+# Bumps the pg_textsearch version from OLD to NEW. Run from the repo
+# root with a clean working tree. Auto-detects mode from the version
+# strings:
+#
+#   OLD=A.B.C       NEW=X.Y.Z-dev   →  dev bump (post-release)
+#   OLD=X.Y.Z-dev   NEW=X.Y.Z       →  release (same triple)
+#
+# Updates the SQL files, Makefile DATA list, control file, mod.c,
+# README, CLAUDE.md, test scripts, and the msmarco benchmark check.
+# Does NOT regenerate the banner image, edit the upgrade-tests
+# matrix, author the upgrade SQL, run tests, or open a PR — those
+# are listed in the "next steps" output.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 OLD NEW" >&2
+    exit 2
+fi
+
+OLD=$1
+NEW=$2
+
+# --- mode detection ------------------------------------------------
+
+is_release() {  # X.Y.Z (no -dev suffix)
+    [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+is_dev() {      # X.Y.Z-dev
+    [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+-dev$ ]]
+}
+
+if is_release "$OLD" && is_dev "$NEW"; then
+    MODE=dev
+elif is_dev "$OLD" && is_release "$NEW" && [[ ${OLD%-dev} == "$NEW" ]]; then
+    MODE=release
+else
+    echo "Error: invalid OLD/NEW combination." >&2
+    echo "  Dev bump: OLD=A.B.C, NEW=X.Y.Z-dev" >&2
+    echo "  Release:  OLD=X.Y.Z-dev, NEW=X.Y.Z (same triple)" >&2
+    exit 2
+fi
+
+# --- safety checks -------------------------------------------------
+
+if [[ ! -f pg_textsearch.control ]]; then
+    echo "Error: run from the repo root." >&2
+    exit 2
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: working tree is not clean. Commit or stash first." >&2
+    exit 2
+fi
+
+SRC_MAIN="sql/pg_textsearch--$OLD.sql"
+DST_MAIN="sql/pg_textsearch--$NEW.sql"
+
+if [[ ! -f $SRC_MAIN ]]; then
+    echo "Error: $SRC_MAIN does not exist." >&2
+    exit 2
+fi
+if [[ -f $DST_MAIN ]]; then
+    echo "Error: $DST_MAIN already exists." >&2
+    exit 2
+fi
+
+# --- mode-specific actions -----------------------------------------
+
+if [[ $MODE == dev ]]; then
+    NEW_UPGRADE="sql/pg_textsearch--$OLD--$NEW.sql"
+    if [[ -f $NEW_UPGRADE ]]; then
+        echo "Error: $NEW_UPGRADE already exists." >&2
+        exit 2
+    fi
+
+    # Rename the base SQL file and rewrite version strings inside.
+    git mv "$SRC_MAIN" "$DST_MAIN"
+    perl -i -pe "s/\Q$OLD\E/$NEW/g" "$DST_MAIN"
+
+    # Create the upgrade-script stub. Authors append feature DDL as
+    # work lands; release-time audit verifies completeness.
+    cat > "$NEW_UPGRADE" <<EOF
+-- Upgrade from $OLD to $NEW
+
+-- Verify loaded library matches this SQL script version
+DO \$\$
+DECLARE
+    lib_ver text;
+BEGIN
+    lib_ver := pg_catalog.current_setting('pg_textsearch.library_version', true);
+    IF lib_ver IS NULL THEN
+        RAISE EXCEPTION
+            'pg_textsearch library not loaded. '
+            'Add pg_textsearch to shared_preload_libraries and restart.';
+    END IF;
+    IF lib_ver OPERATOR(pg_catalog.<>) '$NEW' THEN
+        RAISE EXCEPTION
+            'pg_textsearch library version mismatch: loaded=%, expected=%. '
+            'Restart the server after installing the new binary.',
+            lib_ver, '$NEW';
+    END IF;
+END \$\$;
+EOF
+    git add "$NEW_UPGRADE"
+
+    # Makefile: rename the base-file entry and append the new
+    # upgrade entry as a continuation line.
+    perl -i -pe "s|pg_textsearch--\Q$OLD\E\.sql|pg_textsearch--$NEW.sql|g" Makefile
+    perl -i -pe '
+        if (/^(\s+sql\/pg_textsearch--[0-9].*\.sql)$/) {
+            $_ = "$1 \\\n       sql/pg_textsearch--'"$OLD"'--'"$NEW"'.sql\n";
+        }
+    ' Makefile
+
+elif [[ $MODE == release ]]; then
+    # Find and rename the upgrade file `sql/pg_textsearch--PREV--OLD.sql`.
+    # Globbing here uses bash's nullglob so we can count safely.
+    shopt -s nullglob
+    upgrades=( sql/pg_textsearch--*--"$OLD".sql )
+    shopt -u nullglob
+    if [[ ${#upgrades[@]} -ne 1 ]]; then
+        echo "Error: expected exactly one sql/pg_textsearch--*--$OLD.sql," \
+             "found ${#upgrades[@]}." >&2
+        exit 2
+    fi
+    SRC_UPGRADE=${upgrades[0]}
+    DST_UPGRADE=${SRC_UPGRADE//$OLD.sql/$NEW.sql}
+
+    git mv "$SRC_MAIN" "$DST_MAIN"
+    git mv "$SRC_UPGRADE" "$DST_UPGRADE"
+fi
+
+# --- common text substitutions -------------------------------------
+
+# Files where every literal occurrence of OLD becomes NEW.
+common_files=(
+    pg_textsearch.control
+    src/mod.c
+    README.md
+    CLAUDE.md
+    test/scripts/memory_accounting.sh
+    test/scripts/multi_index.sh
+    test/scripts/segment_wal_recovery.sh
+    benchmarks/datasets/msmarco-v2/run_v2_benchmark.sh
+)
+
+for f in "${common_files[@]}"; do
+    if [[ -f $f ]]; then
+        perl -i -pe "s/\Q$OLD\E/$NEW/g" "$f"
+    fi
+done
+
+# --- straggler check -----------------------------------------------
+
+# Find any remaining references to OLD outside known-safe locations.
+# Excluded: this script, expected outputs, older upgrade SQL files,
+# RELEASING.md (carries the historical upgrade chain), the
+# upgrade-tests workflow (carries phase-history comments).
+stragglers=$(git grep -l --fixed-strings "$OLD" -- \
+    ':!scripts/bump-version.sh' \
+    ':!test/expected/' \
+    ':!sql/pg_textsearch--*--*.sql' \
+    ':!RELEASING.md' \
+    ':!.github/workflows/upgrade-tests.yml' \
+    ':!docs/' \
+    || true)
+
+if [[ -n $stragglers ]]; then
+    echo "Warning: literal '$OLD' still appears in:" >&2
+    echo "$stragglers" | sed 's/^/  /' >&2
+    echo "Review and update by hand if these need bumping." >&2
+fi
+
+# --- next steps ----------------------------------------------------
+
+echo
+echo "Version bump $OLD → $NEW complete."
+echo
+
+if [[ $MODE == release ]]; then
+    PREV=${SRC_UPGRADE#sql/pg_textsearch--}
+    PREV=${PREV%%--*}
+    cat <<EOF
+Next steps (release):
+  1. Add the new banner image at images/tapir_and_friends_v$NEW.png
+     and remove images/tapir_and_friends_v$OLD.png.
+  2. Add $OLD to the old_version matrix in
+     .github/workflows/upgrade-tests.yml.
+  3. Audit sql/pg_textsearch--$PREV--$NEW.sql against the diff:
+       diff sql/pg_textsearch--$PREV.sql sql/pg_textsearch--$NEW.sql
+     Every new CREATE FUNCTION / OPERATOR / OPERATOR CLASS / TYPE /
+     CAST in the main file must have a matching statement in the
+     upgrade file. See RELEASING.md for the full audit checklist.
+  4. Open a PR titled "Release v$NEW".
+EOF
+else
+    cat <<EOF
+Next steps (dev bump):
+  1. Review the generated stub $NEW_UPGRADE.
+  2. Open a PR titled "chore: bump version to $NEW".
+EOF
+fi

--- a/sql/pg_textsearch--1.0.0--1.1.0.sql
+++ b/sql/pg_textsearch--1.0.0--1.1.0.sql
@@ -1,21 +1,16 @@
 -- Upgrade from 1.0.0 to 1.1.0
 
--- Verify loaded library matches this SQL script version
+-- Verify the library is loaded. The version-equality check belongs in
+-- the *latest* upgrade script only; intermediate scripts (this one
+-- becomes intermediate after a future bump) must accept any loaded
+-- version because the chain ends at default_version, not here.
 DO $$
-DECLARE
-    lib_ver text;
 BEGIN
-    lib_ver := pg_catalog.current_setting('pg_textsearch.library_version', true);
-    IF lib_ver IS NULL THEN
+    IF pg_catalog.current_setting('pg_textsearch.library_version', true)
+       IS NULL THEN
         RAISE EXCEPTION
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
-    END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '1.1.0' THEN
-        RAISE EXCEPTION
-            'pg_textsearch library version mismatch: loaded=%, expected=%. '
-            'Restart the server after installing the new binary.',
-            lib_ver, '1.1.0';
     END IF;
 END $$;
 

--- a/sql/pg_textsearch--1.0.0--1.1.0.sql
+++ b/sql/pg_textsearch--1.0.0--1.1.0.sql
@@ -68,9 +68,3 @@ CREATE FUNCTION bm25_memory_usage(
 )
 AS 'MODULE_PATHNAME', 'tp_memory_usage'
 LANGUAGE C VOLATILE;
-
-DO $$
-BEGIN
-    RAISE INFO 'pg_textsearch v1.1.0';
-END
-$$;

--- a/sql/pg_textsearch--1.1.0--1.2.0-dev.sql
+++ b/sql/pg_textsearch--1.1.0--1.2.0-dev.sql
@@ -1,20 +1,16 @@
 -- Upgrade from 1.1.0 to 1.2.0-dev
 
--- Verify loaded library matches this SQL script version
+-- Verify the library is loaded. The version-equality check lives in
+-- the main install file (pg_textsearch--<default_version>.sql); upgrade
+-- scripts must accept any loaded version because they may run as
+-- intermediate steps in a chain that ends at default_version, not at
+-- the version named in this filename.
 DO $$
-DECLARE
-    lib_ver text;
 BEGIN
-    lib_ver := pg_catalog.current_setting('pg_textsearch.library_version', true);
-    IF lib_ver IS NULL THEN
+    IF pg_catalog.current_setting('pg_textsearch.library_version', true)
+       IS NULL THEN
         RAISE EXCEPTION
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
-    END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '1.2.0-dev' THEN
-        RAISE EXCEPTION
-            'pg_textsearch library version mismatch: loaded=%, expected=%. '
-            'Restart the server after installing the new binary.',
-            lib_ver, '1.2.0-dev';
     END IF;
 END $$;

--- a/sql/pg_textsearch--1.1.0--1.2.0-dev.sql
+++ b/sql/pg_textsearch--1.1.0--1.2.0-dev.sql
@@ -1,0 +1,20 @@
+-- Upgrade from 1.1.0 to 1.2.0-dev
+
+-- Verify loaded library matches this SQL script version
+DO $$
+DECLARE
+    lib_ver text;
+BEGIN
+    lib_ver := pg_catalog.current_setting('pg_textsearch.library_version', true);
+    IF lib_ver IS NULL THEN
+        RAISE EXCEPTION
+            'pg_textsearch library not loaded. '
+            'Add pg_textsearch to shared_preload_libraries and restart.';
+    END IF;
+    IF lib_ver OPERATOR(pg_catalog.<>) '1.2.0-dev' THEN
+        RAISE EXCEPTION
+            'pg_textsearch library version mismatch: loaded=%, expected=%. '
+            'Restart the server after installing the new binary.',
+            lib_ver, '1.2.0-dev';
+    END IF;
+END $$;

--- a/sql/pg_textsearch--1.1.0.sql
+++ b/sql/pg_textsearch--1.1.0.sql
@@ -228,13 +228,6 @@ CREATE FUNCTION @extschema@.bm25_dump_index(text) RETURNS text
     AS 'MODULE_PATHNAME', 'tp_dump_index'
     LANGUAGE C STRICT STABLE;
 
--- Display version info
-DO $$
-BEGIN
-    RAISE INFO 'pg_textsearch v1.1.0';
-END
-$$;
-
 -- Function to force segment write (spill memtable to disk)
 CREATE FUNCTION @extschema@.bm25_spill_index(index_name text)
 RETURNS int4

--- a/sql/pg_textsearch--1.2.0-dev.sql
+++ b/sql/pg_textsearch--1.2.0-dev.sql
@@ -1,4 +1,4 @@
--- pg_textsearch extension version 1.1.0
+-- pg_textsearch extension version 1.2.0-dev
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_textsearch" to load this file. \quit
@@ -14,11 +14,11 @@ BEGIN
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
     END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '1.1.0' THEN
+    IF lib_ver OPERATOR(pg_catalog.<>) '1.2.0-dev' THEN
         RAISE EXCEPTION
             'pg_textsearch library version mismatch: loaded=%, expected=%. '
             'Restart the server after installing the new binary.',
-            lib_ver, '1.1.0';
+            lib_ver, '1.2.0-dev';
     END IF;
 END $$;
 

--- a/src/mod.c
+++ b/src/mod.c
@@ -32,7 +32,7 @@
 #include "scoring/bm25.h"
 
 #if PG_VERSION_NUM >= 180000
-PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.1.0");
+PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.2.0-dev");
 #else
 PG_MODULE_MAGIC;
 #endif

--- a/test/expected/abort.out
+++ b/test/expected/abort.out
@@ -7,7 +7,6 @@
 -- are forbidden, so the hook must skip its work.
 --
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Scenario 1: Basic abort with no pg_textsearch objects
 -- This is the original bug report (#247): ROLLBACK after an error in a
 -- transaction that has nothing to do with BM25 should not crash.

--- a/test/expected/aerodocs.out
+++ b/test/expected/aerodocs.out
@@ -4,7 +4,6 @@
 -- Tests both dataset loading and pg_textsearch scoring functionality with the <@> operator
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/aerodocs_1.out
+++ b/test/expected/aerodocs_1.out
@@ -4,7 +4,6 @@
 -- Tests both dataset loading and pg_textsearch scoring functionality with the <@> operator
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;

--- a/test/expected/basic.out
+++ b/test/expected/basic.out
@@ -1,7 +1,6 @@
 -- Basic functionality tests for pg_textsearch extension
 -- Test extension creation
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Verify library version GUC is set
 SELECT current_setting('pg_textsearch.library_version') IS NOT NULL AS has_version;
  has_version 

--- a/test/expected/binary_io.out
+++ b/test/expected/binary_io.out
@@ -1,6 +1,5 @@
 -- Test binary I/O for bm25query type (COPY BINARY)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create a table and index for testing
 CREATE TABLE binary_io_docs (id SERIAL PRIMARY KEY, content TEXT);
 INSERT INTO binary_io_docs (content) VALUES

--- a/test/expected/bmw.out
+++ b/test/expected/bmw.out
@@ -2,7 +2,6 @@
 -- Tests the top-k optimization for both single-term and multi-term queries
 -- Setup: Create extension
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Force index scan so ORDER BY uses the BM25 index (small tables
 -- would otherwise prefer seq scan, returning non-matching rows)
 SET enable_seqscan = off;

--- a/test/expected/bulk_load.out
+++ b/test/expected/bulk_load.out
@@ -1,7 +1,6 @@
 -- Test bulk load spill threshold
 -- Exercises state.c bulk_load_spill_check path
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Set a very low bulk load threshold to trigger automatic spill
 SET pg_textsearch.bulk_load_threshold = 100;
 -- Create table and index

--- a/test/expected/catalog_stats.out
+++ b/test/expected/catalog_stats.out
@@ -1,7 +1,6 @@
 -- Test that BM25 indexes report correct catalog statistics
 -- (pg_class.reltuples, pg_class.relpages, pg_stat_user_indexes)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- ============================================================
 -- heap_tuples vs index_tuples for partial indexes
 --

--- a/test/expected/compression.out
+++ b/test/expected/compression.out
@@ -1,7 +1,6 @@
 -- Test compression functionality
 -- Tests that compression (now default) produces correct results
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Compression is now on by default
 SHOW pg_textsearch.compress_segments;
  pg_textsearch.compress_segments 

--- a/test/expected/concurrent_build.out
+++ b/test/expected/concurrent_build.out
@@ -5,7 +5,6 @@
 -- function can determine which tuples are already indexed and avoid
 -- duplicating entries.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET enable_seqscan = off;
 --------------------------------------------------------------------------------
 -- Test 1: Basic CREATE INDEX CONCURRENTLY

--- a/test/expected/coverage.out
+++ b/test/expected/coverage.out
@@ -1,7 +1,6 @@
 -- Additional coverage tests for untested code paths
 -- Tests debug functions, segment dump, and text<@>text operator
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- =============================================================================
 -- Test 1: Basic debug functions with memtable-only data
 -- =============================================================================

--- a/test/expected/deletion.out
+++ b/test/expected/deletion.out
@@ -1,7 +1,6 @@
 -- Test handling of row deletions in indexed tables
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create test table
 CREATE TABLE deletion_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/dropped.out
+++ b/test/expected/dropped.out
@@ -1,7 +1,6 @@
 -- Test behavior when using a dropped index name in queries
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create test table
 CREATE TABLE dropped_idx_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/empty.out
+++ b/test/expected/empty.out
@@ -1,7 +1,6 @@
 -- Test handling of empty and whitespace-only documents
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create test table with various empty/whitespace content
 CREATE TABLE empty_docs (
     id SERIAL PRIMARY KEY,

--- a/test/expected/explicit_index.out
+++ b/test/expected/explicit_index.out
@@ -1,7 +1,6 @@
 -- Test explicit index name in to_bm25query
 -- Validates fixes for GitHub issues #183 and #194
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -----------------------------------------------------------------------
 -- Issue #194: to_bm25query with explicit index ignores index column
 -- Using an index on a different column should error

--- a/test/expected/expression_index.out
+++ b/test/expected/expression_index.out
@@ -1,6 +1,5 @@
 -- Expression index tests for pg_textsearch
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- ============================================================
 -- JSONB expression index
 -- ============================================================

--- a/test/expected/force_merge.out
+++ b/test/expected/force_merge.out
@@ -7,7 +7,6 @@
 -- 3. Queries return correct results after merge
 -- 4. Inserts work normally after force merge
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;

--- a/test/expected/implicit.out
+++ b/test/expected/implicit.out
@@ -1,7 +1,6 @@
 -- Test implicit index resolution via planner hook
 -- Tests that to_bm25query() without an index name automatically finds the BM25 index
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET enable_seqscan = off;
 -- Create test table with BM25 index
 CREATE TABLE implicit_docs (

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -1,7 +1,6 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Setup test table

--- a/test/expected/index_1.out
+++ b/test/expected/index_1.out
@@ -1,7 +1,6 @@
 -- Test pg_textsearch index access method functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Setup test table

--- a/test/expected/inheritance.out
+++ b/test/expected/inheritance.out
@@ -1,7 +1,6 @@
 -- Test BM25 index behavior with table inheritance
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- =============================================================================
 -- Test 1: PostgreSQL native table inheritance
 -- BM25 indexes on parent tables only index direct rows (ONLY semantics),

--- a/test/expected/limits.out
+++ b/test/expected/limits.out
@@ -3,7 +3,6 @@
 SET log_duration = off;
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/limits_1.out
+++ b/test/expected/limits_1.out
@@ -3,7 +3,6 @@
 SET log_duration = off;
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/lock.out
+++ b/test/expected/lock.out
@@ -1,7 +1,6 @@
 -- Test lock upgrade from shared to exclusive within a single transaction
 -- This exercises the tp_acquire_index_lock upgrade path
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create test table and index
 CREATE TABLE lock_upgrade_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/manyterms.out
+++ b/test/expected/manyterms.out
@@ -2,7 +2,6 @@
 -- This test creates enough unique terms to trigger hash table resize
 -- and verifies the system continues to work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Create test table

--- a/test/expected/max_shared_memory.out
+++ b/test/expected/max_shared_memory.out
@@ -1,7 +1,6 @@
 -- Test pg_textsearch.memory_limit GUC
 -- Derives per-index (limit/8) and global (limit/2) soft limits internally.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Ensure clean GUC state from any prior test runs
 ALTER SYSTEM RESET pg_textsearch.memory_limit;
 ALTER SYSTEM RESET pg_textsearch.bulk_load_threshold;

--- a/test/expected/memory.out
+++ b/test/expected/memory.out
@@ -1,7 +1,6 @@
 -- Test bulk insert with auto-spill for pg_textsearch indexes
 -- Create extension if not exists
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create test table
 DROP TABLE IF EXISTS memory_test CASCADE;
 NOTICE:  table "memory_test" does not exist, skipping

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -6,7 +6,6 @@
 -- 2. L0 -> L1 merge triggered by segments_per_level = 2
 -- 3. Queries across multiple segment levels (L0, L1)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;

--- a/test/expected/mixed.out
+++ b/test/expected/mixed.out
@@ -2,7 +2,6 @@
 -- This test verifies that concurrent access to shared memory structures is safe
 -- and that operations like inserts, searches, and index building work correctly
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 -- Clean up from any previous tests

--- a/test/expected/parallel_bmw.out
+++ b/test/expected/parallel_bmw.out
@@ -6,7 +6,6 @@
 -- causing BMW to underestimate block score upper bounds and incorrectly
 -- skip blocks containing high-scoring short documents.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET enable_seqscan = off;
 SET min_parallel_table_scan_size = 0;
 SET maintenance_work_mem = '256MB';

--- a/test/expected/parallel_build.out
+++ b/test/expected/parallel_build.out
@@ -1,7 +1,6 @@
 -- Test case: parallel_build
 -- Tests parallel index build with various worker counts and corner cases
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET enable_seqscan = off;
 -- Lower threshold so our test tables qualify for parallel build
 SET min_parallel_table_scan_size = 0;

--- a/test/expected/partial_index.out
+++ b/test/expected/partial_index.out
@@ -1,6 +1,5 @@
 -- Partial index tests for pg_textsearch
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- ============================================================
 -- Basic partial index
 -- ============================================================

--- a/test/expected/partitioned.out
+++ b/test/expected/partitioned.out
@@ -16,7 +16,6 @@
 -- partition-local statistics.
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Load validation functions
 \set ECHO none
 SET enable_seqscan = off;

--- a/test/expected/partitioned_1.out
+++ b/test/expected/partitioned_1.out
@@ -16,7 +16,6 @@
 -- partition-local statistics.
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Load validation functions
 \set ECHO none
 SET enable_seqscan = off;

--- a/test/expected/partitioned_many.out
+++ b/test/expected/partitioned_many.out
@@ -5,7 +5,6 @@
 -- The bug triggers during document processing when per-index locks accumulate.
 -- With 200 partitions and data, the old code would exceed MAX_SIMUL_LWLOCKS.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create a partitioned table with 200 partitions
 -- (200 is enough to trigger the bug - old limit was ~142 partitions)
 CREATE TABLE docs_many_parts (

--- a/test/expected/pgstats.out
+++ b/test/expected/pgstats.out
@@ -1,6 +1,5 @@
 -- Test that BM25 index scans report statistics to pg_stat_user_indexes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create a test table with BM25 index
 CREATE TABLE test_pgstats (id serial PRIMARY KEY, content text);
 CREATE INDEX test_pgstats_idx ON test_pgstats

--- a/test/expected/queries.out
+++ b/test/expected/queries.out
@@ -1,7 +1,6 @@
 -- This test demonstrates top-k pg_textsearch query patterns for efficient text search
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/quoted_identifiers.out
+++ b/test/expected/quoted_identifiers.out
@@ -3,7 +3,6 @@
 -- identifiers for both index names and schema names.
 -- Regression test for https://github.com/timescale/pg_textsearch/issues/285
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Test 1: Uppercase index name (the reported bug)
 CREATE TABLE qi_test1 (
     id SERIAL PRIMARY KEY,

--- a/test/expected/rescan.out
+++ b/test/expected/rescan.out
@@ -12,7 +12,6 @@
 -- (exponential backoff: 2x, 4x, ...) until enough rows are found.
 SET log_duration = off;
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET client_min_messages = NOTICE;
 SET enable_seqscan = false;
 ------------------------------------------------------------------------

--- a/test/expected/schema.out
+++ b/test/expected/schema.out
@@ -1,7 +1,6 @@
 -- Test case: schema
 -- Tests index operations with schema-qualified tables
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;
 -- Create a custom schema

--- a/test/expected/scoring1.out
+++ b/test/expected/scoring1.out
@@ -2,7 +2,6 @@
 -- Generated BM25 test with 2 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring2.out
+++ b/test/expected/scoring2.out
@@ -2,7 +2,6 @@
 -- Generated BM25 test with 5 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring3.out
+++ b/test/expected/scoring3.out
@@ -2,7 +2,6 @@
 -- Generated BM25 test with 3 documents and 2 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring4.out
+++ b/test/expected/scoring4.out
@@ -2,7 +2,6 @@
 -- Generated BM25 test with 2 documents and 1 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring5.out
+++ b/test/expected/scoring5.out
@@ -2,7 +2,6 @@
 -- Generated BM25 test with 3 documents and 4 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/scoring6.out
+++ b/test/expected/scoring6.out
@@ -2,7 +2,6 @@
 -- Generated BM25 test with 2 documents and 3 queries
 -- Testing both bulk build and incremental build modes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = true;
 SET enable_seqscan = off;

--- a/test/expected/security.out
+++ b/test/expected/security.out
@@ -1,6 +1,5 @@
 -- Test security restrictions on debug and admin functions
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create test data
 CREATE TABLE security_test (id serial, content text);
 INSERT INTO security_test (content) VALUES ('test document');

--- a/test/expected/segment.out
+++ b/test/expected/segment.out
@@ -2,7 +2,6 @@
 -- Tests segment query functionality with multiple spill cycles and
 -- post-spill inserts
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;

--- a/test/expected/segment_integrity.out
+++ b/test/expected/segment_integrity.out
@@ -9,7 +9,6 @@
 -- - Document length encoding errors
 -- - Term frequency encoding errors
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET pg_textsearch.log_scores = false;
 SET enable_seqscan = off;
 -- Create table with enough documents to be meaningful

--- a/test/expected/strings.out
+++ b/test/expected/strings.out
@@ -1,7 +1,6 @@
 -- Test long string handling including URLs, paths, and long terms
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/temp_table.out
+++ b/test/expected/temp_table.out
@@ -4,7 +4,6 @@
 -- scanning a BM25 index on a temp table.
 --
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Basic: create, populate, query, drop
 CREATE TEMP TABLE t_basic (id serial, body text);
 INSERT INTO t_basic VALUES (DEFAULT, 'hello world'), (DEFAULT, 'foo bar baz');

--- a/test/expected/text_array.out
+++ b/test/expected/text_array.out
@@ -1,6 +1,5 @@
 -- Test BM25 index on text[] columns
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Basic text array table and index
 CREATE TABLE docs_array (
     id SERIAL PRIMARY KEY,

--- a/test/expected/text_config.out
+++ b/test/expected/text_config.out
@@ -1,6 +1,5 @@
 -- Test parameter "text_config" accepts qualified names
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create table
 CREATE TABLE text_config_tbl (
     id SERIAL PRIMARY KEY,

--- a/test/expected/unlogged_index.out
+++ b/test/expected/unlogged_index.out
@@ -1,6 +1,5 @@
 -- Test unlogged index behavior and initialization fork creation
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create UNLOGGED table and index
 CREATE UNLOGGED TABLE unlogged_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/unsupported.out
+++ b/test/expected/unsupported.out
@@ -1,7 +1,6 @@
 -- Test cases for queries that are NOT YET fully supported
 -- These document known limitations of the current implicit index resolution
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Setup test tables
 CREATE TABLE docs (
     id SERIAL PRIMARY KEY,

--- a/test/expected/updates.out
+++ b/test/expected/updates.out
@@ -2,7 +2,6 @@
 -- This test reproduces the NULL index_state crash reported in production
 -- Install the extension if not already installed
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Test basic UPDATE operations
 CREATE TABLE update_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -1,7 +1,6 @@
 -- Test VACUUM behavior with BM25 indexes
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Create test table
 CREATE TABLE vacuum_test (
     id SERIAL PRIMARY KEY,

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -1,6 +1,5 @@
 -- Test alive bitset tombstone tracking during VACUUM
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- =============================================================
 -- Test 1: Basic VACUUM with bitmap marking
 -- =============================================================

--- a/test/expected/vacuum_extended.out
+++ b/test/expected/vacuum_extended.out
@@ -1,7 +1,6 @@
 -- Extended vacuum tests for BM25 indexes
 -- Exercises vacuum paths with segments, bulk deletes, and empty indexes
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- =============================================================================
 -- Test 1: Vacuum with segments present
 -- =============================================================================

--- a/test/expected/vacuum_rebuild.out
+++ b/test/expected/vacuum_rebuild.out
@@ -6,7 +6,6 @@
 -- the heap tuple and catch stale results. We use enable_seqscan=off
 -- to ensure the index scan is used even for small tables.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 SET enable_seqscan = off;
 -- ================================================================
 -- Test 1: Basic CTID reuse after VACUUM

--- a/test/expected/vector.out
+++ b/test/expected/vector.out
@@ -1,7 +1,6 @@
 -- Test bm25vector type and operators functionality
 -- Load pg_textsearch extension
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 -- Enable score logging for testing
 SET pg_textsearch.log_scores = true;
 SET client_min_messages = NOTICE;

--- a/test/expected/wand.out
+++ b/test/expected/wand.out
@@ -5,7 +5,6 @@
 -- are correctly scored. Uses validation.sql to verify scores match
 -- the reference BM25 implementation.
 CREATE EXTENSION pg_textsearch;
-INFO:  pg_textsearch v1.1.0
 \set ECHO none
 -- ============================================================
 -- TEST: Multi-term documents score correctly across block boundaries

--- a/test/scripts/memory_accounting.sh
+++ b/test/scripts/memory_accounting.sh
@@ -66,7 +66,7 @@ EOF
     "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" "${TEST_DB}"
     "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
         -d "${TEST_DB}" \
-        -c "CREATE EXTENSION pg_textsearch VERSION '1.1.0';" \
+        -c "CREATE EXTENSION pg_textsearch VERSION '1.2.0-dev';" \
         >/dev/null
 
     # Create a persistent probe table used to force DSA attachment

--- a/test/scripts/multi_index.sh
+++ b/test/scripts/multi_index.sh
@@ -94,7 +94,7 @@ EOF
         "${TEST_DB}"
 
     run_sql_quiet "CREATE EXTENSION pg_textsearch
-                       VERSION '1.1.0';"
+                       VERSION '1.2.0-dev';"
 }
 
 run_sql() {

--- a/test/scripts/segment_wal_recovery.sh
+++ b/test/scripts/segment_wal_recovery.sh
@@ -147,7 +147,7 @@ EOF
 
 "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" \
     "${TEST_DB}"
-run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.1.0';"
+run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.2.0-dev';"
 
 # -------------------------------------------------------
 # Part 1: WAL coverage check


### PR DESCRIPTION
## Summary

Post-1.1.0 dev bump, plus tooling so future bumps are mechanical.

Three commits:

1. **Drop CREATE EXTENSION load banner; add bump-version.sh** — Remove
   the `RAISE INFO 'pg_textsearch vX.Y.Z'` block that fired on every
   \`CREATE EXTENSION\`. It produced one INFO line that 62 expected
   outputs had to absorb, so every release regenerated 62 files for
   the same one-line diff. Survey of nearby extensions (pgvector,
   pgvectorscale, pg_search, timescaledb) and standard contribs
   (pg_stat_statements, hstore, pg_trgm, pgcrypto, postgis) confirms
   none emit a load banner; pg_textsearch was the outlier. The
   library-version mismatch \`RAISE EXCEPTION\` (the actual
   correctness check) stays. Version remains discoverable via
   \`SHOW pg_textsearch.library_version\`, \`\\dx\`, and
   \`pg_extension.extversion\`.

   Also adds \`scripts/bump-version.sh\`, which automates the text
   substitutions across SQL files, Makefile DATA, control file,
   mod.c, README, CLAUDE.md, test scripts, and the msmarco benchmark
   version check. Auto-detects dev-bump vs release mode from the
   version pattern; refuses to run on a dirty tree; reports
   stragglers after substituting; prints next-steps for the human.

2. **docs: simplify RELEASING.md around bump-version.sh** — Collapse
   the per-file substitution checklist (the script does it now) and
   replace with a step-driven sequence. Add a section on auditing
   the upgrade SQL script — the one piece the script can't automate
   and the most likely place to ship a regression.

3. **chore: bump version to 1.2.0-dev** — Generated by running
   \`scripts/bump-version.sh 1.1.0 1.2.0-dev\` (the dogfood proves
   the script works). Renames the base SQL file, creates the
   upgrade-script stub, updates default_version /
   PG_MODULE_MAGIC_EXT / Makefile / README / CLAUDE.md / test
   scripts / msmarco benchmark.

## Testing

- \`make test\` — 58/58 pass on pg18-release after the bump
- \`make format-check\` — clean
- The script itself is the integration test (commit 3 is its output)

## Follow-up for the next release

Replace the banner image and add 1.1.0 to the upgrade-tests matrix
when cutting v1.2.0; \`scripts/bump-version.sh\` reminds you of both
in its next-steps output.