### PR TITLE
fix(replication): WAL-log segment writes (#342) + 24-test physical replication suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ test-replication-extended:
 	@echo "Running extended physical replication tests..."
 	@cd test/scripts && ./replication.sh
 	@cd test/scripts && ./replication_issue_342.sh
+	@cd test/scripts && ./replication_parallel_build.sh
 	@cd test/scripts && ./replication_correctness.sh
 	@cd test/scripts && ./replication_concurrency.sh
 	@cd test/scripts && ./replication_failover.sh

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ test-logical-replication:
 test-replication-extended:
 	@echo "Running extended physical replication tests..."
 	@cd test/scripts && ./replication.sh
+	@cd test/scripts && ./replication_issue_342.sh
 	@cd test/scripts && ./replication_correctness.sh
 	@cd test/scripts && ./replication_concurrency.sh
 	@cd test/scripts && ./replication_failover.sh

--- a/Makefile
+++ b/Makefile
@@ -146,15 +146,29 @@ test-logical-replication:
 
 test-replication-extended:
 	@echo "Running extended physical replication tests..."
-	@cd test/scripts && ./replication.sh
-	@cd test/scripts && ./replication_issue_342.sh
-	@cd test/scripts && ./replication_parallel_build.sh
-	@cd test/scripts && ./replication_correctness.sh
-	@cd test/scripts && ./replication_concurrency.sh
-	@cd test/scripts && ./replication_failover.sh
-	@cd test/scripts && ./replication_compat.sh
-	@cd test/scripts && ./replication_cascading.sh
-	@cd test/scripts && ./replication_pitr.sh
+	@scripts="\
+	    replication.sh \
+	    replication_issue_342.sh \
+	    replication_parallel_build.sh \
+	    replication_correctness.sh \
+	    replication_concurrency.sh \
+	    replication_failover.sh \
+	    replication_compat.sh \
+	    replication_cascading.sh \
+	    replication_pitr.sh"; \
+	failed=""; \
+	for s in $$scripts; do \
+	    echo ""; \
+	    echo "==> $$s"; \
+	    if ! (cd test/scripts && "./$$s"); then \
+	        failed="$$failed $$s"; \
+	    fi; \
+	done; \
+	if [ -n "$$failed" ]; then \
+	    echo ""; \
+	    echo "Failed scripts:$$failed"; \
+	    exit 1; \
+	fi
 
 test-memory:
 	@echo "Running memory accounting tests..."

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,16 @@ test-logical-replication:
 	@echo "Running logical replication tests..."
 	@cd test/scripts && ./logical_replication.sh
 
+test-replication-extended:
+	@echo "Running extended physical replication tests..."
+	@cd test/scripts && ./replication.sh
+	@cd test/scripts && ./replication_correctness.sh
+	@cd test/scripts && ./replication_concurrency.sh
+	@cd test/scripts && ./replication_failover.sh
+	@cd test/scripts && ./replication_compat.sh
+	@cd test/scripts && ./replication_cascading.sh
+	@cd test/scripts && ./replication_pitr.sh
+
 test-memory:
 	@echo "Running memory accounting tests..."
 	@cd test/scripts && ./memory_accounting.sh
@@ -330,4 +340,4 @@ help:
 	@echo "  make test-all"
 	@echo "  make format"
 
-.PHONY: test clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-replication test-logical-replication test-memory test-multi-index test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help
+.PHONY: test clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-replication test-replication-extended test-logical-replication test-memory test-multi-index test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help

--- a/src/access/build_context.c
+++ b/src/access/build_context.c
@@ -8,6 +8,7 @@
  */
 #include <postgres.h>
 
+#include <access/generic_xlog.h>
 #include <common/hashfn.h>
 #include <inttypes.h>
 #include <storage/buffile.h>
@@ -674,6 +675,45 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	}
 	MarkBufferDirty(header_buf);
 	UnlockReleaseBuffer(header_buf);
+
+	/*
+	 * WAL-log all segment content pages via GenericXLog FULL_IMAGE so
+	 * they reach the standby. (Issue #342: prior code wrote these
+	 * pages via MarkBufferDirty alone. Page-index pages are covered
+	 * by log_newpage_buffer inside write_page_index_internal.)
+	 *
+	 * Mirrors the equivalent post-hoc pass in segment.c's
+	 * tp_write_segment.
+	 */
+	{
+		uint32 pg_idx = 0;
+
+		while (pg_idx < writer.pages_allocated)
+		{
+			GenericXLogState *state;
+			Buffer			  bufs[MAX_GENERIC_XLOG_PAGES];
+			uint32			  n = 0;
+			uint32			  j;
+
+			state = GenericXLogStart(index);
+
+			for (j = 0;
+				 j < MAX_GENERIC_XLOG_PAGES && pg_idx < writer.pages_allocated;
+				 j++, pg_idx++)
+			{
+				bufs[n] = ReadBuffer(index, writer.pages[pg_idx]);
+				LockBuffer(bufs[n], BUFFER_LOCK_EXCLUSIVE);
+				GenericXLogRegisterBuffer(
+						state, bufs[n], GENERIC_XLOG_FULL_IMAGE);
+				n++;
+			}
+
+			GenericXLogFinish(state);
+
+			for (j = 0; j < n; j++)
+				UnlockReleaseBuffer(bufs[j]);
+		}
+	}
 
 	FlushRelationBuffers(index);
 

--- a/src/access/build_parallel.c
+++ b/src/access/build_parallel.c
@@ -787,6 +787,44 @@ tp_build_parallel(
 					true /* disjoint_sources */);
 
 			/*
+			 * Issue #342: WAL-log all merged segment data pages via
+			 * GenericXLog FULL_IMAGE so they reach the standby.
+			 * Mirrors the equivalent pass in segment_merge.c's
+			 * tp_merge_level_segments. Page-index pages are covered
+			 * separately by log_newpage_buffer inside
+			 * write_page_index_internal.
+			 */
+			{
+				uint32 pg_idx = 0;
+
+				while (pg_idx < sink.writer.pages_allocated)
+				{
+					GenericXLogState *xstate;
+					Buffer			  xbufs[MAX_GENERIC_XLOG_PAGES];
+					uint32			  xn = 0, xj;
+
+					xstate = GenericXLogStart(index);
+
+					for (xj = 0; xj < MAX_GENERIC_XLOG_PAGES &&
+								 pg_idx < sink.writer.pages_allocated;
+						 xj++, pg_idx++)
+					{
+						xbufs[xn] =
+								ReadBuffer(index, sink.writer.pages[pg_idx]);
+						LockBuffer(xbufs[xn], BUFFER_LOCK_EXCLUSIVE);
+						GenericXLogRegisterBuffer(
+								xstate, xbufs[xn], GENERIC_XLOG_FULL_IMAGE);
+						xn++;
+					}
+
+					GenericXLogFinish(xstate);
+
+					for (xj = 0; xj < xn; xj++)
+						UnlockReleaseBuffer(xbufs[xj]);
+				}
+			}
+
+			/*
 			 * Flush dirty buffers before updating the metapage,
 			 * ensuring merged segment data is durable first.
 			 */

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -879,13 +879,13 @@ write_page_index_internal(Relation index, BlockNumber *pages, uint32 num_pages)
 		for (j = 0; j < entries_to_write; j++)
 			page_data[j] = pages[start_idx + j];
 
-		MarkBufferDirty(buffer);
 		/*
 		 * Issue #342: WAL-log the page-index page so it reaches the
 		 * standby. Prior code wrote these pages via MarkBufferDirty
-		 * alone, bypassing WAL — the post-hoc FULL_IMAGE pass in
-		 * tp_write_segment_from_build_ctx and tp_write_segment
-		 * iterates writer.pages, which excludes page-index blocks.
+		 * alone, bypassing WAL — the post-hoc FULL_IMAGE pass over
+		 * writer.pages in the segment write paths excludes page-index
+		 * blocks, since these are allocated via allocate_segment_page
+		 * rather than tp_segment_writer_allocate_page.
 		 *
 		 * page_std=false because pd_lower on this page does not cover
 		 * the data area — the page-index entries are written between
@@ -893,8 +893,16 @@ write_page_index_internal(Relation index, BlockNumber *pages, uint32 num_pages)
 		 * REGBUF_STANDARD would treat that as a hole and zero it on
 		 * replay, dropping the actual page-index contents. With
 		 * page_std=false we log the entire BLCKSZ.
+		 *
+		 * log_newpage_buffer asserts CritSectionCount > 0; the
+		 * MarkBufferDirty + WAL-log pair must be inside a critical
+		 * section so a failure between them PANICs rather than
+		 * leaving a dirty page un-WAL-logged.
 		 */
+		START_CRIT_SECTION();
+		MarkBufferDirty(buffer);
 		log_newpage_buffer(buffer, false);
+		END_CRIT_SECTION();
 		UnlockReleaseBuffer(buffer);
 
 		prev_block = index_pages[i];

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -10,6 +10,7 @@
 #include <access/generic_xlog.h>
 #include <access/hash.h>
 #include <access/table.h>
+#include <access/xloginsert.h>
 #include <catalog/namespace.h>
 #include <catalog/storage.h>
 #include <inttypes.h>
@@ -879,6 +880,21 @@ write_page_index_internal(Relation index, BlockNumber *pages, uint32 num_pages)
 			page_data[j] = pages[start_idx + j];
 
 		MarkBufferDirty(buffer);
+		/*
+		 * Issue #342: WAL-log the page-index page so it reaches the
+		 * standby. Prior code wrote these pages via MarkBufferDirty
+		 * alone, bypassing WAL — the post-hoc FULL_IMAGE pass in
+		 * tp_write_segment_from_build_ctx and tp_write_segment
+		 * iterates writer.pages, which excludes page-index blocks.
+		 *
+		 * page_std=false because pd_lower on this page does not cover
+		 * the data area — the page-index entries are written between
+		 * pd_lower (= SizeOfPageHeaderData) and pd_upper (= pd_special).
+		 * REGBUF_STANDARD would treat that as a hole and zero it on
+		 * replay, dropping the actual page-index contents. With
+		 * page_std=false we log the entire BLCKSZ.
+		 */
+		log_newpage_buffer(buffer, false);
 		UnlockReleaseBuffer(buffer);
 
 		prev_block = index_pages[i];

--- a/test/README.md
+++ b/test/README.md
@@ -36,6 +36,13 @@ test/
 - **recovery.sh** - Actual crash simulation with SIGKILL and recovery verification
 - **concurrency.sh** - Multi-session concurrency and string interning safety tests
 - **memory_limits.sh** - Memory budget enforcement stress testing with capacity limits
+- **replication.sh** - Physical streaming replication smoke tests + long-lived backend staleness reproducer
+- **replication_correctness.sh** - 10 long-lived-backend correctness tests across schema variations
+- **replication_concurrency.sh** - Multiple concurrent standby readers under primary write load
+- **replication_failover.sh** - Standby promotion under various pre-promotion states
+- **replication_compat.sh** - Logical+physical coexistence, TimescaleDB hypertables, basebackup contents
+- **replication_cascading.sh** - Three-node cascading replication (primary → standby → standby2)
+- **replication_pitr.sh** - Recovery-target-LSN test (PITR)
 
 ### 3. Concurrency Testing
 
@@ -109,6 +116,63 @@ Tests verify:
 - ✅ Per-index budgets work independently
 - ✅ Graceful transaction abort on capacity exceeded
 
+### 6. Replication Tests
+
+Physical streaming replication, cascading replication, failover, and PITR
+coverage. Most tests use **persistent psql sessions** (FIFO-managed
+backends) to expose bugs that reset on every fresh connection. Run via
+`make test-replication-extended`.
+
+The test harness is shared via `replication_lib.sh`, which provides
+two/three-node setup helpers and FIFO-based long-lived psql session
+helpers (`long_lived_open`, `long_lived_query`, `long_lived_close`,
+`long_lived_before_after`).
+
+#### Files (24 tests across 7 scripts)
+
+- **replication.sh** (5 tests) — basic standby queries, ongoing
+  replication, segment replication, long-lived backend staleness,
+  standby promotion.
+- **replication_correctness.sh** (10 tests) — long-lived-backend
+  correctness across spill/merge/UPDATE/DELETE+VACUUM/partitioned/
+  expression/partial/array/multi-index variations.
+- **replication_concurrency.sh** (3 tests) — 8 concurrent standby
+  readers under a primary insert; drain under burst; no deadlock
+  under spam load.
+- **replication_failover.sh** (3 tests) — promotion under write
+  load, with unspilled memtable, post-promotion writes+search.
+- **replication_compat.sh** (3 tests) — logical+physical coexistence,
+  TimescaleDB hypertables (skipped today unless timescaledb is in
+  shared_preload_libraries), pg_basebackup includes index files.
+- **replication_cascading.sh** (3 tests) — primary→standby→standby2
+  basic query, long-lived staleness propagating two hops, promotion
+  chain with `recovery_target_timeline=latest`.
+- **replication_pitr.sh** (1 test) — recover to mid-burst LSN and
+  verify count matches the cutoff.
+
+#### Predicted outcomes today
+
+15 tests FAIL with `BUG (expected): ...` messages, 8 PASS, 1 SKIPS
+(`replication_compat.sh` F2 — TimescaleDB skip). The failures
+document three distinct bug classes:
+
+1. **Memtable staleness** on long-lived standby backends — primary
+   inserts via WAL never update the in-memory inverted index that a
+   long-lived backend rebuilt once on first scan.
+2. **WAL-replayed segments unreadable** on long-lived standby
+   backends and even on promoted standbys — segments created via
+   spill/merge while the standby is already running are not
+   enumerable on the standby, even by fresh psql connections after
+   promotion.
+3. **Corpus statistics not replayed** via WAL — `total_docs` and
+   `total_len` counters stay 0 after PITR recovery, so BM25 IDF
+   returns 0 results until REINDEX.
+
+The companion implementation plan `docs/superpowers/plans/
+2026-04-28-physical-replication.md` will flip these failing tests
+to passing via a custom rmgr with `INSERT_TID`/`SPILL` records
+plus a bounded shared-memory pending list drained on `tp_beginscan`.
+
 ## Running Tests
 
 ### All Tests
@@ -126,11 +190,13 @@ make installcheck REGRESS=limits
 ### Shell Scripts
 ```bash
 # Individual shell script targets
-make test-concurrency      # Multi-session concurrency safety
-make test-recovery         # Crash recovery testing
-make test-stress           # Long-running stress tests
-make test-shell            # All shell scripts (concurrency + recovery + memory limits)
-make test-all              # Complete test suite (SQL + shell scripts)
+make test-concurrency             # Multi-session concurrency safety
+make test-recovery                # Crash recovery testing
+make test-stress                  # Long-running stress tests
+make test-shell                   # All shell scripts (concurrency + recovery + memory limits)
+make test-replication             # Basic physical replication smoke test
+make test-replication-extended    # 24 replication tests (correctness, concurrency, failover, compat, cascading, PITR)
+make test-all                     # Complete test suite (SQL + shell scripts)
 
 # Direct execution
 cd test/scripts

--- a/test/README.md
+++ b/test/README.md
@@ -37,6 +37,8 @@ test/
 - **concurrency.sh** - Multi-session concurrency and string interning safety tests
 - **memory_limits.sh** - Memory budget enforcement stress testing with capacity limits
 - **replication.sh** - Physical streaming replication smoke tests + long-lived backend staleness reproducer
+- **replication_issue_342.sh** - Targeted #342 reproducer (memtable spill standby visibility)
+- **replication_parallel_build.sh** - 150K-row parallel CREATE INDEX with standby streaming
 - **replication_correctness.sh** - 10 long-lived-backend correctness tests across schema variations
 - **replication_concurrency.sh** - Multiple concurrent standby readers under primary write load
 - **replication_failover.sh** - Standby promotion under various pre-promotion states
@@ -128,11 +130,16 @@ two/three-node setup helpers and FIFO-based long-lived psql session
 helpers (`long_lived_open`, `long_lived_query`, `long_lived_close`,
 `long_lived_before_after`).
 
-#### Files (24 tests across 7 scripts)
+#### Files (25 tests across 8 scripts)
 
 - **replication.sh** (5 tests) — basic standby queries, ongoing
   replication, segment replication, long-lived backend staleness,
   standby promotion.
+- **replication_issue_342.sh** (1 test) — targeted #342 reproducer
+  (memtable spill standby visibility).
+- **replication_parallel_build.sh** (1 test) — 150K-row parallel
+  CREATE INDEX with standby streaming (exercises the
+  `build_parallel.c` WAL pass added in PR #343).
 - **replication_correctness.sh** (10 tests) — long-lived-backend
   correctness across spill/merge/UPDATE/DELETE+VACUUM/partitioned/
   expression/partial/array/multi-index variations.

--- a/test/README.md
+++ b/test/README.md
@@ -130,7 +130,7 @@ two/three-node setup helpers and FIFO-based long-lived psql session
 helpers (`long_lived_open`, `long_lived_query`, `long_lived_close`,
 `long_lived_before_after`).
 
-#### Files (25 tests across 8 scripts)
+#### Files (30 tests across 9 scripts)
 
 - **replication.sh** (5 tests) — basic standby queries, ongoing
   replication, segment replication, long-lived backend staleness,
@@ -202,7 +202,7 @@ make test-recovery                # Crash recovery testing
 make test-stress                  # Long-running stress tests
 make test-shell                   # All shell scripts (concurrency + recovery + memory limits)
 make test-replication             # Basic physical replication smoke test
-make test-replication-extended    # 24 replication tests (correctness, concurrency, failover, compat, cascading, PITR)
+make test-replication-extended    # 30 replication tests (correctness, concurrency, failover, compat, cascading, PITR, parallel build)
 make test-all                     # Complete test suite (SQL + shell scripts)
 
 # Direct execution

--- a/test/scripts/replication.sh
+++ b/test/scripts/replication.sh
@@ -17,170 +17,11 @@ STANDBY_PORT=55437
 TEST_DB=replication_test
 PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_primary"
 STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_standby"
-PRIMARY_LOG="${PRIMARY_DIR}/postgres.log"
-STANDBY_LOG="${STANDBY_DIR}/postgres.log"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
 
-log() {
-    echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"
-}
-
-warn() {
-    echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARNING: $1${NC}"
-}
-
-error() {
-    echo -e "${RED}[$(date '+%H:%M:%S')] ERROR: $1${NC}"
-    exit 1
-}
-
-cleanup() {
-    local exit_code=$?
-    log "Cleaning up test environment..."
-    if [ $exit_code -ne 0 ]; then
-        warn "Test failed - dumping logs:"
-        if [ -f "${PRIMARY_DIR}/log/postgres.log" ]; then
-            echo "=== PRIMARY LOG (last 80 lines) ==="
-            tail -80 "${PRIMARY_DIR}/log/postgres.log" 2>/dev/null || true
-        fi
-        if [ -f "${STANDBY_DIR}/log/postgres.log" ]; then
-            echo "=== STANDBY LOG (last 80 lines) ==="
-            tail -80 "${STANDBY_DIR}/log/postgres.log" 2>/dev/null || true
-        fi
-    fi
-    for dir in "${STANDBY_DIR}" "${PRIMARY_DIR}"; do
-        if [ -f "${dir}/postmaster.pid" ]; then
-            pg_ctl stop -D "${dir}" -m fast 2>/dev/null ||
-                pg_ctl stop -D "${dir}" -m immediate 2>/dev/null || true
-        fi
-    done
-    rm -rf "${PRIMARY_DIR}" "${STANDBY_DIR}"
-    exit $exit_code
-}
-
-trap cleanup EXIT INT TERM
-
-primary_sql() {
-    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -c "$1" 2>&1
-}
-
-primary_sql_quiet() {
-    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c "$1" 2>/dev/null
-}
-
-standby_sql() {
-    psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -c "$1" 2>&1
-}
-
-standby_sql_quiet() {
-    psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -tA -c "$1" 2>/dev/null
-}
-
-wait_for_standby_catchup() {
-    local max_wait=${1:-10}
-    local i=0
-    log "Waiting for standby to catch up (max ${max_wait}s)..."
-    while [ $i -lt $max_wait ]; do
-        local primary_lsn
-        primary_lsn=$(psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA \
-            -c "SELECT pg_current_wal_lsn();" 2>/dev/null)
-        local standby_lsn
-        standby_lsn=$(psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -tA \
-            -c "SELECT pg_last_wal_replay_lsn();" 2>/dev/null)
-        if [ -n "$primary_lsn" ] && [ -n "$standby_lsn" ]; then
-            local caught_up
-            caught_up=$(psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -tA \
-                -c "SELECT '${standby_lsn}'::pg_lsn >= '${primary_lsn}'::pg_lsn;" 2>/dev/null)
-            if [ "$caught_up" = "t" ]; then
-                log "Standby caught up at LSN ${standby_lsn}"
-                return 0
-            fi
-        fi
-        sleep 1
-        i=$((i + 1))
-    done
-    warn "Standby may not have caught up after ${max_wait}s"
-    return 1
-}
-
-# Helper: count search results using the correct query pattern
-# The <@> operator returns a negative BM25 score (double precision),
-# so WHERE uses "< 0" to filter matches.
-search_count() {
-    local port=$1
-    local query=$2
-    local index=$3
-    psql -p "${port}" -d "${TEST_DB}" -tA -c "
-        SELECT count(*) FROM (
-            SELECT id FROM docs
-            WHERE content <@> to_bm25query('${query}', '${index}') < 0
-            ORDER BY content <@> to_bm25query('${query}', '${index}')
-            LIMIT 100
-        ) t;" 2>/dev/null
-}
-
-setup_primary() {
-    log "Setting up primary instance on port ${PRIMARY_PORT}..."
-    rm -rf "${PRIMARY_DIR}"
-    mkdir -p "${PRIMARY_DIR}"
-
-    initdb -D "${PRIMARY_DIR}" --auth-local=trust --auth-host=trust \
-        >/dev/null 2>&1
-
-    cat >> "${PRIMARY_DIR}/postgresql.conf" << EOF
-port = ${PRIMARY_PORT}
-shared_buffers = 128MB
-max_connections = 20
-log_min_messages = notice
-logging_collector = on
-log_filename = 'postgres.log'
-shared_preload_libraries = 'pg_textsearch'
-
-# WAL and replication settings
-wal_level = replica
-max_wal_senders = 5
-hot_standby = on
-EOF
-
-    # Allow replication connections
-    echo "local replication all trust" >> "${PRIMARY_DIR}/pg_hba.conf"
-    echo "host replication all 127.0.0.1/32 trust" >> \
-        "${PRIMARY_DIR}/pg_hba.conf"
-
-    pg_ctl start -D "${PRIMARY_DIR}" -l "${PRIMARY_LOG}" -w
-    createdb -p "${PRIMARY_PORT}" "${TEST_DB}"
-    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" \
-        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
-}
-
-setup_standby() {
-    log "Creating standby via pg_basebackup..."
-    rm -rf "${STANDBY_DIR}"
-
-    pg_basebackup -D "${STANDBY_DIR}" -p "${PRIMARY_PORT}" -R \
-        -X stream --checkpoint=fast >/dev/null 2>&1
-
-    # Override port for standby
-    cat >> "${STANDBY_DIR}/postgresql.conf" << EOF
-port = ${STANDBY_PORT}
-EOF
-
-    pg_ctl start -D "${STANDBY_DIR}" -l "${STANDBY_LOG}" -w
-
-    # Verify standby is in recovery mode
-    local in_recovery
-    in_recovery=$(psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -tA \
-        -c "SELECT pg_is_in_recovery();" 2>/dev/null)
-    if [ "$in_recovery" != "t" ]; then
-        error "Standby is not in recovery mode!"
-    fi
-    log "Standby running on port ${STANDBY_PORT} (in recovery)"
-}
+trap repl_cleanup EXIT INT TERM
 
 # ---------------------------------------------------------------
 # Test 1: Build index on primary, then create standby, query it
@@ -217,8 +58,8 @@ test_basic_standby_queries() {
 
     # Verify search works on primary
     local primary_count
-    primary_count=$(search_count "${PRIMARY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    primary_count=$(search_count "${PRIMARY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
     log "Primary search for 'algorithms': ${primary_count} results"
     if [ -z "$primary_count" ] || [ "$primary_count" -lt 1 ]; then
         error "Primary search returned no results!"
@@ -244,8 +85,8 @@ test_basic_standby_queries() {
     echo "$standby_result"
 
     local standby_count
-    standby_count=$(search_count "${STANDBY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    standby_count=$(search_count "${STANDBY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
     log "Standby search for 'algorithms': ${standby_count} results"
 
     if [ -z "$standby_count" ] || [ "$standby_count" -lt 1 ]; then
@@ -278,8 +119,8 @@ test_ongoing_replication() {
 
     log "Searching on standby after new inserts..."
     local standby_count
-    standby_count=$(search_count "${STANDBY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    standby_count=$(search_count "${STANDBY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
     log "Standby search for 'algorithms' after inserts: \
 ${standby_count} results"
 
@@ -290,8 +131,8 @@ ${standby_count} results"
 
     # Verify counts match primary
     local primary_count
-    primary_count=$(search_count "${PRIMARY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    primary_count=$(search_count "${PRIMARY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
 
     if [ "$standby_count" != "$primary_count" ]; then
         error "Result count mismatch after inserts: \
@@ -314,13 +155,13 @@ test_segment_replication() {
 
     log "Searching on standby after segment spill..."
     local standby_count
-    standby_count=$(search_count "${STANDBY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    standby_count=$(search_count "${STANDBY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
     log "Standby search after spill: ${standby_count} results"
 
     local primary_count
-    primary_count=$(search_count "${PRIMARY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    primary_count=$(search_count "${PRIMARY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
 
     if [ "$standby_count" != "$primary_count" ]; then
         error "Result mismatch after spill: \
@@ -338,8 +179,8 @@ test_standby_promotion() {
 
     # Capture pre-promotion search state
     local pre_count
-    pre_count=$(search_count "${STANDBY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    pre_count=$(search_count "${STANDBY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
     log "Pre-promotion search count: ${pre_count}"
 
     log "Promoting standby to primary..."
@@ -369,8 +210,8 @@ test_standby_promotion() {
     # Test read queries on promoted standby
     log "Testing search on promoted standby..."
     local promoted_count
-    promoted_count=$(search_count "${STANDBY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    promoted_count=$(search_count "${STANDBY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
     log "Search results on promoted standby: ${promoted_count}"
 
     if [ -z "$promoted_count" ] || [ "$promoted_count" -lt 1 ]; then
@@ -385,8 +226,8 @@ test_standby_promotion() {
     " >/dev/null 2>&1
 
     local post_insert_count
-    post_insert_count=$(search_count "${STANDBY_PORT}" "algorithms" \
-        "docs_bm25_idx")
+    post_insert_count=$(search_count "${STANDBY_PORT}" docs content \
+        "algorithms" "docs_bm25_idx")
     log "Search after insert on promoted standby: \
 ${post_insert_count}"
 

--- a/test/scripts/replication.sh
+++ b/test/scripts/replication.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 #
-# Physical (streaming) replication test for pg_textsearch
+# replication.sh — physical (streaming) replication smoke test for
+# pg_textsearch. Sets up a primary + hot-standby pair via
+# pg_basebackup, exercises the index across the basic write/replay
+# cycle, and asserts the standby sees the same results as the
+# primary.
 #
 # Tests:
-#   1. Standby starts up with replicated bm25 index
-#   2. BM25 search queries work on hot standby
-#   3. Inserts on primary replicate and become searchable on standby
-#   4. Standby promotion preserves index functionality
+#   1. Standby starts up with replicated bm25 index (basebackup
+#      includes the index file).
+#   2. BM25 search queries work on the hot standby (read-side
+#      smoke test).
+#   3. Primary inserts replicate via WAL and a primary-side spill
+#      reaches the standby (exercises the #342 fix in this PR via
+#      the memtable-spill path).
+#   4. Standby can be promoted; index still works on the new
+#      primary.
+#   5. Long-lived standby backend sees primary inserts that arrive
+#      via WAL replay during the backend's lifetime. Currently
+#      FAILS — see #345 (per-backend cache not invalidated by WAL
+#      replay).
 #
 
 set -e

--- a/test/scripts/replication.sh
+++ b/test/scripts/replication.sh
@@ -294,8 +294,8 @@ test_long_lived_backend_staleness() {
     #      (long-lived backend has a stale view of segment storage).
     # Once fixed, LL_AFTER should be LL_BEFORE + 1 (the new doc is visible).
     if [[ "${LL_AFTER}" == *ERROR* ]] || \
-       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
-         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+       ! [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] || \
+       [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; then
         error "BUG (expected): long-lived standby backend did not see \
 new primary insert (before=${LL_BEFORE}, after=${LL_AFTER})"
     fi

--- a/test/scripts/replication.sh
+++ b/test/scripts/replication.sh
@@ -239,6 +239,70 @@ ${post_insert_count}"
     log "Test 4 PASSED: Standby promotion works"
 }
 
+# ---------------------------------------------------------------
+# Test 5: Long-lived standby backend sees new primary inserts
+#
+# This test exposes the memtable-staleness bug: a backend that
+# stays alive across primary inserts rebuilds its memtable once
+# (on first scan) and then never updates it because WAL replay
+# does not call into our aminsert path.
+# ---------------------------------------------------------------
+test_long_lived_backend_staleness() {
+    log "=== Test 5: Long-lived backend staleness ==="
+
+    primary_sql "
+        DROP TABLE IF EXISTS staleness_docs CASCADE;
+        CREATE TABLE staleness_docs (
+            id SERIAL PRIMARY KEY,
+            content TEXT NOT NULL
+        );
+        INSERT INTO staleness_docs (content) VALUES
+            ('initial document about quantum mechanics'),
+            ('initial document about general relativity');
+        CREATE INDEX staleness_idx ON staleness_docs USING bm25(content)
+            WITH (text_config='english');
+    " >/dev/null
+
+    wait_for_standby_catchup
+
+    local query="
+        SELECT count(*) FROM (
+            SELECT id FROM staleness_docs
+            ORDER BY content <@> to_bm25query('quantum',
+                'staleness_idx')
+            LIMIT 100
+        ) t;
+    "
+
+    long_lived_before_after "${STANDBY_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO staleness_docs (content) VALUES
+                ('quantum entanglement and bell inequalities');
+        \" >/dev/null
+        wait_for_standby_catchup"
+
+    log "Initial standby count: ${LL_BEFORE}"
+    log "Standby count after primary insert: ${LL_AFTER}"
+
+    if [ "${LL_BEFORE}" != "2" ]; then
+        error "Expected initial count=2, got '${LL_BEFORE}'"
+    fi
+
+    # The bug manifests in two ways:
+    #   1. Silent staleness: LL_AFTER == LL_BEFORE (memtable not updated).
+    #   2. Segment-block invalidation: LL_AFTER contains 'ERROR'
+    #      (long-lived backend has a stale view of segment storage).
+    # Once fixed, LL_AFTER should be LL_BEFORE + 1 (the new doc is visible).
+    if [[ "${LL_AFTER}" == *ERROR* ]] || \
+       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
+         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+        error "BUG (expected): long-lived standby backend did not see \
+new primary insert (before=${LL_BEFORE}, after=${LL_AFTER})"
+    fi
+
+    log "Test 5 PASSED: Long-lived backend sees new primary inserts"
+}
+
 main() {
     log "Starting pg_textsearch physical replication test..."
 
@@ -252,6 +316,7 @@ main() {
     test_basic_standby_queries
     test_ongoing_replication
     test_segment_replication
+    test_long_lived_backend_staleness
     test_standby_promotion
 
     log "All physical replication tests passed!"

--- a/test/scripts/replication_cascading.sh
+++ b/test/scripts/replication_cascading.sh
@@ -81,8 +81,8 @@ test_cascading_long_lived_staleness() {
 
     log "  before=${LL_BEFORE}, after=${LL_AFTER}"
     if [[ "${LL_AFTER}" == *ERROR* ]] || \
-       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
-         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+       ! [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] || \
+       [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; then
         error "C2 BUG (expected): standby2 long-lived backend missed \
 primary insert (before=${LL_BEFORE}, after=${LL_AFTER})"
     fi
@@ -131,7 +131,8 @@ EOF
     if [[ "${count}" == *ERROR* ]] || \
        ! [[ "${count}" =~ ^[0-9]+$ ]] || \
        [ "${count}" -lt 2 ]; then
-        warn "C3: standby2 may not have caught up yet (got ${count})"
+        error "C3: standby2 not caught up after chain promotion \
+(got ${count}, expected >= 2)"
     fi
     log "C3 PASSED"
 }

--- a/test/scripts/replication_cascading.sh
+++ b/test/scripts/replication_cascading.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 #
 # replication_cascading.sh — three-node cascading replication.
-# primary -> standby1 -> standby2.
+# primary -> standby1 -> standby2 (standby2 is built via
+# pg_basebackup from standby1, not from the primary). Validates that
+# pg_textsearch behaves correctly when WAL flows through an
+# intermediate hop.
+#
+# Tests:
+#   C1: standby2 sees primary's data via standby1 — basic two-hop
+#       read.
+#   C2: Long-lived standby2 backend should see primary inserts that
+#       arrive over the two-hop WAL chain. Currently FAILS — the
+#       #345 staleness bug propagates two hops just like one.
+#   C3: Promotion chain — promote standby1 to primary; standby2
+#       (configured with recovery_target_timeline = latest) follows
+#       the new timeline and remains queryable.
 
 set -e
 

--- a/test/scripts/replication_cascading.sh
+++ b/test/scripts/replication_cascading.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+#
+# replication_cascading.sh — three-node cascading replication.
+# primary -> standby1 -> standby2.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55448
+STANDBY_PORT=55449
+STANDBY2_PORT=55450
+TEST_DB=replication_cascading
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_casc_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_casc_standby"
+STANDBY2_DIR="${SCRIPT_DIR}/../tmp_repl_casc_standby2"
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+# -------------------------------------------------------------------
+# C1: Cascading basic query.
+# standby2 sees primary's data via standby1.
+# Expected: PASS today.
+# -------------------------------------------------------------------
+test_cascading_basic_query() {
+    log "=== C1: cascading basic query ==="
+    primary_sql "
+        DROP TABLE IF EXISTS c1_docs CASCADE;
+        CREATE TABLE c1_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO c1_docs (content)
+            SELECT 'cascade doc ' || i || ' alpha'
+            FROM generate_series(1,30) i;
+        CREATE INDEX c1_idx ON c1_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_node_catchup "${STANDBY_PORT}"
+    wait_for_node_catchup "${STANDBY2_PORT}"
+
+    local count
+    count=$(search_count "${STANDBY2_PORT}" c1_docs content "alpha" \
+        "c1_idx")
+    log "  standby2 count: ${count} (expect 30)"
+    if [ "${count}" != "30" ]; then
+        error "C1: standby2 missing data (got ${count})"
+    fi
+    log "C1 PASSED"
+}
+
+# -------------------------------------------------------------------
+# C2: Cascading long-lived staleness.
+# Long-lived backend on standby2 should see new primary inserts.
+# Expected: FAIL today (the bug propagates two hops).
+# -------------------------------------------------------------------
+test_cascading_long_lived_staleness() {
+    log "=== C2: cascading long-lived staleness (should FAIL) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS c2_docs CASCADE;
+        CREATE TABLE c2_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO c2_docs (content) VALUES
+            ('initial cascade alpha');
+        CREATE INDEX c2_idx ON c2_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_node_catchup "${STANDBY_PORT}"
+    wait_for_node_catchup "${STANDBY2_PORT}"
+
+    local query="
+        SELECT count(*) FROM (SELECT id FROM c2_docs
+            ORDER BY content <@> to_bm25query('alpha','c2_idx')
+            LIMIT 100) t;
+    "
+    long_lived_before_after "${STANDBY2_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO c2_docs (content) VALUES
+                ('new cascade alpha bravo');
+        \" >/dev/null
+        wait_for_node_catchup \"${STANDBY_PORT}\"
+        wait_for_node_catchup \"${STANDBY2_PORT}\""
+
+    log "  before=${LL_BEFORE}, after=${LL_AFTER}"
+    if [[ "${LL_AFTER}" == *ERROR* ]] || \
+       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
+         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+        error "C2 BUG (expected): standby2 long-lived backend missed \
+primary insert (before=${LL_BEFORE}, after=${LL_AFTER})"
+    fi
+    log "C2 PASSED"
+}
+
+# -------------------------------------------------------------------
+# C3: Cascading promotion chain.
+# Promote standby1 to primary; standby2 follows the new timeline.
+# Expected: PASS today (Postgres handles the timeline; bm25 just
+# rides on top).
+# -------------------------------------------------------------------
+test_cascading_promotion_chain() {
+    log "=== C3: cascading promotion chain ==="
+    # standby2 needs recovery_target_timeline=latest so it picks up
+    # the new timeline after standby1's promotion.
+    cat >> "${STANDBY2_DIR}/postgresql.conf" <<EOF
+recovery_target_timeline = 'latest'
+EOF
+    pg_ctl restart -D "${STANDBY2_DIR}" -m fast -w
+
+    pg_ctl promote -D "${STANDBY_DIR}" -w
+    local i=0
+    while [ $i -lt 15 ]; do
+        local in_recovery
+        in_recovery=$(node_sql_quiet "${STANDBY_PORT}" \
+            "SELECT pg_is_in_recovery();")
+        if [ "$in_recovery" = "f" ]; then break; fi
+        sleep 1; i=$((i + 1))
+    done
+
+    # standby2 should now be replicating from the new primary (was
+    # standby1). Sleep a bit, then write to new primary and check
+    # standby2 sees it.
+    sleep 3
+    psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -c "
+        INSERT INTO c2_docs (content) VALUES
+            ('post-promotion cascade alpha');
+    " >/dev/null
+    sleep 3
+
+    local count
+    count=$(search_count "${STANDBY2_PORT}" c2_docs content "alpha" \
+        "c2_idx")
+    log "  standby2 count after chain promotion: ${count}"
+    if [[ "${count}" == *ERROR* ]] || \
+       ! [[ "${count}" =~ ^[0-9]+$ ]] || \
+       [ "${count}" -lt 2 ]; then
+        warn "C3: standby2 may not have caught up yet (got ${count})"
+    fi
+    log "C3 PASSED"
+}
+
+main() {
+    log "Starting pg_textsearch cascading replication tests..."
+    check_required_tools
+    setup_primary
+    setup_standby
+    setup_standby2
+
+    test_cascading_basic_query
+    test_cascading_long_lived_staleness
+    test_cascading_promotion_chain
+
+    log "All cascading replication tests completed!"
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/test/scripts/replication_compat.sh
+++ b/test/scripts/replication_compat.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+#
+# replication_compat.sh — compatibility tests:
+#   F1: physical + logical replication coexistence
+#   F2: TimescaleDB hypertable replication
+#   F3: pg_basebackup with bm25 index files
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55446
+STANDBY_PORT=55447
+LOGICAL_SUB_PORT=55448
+TEST_DB=replication_compat
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_compat_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_compat_standby"
+LOGICAL_SUB_DIR="${SCRIPT_DIR}/../tmp_repl_compat_subscriber"
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+# Custom cleanup that also handles the logical-subscriber instance.
+compat_cleanup() {
+    if [ -n "${LOGICAL_SUB_DIR:-}" ] && \
+       [ -f "${LOGICAL_SUB_DIR}/postmaster.pid" ]; then
+        pg_ctl stop -D "${LOGICAL_SUB_DIR}" -m fast 2>/dev/null \
+            || true
+    fi
+    rm -rf "${LOGICAL_SUB_DIR:-}"
+    repl_cleanup
+}
+trap compat_cleanup EXIT INT TERM
+
+# Bring up a third standalone instance to act as a logical
+# subscriber.
+setup_logical_subscriber() {
+    log "Setting up logical subscriber on port ${LOGICAL_SUB_PORT}..."
+    rm -rf "${LOGICAL_SUB_DIR}"
+    mkdir -p "${LOGICAL_SUB_DIR}"
+    initdb -D "${LOGICAL_SUB_DIR}" --auth-local=trust \
+        --auth-host=trust >/dev/null 2>&1
+    cat >> "${LOGICAL_SUB_DIR}/postgresql.conf" <<EOF
+port = ${LOGICAL_SUB_PORT}
+shared_preload_libraries = 'pg_textsearch'
+wal_level = logical
+log_min_messages = notice
+logging_collector = on
+log_filename = 'postgres.log'
+EOF
+    pg_ctl start -D "${LOGICAL_SUB_DIR}" \
+        -l "${LOGICAL_SUB_DIR}/postgres.log" -w
+    createdb -p "${LOGICAL_SUB_PORT}" "${TEST_DB}"
+    psql -p "${LOGICAL_SUB_PORT}" -d "${TEST_DB}" -c "
+        CREATE EXTENSION pg_textsearch;
+    " >/dev/null
+}
+
+# -------------------------------------------------------------------
+# F1: physical + logical replication coexistence.
+# Primary publishes a logical pub for one table, has a physical
+# standby, AND has a logical subscriber on a third instance.
+# All three views agree.
+# Expected: PASS today.
+# -------------------------------------------------------------------
+test_logical_and_physical_coexist() {
+    log "=== F1: logical + physical coexistence ==="
+
+    # Need wal_level=logical on primary.
+    psql -p "${PRIMARY_PORT}" -d postgres -c "
+        ALTER SYSTEM SET wal_level = logical;
+    " >/dev/null
+    pg_ctl restart -D "${PRIMARY_DIR}" -m fast -w
+    # Recreate standby with logical-level WAL.
+    pg_ctl stop -D "${STANDBY_DIR}" -m fast 2>/dev/null || true
+    rm -rf "${STANDBY_DIR}"
+
+    primary_sql "
+        DROP TABLE IF EXISTS f1_docs CASCADE;
+        CREATE TABLE f1_docs (id INT PRIMARY KEY, content TEXT);
+        INSERT INTO f1_docs VALUES
+            (1, 'initial alpha bravo'),
+            (2, 'second alpha charlie');
+        CREATE INDEX f1_idx ON f1_docs USING bm25(content)
+            WITH (text_config='simple');
+        CREATE PUBLICATION f1_pub FOR TABLE f1_docs;
+    " >/dev/null
+
+    setup_standby
+    setup_logical_subscriber
+
+    psql -p "${LOGICAL_SUB_PORT}" -d "${TEST_DB}" -c "
+        CREATE TABLE f1_docs (id INT PRIMARY KEY, content TEXT);
+    " >/dev/null
+    # CREATE SUBSCRIPTION with create_slot=true (the default) cannot
+    # run inside a transaction block, so issue it on its own.
+    psql -p "${LOGICAL_SUB_PORT}" -d "${TEST_DB}" -c \
+        "CREATE SUBSCRIPTION f1_sub CONNECTION 'host=127.0.0.1 port=${PRIMARY_PORT} dbname=${TEST_DB}' PUBLICATION f1_pub;" \
+        >/dev/null
+    sleep 3  # initial sync
+
+    # Insert on primary.
+    primary_sql "
+        INSERT INTO f1_docs VALUES (3, 'third alpha delta');
+    " >/dev/null
+    wait_for_standby_catchup
+    sleep 2  # let logical replication catch up
+
+    # Subscriber: build the bm25 index now (logical only replicates
+    # the heap).
+    psql -p "${LOGICAL_SUB_PORT}" -d "${TEST_DB}" -c "
+        CREATE INDEX IF NOT EXISTS f1_sub_idx ON f1_docs
+            USING bm25(content) WITH (text_config='simple');
+    " >/dev/null
+
+    local primary_count standby_count subscriber_count
+    primary_count=$(search_count "${PRIMARY_PORT}" f1_docs content \
+        "alpha" "f1_idx")
+    standby_count=$(search_count "${STANDBY_PORT}" f1_docs content \
+        "alpha" "f1_idx")
+    subscriber_count=$(search_count "${LOGICAL_SUB_PORT}" f1_docs \
+        content "alpha" "f1_sub_idx")
+
+    log "  primary=${primary_count} standby=${standby_count} \
+subscriber=${subscriber_count}"
+
+    if [ "${primary_count}" != "3" ] || \
+       [ "${standby_count}" != "3" ] || \
+       [ "${subscriber_count}" != "3" ]; then
+        error "F1: counts disagree across nodes"
+    fi
+    log "F1 PASSED"
+}
+
+# -------------------------------------------------------------------
+# F2: TimescaleDB hypertable replication.
+# Hypertable on primary has a bm25 index. Long-lived standby backend
+# should see new inserts to recent chunks.
+# Expected: FAIL today when actually run (memtable staleness on
+# hypertable inserts).
+# Skipped if TimescaleDB is not available OR not loaded via
+# shared_preload_libraries. Today the test is typically SKIPPED on
+# pg18-release because setup_primary in replication_lib.sh sets
+# SPL='pg_textsearch' only.
+# -------------------------------------------------------------------
+test_timescaledb_hypertable_replication_long_lived() {
+    log "=== F2: TimescaleDB hypertable (should FAIL today) ==="
+
+    local has_ts
+    has_ts=$(psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c "
+        SELECT count(*) FROM pg_available_extensions
+        WHERE name='timescaledb';" 2>/dev/null)
+    if [ "${has_ts}" != "1" ]; then
+        warn "F2: TimescaleDB not available, skipping"
+        return 0
+    fi
+
+    # Try to actually load it. Fails if timescaledb is not in
+    # shared_preload_libraries on the primary.
+    if ! psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" \
+         -c "CREATE EXTENSION IF NOT EXISTS timescaledb;" \
+         >/dev/null 2>&1; then
+        warn "F2: TimescaleDB present but not in \
+shared_preload_libraries — skipping. To actually exercise this \
+test, add timescaledb to shared_preload_libraries in setup_primary \
+(replication_lib.sh)."
+        return 0
+    fi
+
+    primary_sql "
+        DROP TABLE IF EXISTS f2_events CASCADE;
+        CREATE TABLE f2_events (
+            ts TIMESTAMPTZ NOT NULL,
+            content TEXT
+        );
+        SELECT create_hypertable('f2_events', 'ts',
+            chunk_time_interval => INTERVAL '1 day');
+        INSERT INTO f2_events VALUES
+            (now() - INTERVAL '12 hours', 'old event alpha'),
+            (now() - INTERVAL '1 hour',   'recent event alpha');
+        CREATE INDEX f2_idx ON f2_events USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local query="
+        SELECT count(*) FROM (SELECT ts FROM f2_events
+            ORDER BY content <@> to_bm25query('alpha','f2_idx')
+            LIMIT 100) t;
+    "
+    long_lived_before_after "${STANDBY_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO f2_events VALUES
+                (now(), 'brand new event alpha bravo');
+        \" >/dev/null
+        wait_for_standby_catchup"
+
+    log "  before=${LL_BEFORE}, after=${LL_AFTER}"
+    if [[ "${LL_AFTER}" == *ERROR* ]] || \
+       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
+         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+        error "F2 BUG (expected): hypertable standby long-lived \
+backend missed primary insert (before=${LL_BEFORE}, after=${LL_AFTER})"
+    fi
+    log "F2 PASSED"
+}
+
+# -------------------------------------------------------------------
+# F3: pg_basebackup with bm25 index files.
+# Standby was already created via pg_basebackup. Verify the bm25
+# index file made it into the backup and is queryable on the
+# standby. (This is a sanity check that segment files are not
+# excluded from basebackup.)
+# Expected: PASS today.
+# -------------------------------------------------------------------
+test_pg_basebackup_with_bm25_index() {
+    log "=== F3: pg_basebackup includes bm25 index files ==="
+
+    # Use the F1 table+index that's already on primary+standby.
+    # Spill primary so segment files exist on disk.
+    primary_sql "SELECT bm25_spill_index('f1_idx');" >/dev/null
+    wait_for_standby_catchup
+
+    # Wipe standby and rebuild from basebackup.
+    pg_ctl stop -D "${STANDBY_DIR}" -m fast 2>/dev/null || true
+    rm -rf "${STANDBY_DIR}"
+    setup_standby
+    wait_for_standby_catchup
+
+    local count
+    count=$(search_count "${STANDBY_PORT}" f1_docs content "alpha" \
+        "f1_idx")
+    log "  re-basebackuped standby count: ${count}"
+    if [ "${count}" != "3" ]; then
+        error "F3: re-basebackuped standby missing data (got ${count})"
+    fi
+    log "F3 PASSED"
+}
+
+main() {
+    log "Starting pg_textsearch replication compat tests..."
+    check_required_tools
+    setup_primary
+    setup_standby
+    test_logical_and_physical_coexist
+    test_timescaledb_hypertable_replication_long_lived
+    test_pg_basebackup_with_bm25_index
+
+    log "All replication compat tests completed!"
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/test/scripts/replication_compat.sh
+++ b/test/scripts/replication_compat.sh
@@ -20,13 +20,19 @@ LOGICAL_SUB_DIR="${SCRIPT_DIR}/../tmp_repl_compat_subscriber"
 source "${SCRIPT_DIR}/replication_lib.sh"
 
 # Custom cleanup that also handles the logical-subscriber instance.
+# Capture $? on entry: the wrapper runs commands before delegating
+# to repl_cleanup, which destroys the original exit code. Restore it
+# (via a subshell `exit`) so repl_cleanup's `local exit_code=$?`
+# captures the script's real exit status, not `rm -rf`'s.
 compat_cleanup() {
+    local rc=$?
     if [ -n "${LOGICAL_SUB_DIR:-}" ] && \
        [ -f "${LOGICAL_SUB_DIR}/postmaster.pid" ]; then
         pg_ctl stop -D "${LOGICAL_SUB_DIR}" -m fast 2>/dev/null \
             || true
     fi
     rm -rf "${LOGICAL_SUB_DIR:-}"
+    (exit "$rc")
     repl_cleanup
 }
 trap compat_cleanup EXIT INT TERM
@@ -196,8 +202,8 @@ test, add timescaledb to shared_preload_libraries in setup_primary \
 
     log "  before=${LL_BEFORE}, after=${LL_AFTER}"
     if [[ "${LL_AFTER}" == *ERROR* ]] || \
-       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
-         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+       ! [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] || \
+       [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; then
         error "F2 BUG (expected): hypertable standby long-lived \
 backend missed primary insert (before=${LL_BEFORE}, after=${LL_AFTER})"
     fi

--- a/test/scripts/replication_concurrency.sh
+++ b/test/scripts/replication_concurrency.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+#
+# replication_concurrency.sh — concurrency tests for physical
+# replication. Multiple standby readers under primary write load.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55442
+STANDBY_PORT=55443
+TEST_DB=replication_concurrency
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_conc_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_conc_standby"
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+# -------------------------------------------------------------------
+# B1: N concurrent long-lived backends on standby.
+# Eight long-lived backends each query before+after a primary
+# insert. All should see the new row.
+# Expected: FAIL today (every long-lived backend goes stale).
+# -------------------------------------------------------------------
+test_concurrent_standby_readers() {
+    log "=== B1: 8 concurrent long-lived standby readers ==="
+
+    primary_sql "
+        DROP TABLE IF EXISTS b1_docs CASCADE;
+        CREATE TABLE b1_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO b1_docs (content) VALUES
+            ('initial doc alpha bravo');
+        CREATE INDEX b1_idx ON b1_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    # Spawn 8 reader subprocesses. Each opens its own long-lived
+    # session, takes a 'before' reading, waits for a sync file,
+    # takes an 'after' reading, and writes both to a result file.
+    local sync_file
+    sync_file=$(mktemp)
+    rm "${sync_file}"  # parent recreates after primary insert
+    local results_dir
+    results_dir=$(mktemp -d)
+
+    local pids=()
+    for i in $(seq 1 8); do
+        (
+            # shellcheck source=replication_lib.sh
+            source "${SCRIPT_DIR}/replication_lib.sh"
+            long_lived_open "${STANDBY_PORT}"
+            local before
+            before=$(long_lived_query "
+                SELECT count(*) FROM (SELECT id FROM b1_docs
+                    ORDER BY content <@> to_bm25query('alpha', 'b1_idx')
+                    LIMIT 100) t;")
+            # Wait until parent flips sync file.
+            while [ ! -f "${sync_file}" ]; do sleep 0.1; done
+            local after
+            after=$(long_lived_query "
+                SELECT count(*) FROM (SELECT id FROM b1_docs
+                    ORDER BY content <@> to_bm25query('alpha', 'b1_idx')
+                    LIMIT 100) t;")
+            long_lived_close
+            echo "${before} ${after}" > "${results_dir}/r_${i}"
+        ) &
+        pids+=($!)
+    done
+
+    # Give readers time to take 'before' readings.
+    sleep 2
+
+    # Insert on primary, wait for replication, signal readers.
+    primary_sql "
+        INSERT INTO b1_docs (content) VALUES
+            ('newly added alpha bravo charlie');
+    " >/dev/null
+    wait_for_standby_catchup
+    touch "${sync_file}"
+
+    for p in "${pids[@]}"; do wait "$p"; done
+
+    local fail_count=0
+    for i in $(seq 1 8); do
+        local before after
+        read -r before after < "${results_dir}/r_${i}"
+        log "  reader ${i}: before=${before}, after=${after}"
+        if [[ "${after}" == *ERROR* ]] || \
+           { [[ "${after}" =~ ^[0-9]+$ ]] && \
+             [ "${after}" -le "${before}" ]; }; then
+            fail_count=$((fail_count + 1))
+        fi
+    done
+
+    rm -rf "${results_dir}" "${sync_file}"
+
+    if [ "${fail_count}" -gt 0 ]; then
+        error "B1 BUG (expected): ${fail_count}/8 standby readers \
+missed the new primary insert"
+    fi
+    log "B1 PASSED"
+}
+
+# -------------------------------------------------------------------
+# B2: Drain under insert burst.
+# Primary inserts 5000 docs; 4 standby long-lived readers
+# repeatedly query during and after. All should converge to seeing
+# all 5000.
+# Expected: FAIL today.
+# -------------------------------------------------------------------
+test_drain_under_insert_burst() {
+    log "=== B2: drain under insert burst ==="
+
+    primary_sql "
+        DROP TABLE IF EXISTS b2_docs CASCADE;
+        CREATE TABLE b2_docs (id SERIAL PRIMARY KEY, content TEXT);
+        CREATE INDEX b2_idx ON b2_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local results_dir
+    results_dir=$(mktemp -d)
+    local stop_file
+    stop_file=$(mktemp); rm "${stop_file}"
+
+    local pids=()
+    for i in 1 2 3 4; do
+        (
+            # shellcheck source=replication_lib.sh
+            source "${SCRIPT_DIR}/replication_lib.sh"
+            long_lived_open "${STANDBY_PORT}"
+            local last=0
+            while [ ! -f "${stop_file}" ]; do
+                last=$(long_lived_query "
+                    SELECT count(*) FROM (SELECT id FROM b2_docs
+                        ORDER BY content <@> to_bm25query('burst','b2_idx')
+                        LIMIT 10000) t;")
+                sleep 0.2
+            done
+            # Final reading after stop signal.
+            local final
+            final=$(long_lived_query "
+                SELECT count(*) FROM (SELECT id FROM b2_docs
+                    ORDER BY content <@> to_bm25query('burst','b2_idx')
+                    LIMIT 10000) t;")
+            long_lived_close
+            echo "${last} ${final}" > "${results_dir}/r_${i}"
+        ) &
+        pids+=($!)
+    done
+
+    # Insert burst on primary in batches.
+    for batch in $(seq 1 50); do
+        primary_sql "
+            INSERT INTO b2_docs (content)
+                SELECT 'burst batch ${batch} doc ' || j
+                FROM generate_series(1, 100) j;
+        " >/dev/null
+    done
+    wait_for_standby_catchup
+    sleep 1
+    touch "${stop_file}"
+
+    for p in "${pids[@]}"; do wait "$p"; done
+
+    local fail_count=0
+    for i in 1 2 3 4; do
+        local last final
+        read -r last final < "${results_dir}/r_${i}"
+        log "  reader ${i}: last_during=${last}, final_after=${final}"
+        if [[ "${final}" == *ERROR* ]] || \
+           ! [[ "${final}" =~ ^[0-9]+$ ]] || \
+           [ "${final}" -lt "5000" ]; then
+            fail_count=$((fail_count + 1))
+        fi
+    done
+    rm -rf "${results_dir}" "${stop_file}"
+
+    if [ "${fail_count}" -gt 0 ]; then
+        error "B2 BUG (expected): ${fail_count}/4 standby readers \
+did not converge to 5000 after burst"
+    fi
+    log "B2 PASSED"
+}
+
+# -------------------------------------------------------------------
+# B3: No deadlock under spam load.
+# Primary spam-inserts and spam-spills; many standby readers
+# repeatedly query. No process crashes, no deadlocks, no error
+# messages in standby log.
+# Expected: PASS today (passes vacuously — there's no drain code
+# to deadlock yet). After implementation, this guards the LWLock.
+# -------------------------------------------------------------------
+test_no_deadlock_under_spam_load() {
+    log "=== B3: no deadlock under spam load ==="
+
+    primary_sql "
+        DROP TABLE IF EXISTS b3_docs CASCADE;
+        CREATE TABLE b3_docs (id SERIAL PRIMARY KEY, content TEXT);
+        CREATE INDEX b3_idx ON b3_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local stop_file
+    stop_file=$(mktemp); rm "${stop_file}"
+
+    # 4 standby readers
+    local rd_pids=()
+    for i in 1 2 3 4; do
+        (
+            while [ ! -f "${stop_file}" ]; do
+                psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -tA -c "
+                    SELECT count(*) FROM (SELECT id FROM b3_docs
+                        ORDER BY content <@>
+                            to_bm25query('spam','b3_idx')
+                        LIMIT 1000) t;
+                " >/dev/null 2>&1 || true
+            done
+        ) &
+        rd_pids+=($!)
+    done
+
+    # Primary writer: insert + occasional spill.
+    for batch in $(seq 1 30); do
+        primary_sql "
+            INSERT INTO b3_docs (content)
+                SELECT 'spam batch ${batch} doc ' || j
+                FROM generate_series(1, 200) j;
+        " >/dev/null
+        if [ $((batch % 5)) -eq 0 ]; then
+            primary_sql "SELECT bm25_spill_index('b3_idx');" >/dev/null
+        fi
+    done
+
+    wait_for_standby_catchup
+    sleep 2
+    touch "${stop_file}"
+    for p in "${rd_pids[@]}"; do wait "$p" 2>/dev/null; done
+    rm -f "${stop_file}"
+
+    # Verify standby is still alive and logs clean of fatal errors.
+    local alive
+    alive=$(node_sql_quiet "${STANDBY_PORT}" "SELECT 1;")
+    if [ "${alive}" != "1" ]; then
+        error "B3: standby is dead after spam load"
+    fi
+
+    if grep -E 'PANIC|FATAL|deadlock' \
+       "${STANDBY_DIR}/log/postgres.log" >/dev/null 2>&1; then
+        error "B3: standby log shows PANIC/FATAL/deadlock entries"
+    fi
+
+    log "B3 PASSED"
+}
+
+main() {
+    log "Starting pg_textsearch replication concurrency tests..."
+    check_required_tools
+    setup_primary
+    setup_standby
+
+    test_concurrent_standby_readers
+    test_drain_under_insert_burst
+    test_no_deadlock_under_spam_load
+
+    log "All replication concurrency tests completed!"
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/test/scripts/replication_concurrency.sh
+++ b/test/scripts/replication_concurrency.sh
@@ -88,8 +88,8 @@ test_concurrent_standby_readers() {
         read -r before after < "${results_dir}/r_${i}"
         log "  reader ${i}: before=${before}, after=${after}"
         if [[ "${after}" == *ERROR* ]] || \
-           { [[ "${after}" =~ ^[0-9]+$ ]] && \
-             [ "${after}" -le "${before}" ]; }; then
+           ! [[ "${after}" =~ ^[0-9]+$ ]] || \
+           [ "${after}" -le "${before}" ]; then
             fail_count=$((fail_count + 1))
         fi
     done

--- a/test/scripts/replication_concurrency.sh
+++ b/test/scripts/replication_concurrency.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
 #
 # replication_concurrency.sh — concurrency tests for physical
-# replication. Multiple standby readers under primary write load.
+# replication. Each test holds N persistent psql sessions open
+# against the standby (long-lived backends), drives a write
+# workload on the primary, and asserts that all standby sessions
+# converge on the right answer.
+#
+# Tests:
+#   B1: 8 concurrent long-lived standby readers each take a
+#       before/after reading around a single primary insert.
+#       Currently FAILS — exposes #345 in the multi-reader case.
+#   B2: 4 long-lived standby readers query repeatedly during and
+#       after a 5000-doc primary insert burst. All should converge
+#       on 5000. Currently FAILS — same root cause as B1.
+#   B3: Many standby readers under a primary spam-insert + spam-
+#       spill workload. Validates no crashes, no deadlocks, no
+#       errors in the standby log. PASSES today (vacuously — the
+#       drain code that this would guard doesn't exist yet).
 
 set -e
 

--- a/test/scripts/replication_correctness.sh
+++ b/test/scripts/replication_correctness.sh
@@ -352,8 +352,8 @@ test_long_lived_partitioned_table() {
 
     log "before=${LL_BEFORE}, after=${LL_AFTER}"
     if [[ "${LL_AFTER}" == *ERROR* ]] || \
-       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
-         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+       ! [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] || \
+       [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; then
         error "E1 BUG (expected): standby long-lived backend missed \
 partition insert (before=${LL_BEFORE}, after=${LL_AFTER})"
     fi
@@ -393,8 +393,8 @@ test_long_lived_expression_index() {
 
     log "before=${LL_BEFORE} (expect 1), after=${LL_AFTER} (expect 2)"
     if [[ "${LL_AFTER}" == *ERROR* ]] || \
-       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
-         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+       ! [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] || \
+       [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; then
         error "E2 BUG (expected): expression-index standby long-lived \
 backend missed insert (before=${LL_BEFORE}, after=${LL_AFTER})"
     fi
@@ -437,8 +437,8 @@ test_long_lived_partial_index() {
 
     log "before=${LL_BEFORE} (expect 1), after=${LL_AFTER} (expect 2)"
     if [[ "${LL_AFTER}" == *ERROR* ]] || \
-       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
-         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+       ! [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] || \
+       [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; then
         error "E3 BUG (expected): partial-index standby long-lived \
 backend missed insert (before=${LL_BEFORE}, after=${LL_AFTER})"
     fi
@@ -477,8 +477,8 @@ test_long_lived_text_array() {
 
     log "before=${LL_BEFORE} (expect 1), after=${LL_AFTER} (expect 2)"
     if [[ "${LL_AFTER}" == *ERROR* ]] || \
-       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
-         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+       ! [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] || \
+       [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; then
         error "E4 BUG (expected): text[]-index standby long-lived \
 backend missed insert (before=${LL_BEFORE}, after=${LL_AFTER})"
     fi
@@ -540,10 +540,10 @@ test_long_lived_multiple_indexes_same_table() {
     log "body:  before=${body_before}, after=${body_after}"
     if [[ "${title_after}" == *ERROR* ]] || \
        [[ "${body_after}" == *ERROR* ]] || \
-       { [[ "${title_after}" =~ ^[0-9]+$ ]] && \
-         [[ "${body_after}" =~ ^[0-9]+$ ]] && \
-         { [ "${title_after}" -le "${title_before}" ] || \
-           [ "${body_after}" -le "${body_before}" ]; }; }; then
+       ! [[ "${title_after}" =~ ^[0-9]+$ ]] || \
+       ! [[ "${body_after}" =~ ^[0-9]+$ ]] || \
+       [ "${title_after}" -le "${title_before}" ] || \
+       [ "${body_after}" -le "${body_before}" ]; then
         error "E5 BUG (expected): standby long-lived backend missed \
 inserts on one or both indexes (title=${title_after}, body=${body_after})"
     fi

--- a/test/scripts/replication_correctness.sh
+++ b/test/scripts/replication_correctness.sh
@@ -1,0 +1,575 @@
+#!/bin/bash
+#
+# replication_correctness.sh — physical replication correctness
+# tests focusing on long-lived standby backends across schema
+# variations and primary write events (insert/update/delete/spill/
+# merge).
+#
+# Most tests in this file FAIL on current (un-fixed) code. Two bugs
+# are documented:
+#   1. Memtable staleness: long-lived standby backends miss new
+#      primary inserts because aminsert is never called on standby.
+#   2. WAL-replayed segments unreadable: long-lived standby backends
+#      error on segment reads when the segments were created via
+#      WAL replay (rather than included in the initial basebackup).
+#
+# A1 PASSES today — it reads segments that existed before basebackup.
+# All other tests FAIL today and document one of the two bug classes.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55440
+STANDBY_PORT=55441
+TEST_DB=replication_correctness
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_corr_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_corr_standby"
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+# -------------------------------------------------------------------
+# Test A1: Long-lived read after primary spill.
+# After the primary spills its memtable, the long-lived standby
+# backend re-queries and sees the spilled (now-segment) data.
+# Expected: PASS today (segments replicate via GenericXLog).
+# -------------------------------------------------------------------
+test_long_lived_read_after_primary_spill() {
+    log "=== A1: read after primary spill ==="
+    primary_sql "
+        DROP TABLE IF EXISTS a1_docs CASCADE;
+        CREATE TABLE a1_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO a1_docs (content)
+            SELECT 'doc ' || i || ' alpha bravo charlie'
+            FROM generate_series(1,200) i;
+        CREATE INDEX a1_idx ON a1_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    setup_standby
+    wait_for_standby_catchup
+
+    long_lived_open "${STANDBY_PORT}"
+    local before
+    before=$(long_lived_query "
+        SELECT count(*) FROM (
+            SELECT id FROM a1_docs
+            ORDER BY content <@> to_bm25query('alpha', 'a1_idx')
+            LIMIT 1000
+        ) t;")
+    primary_sql "SELECT bm25_spill_index('a1_idx');" >/dev/null
+    wait_for_standby_catchup
+    local after
+    after=$(long_lived_query "
+        SELECT count(*) FROM (
+            SELECT id FROM a1_docs
+            ORDER BY content <@> to_bm25query('alpha', 'a1_idx')
+            LIMIT 1000
+        ) t;")
+    long_lived_close
+
+    log "before=${before} after=${after} (both should be 200)"
+    if [ "${before}" != "200" ] || [ "${after}" != "200" ]; then
+        error "A1: counts wrong (before=${before}, after=${after})"
+    fi
+    log "A1 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test A2: Long-lived read after segment merge.
+# Force enough segments on the primary that compaction triggers,
+# then query on standby.
+# Expected: FAIL today — distinct from the memtable bug. Segments
+# created on the primary via spill while the standby is already
+# running (WAL-replayed) are not readable by a long-lived standby
+# backend; queries error with "invalid page index at block N /
+# magic=0x00000000". Will pass once the rmgr-based replication
+# implementation lands.
+# -------------------------------------------------------------------
+test_long_lived_read_after_segment_merge() {
+    log "=== A2: read after segment merge ==="
+    primary_sql "
+        DROP TABLE IF EXISTS a2_docs CASCADE;
+        CREATE TABLE a2_docs (id SERIAL PRIMARY KEY, content TEXT);
+        CREATE INDEX a2_idx ON a2_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+
+    # Force several spills via repeated insert + spill.
+    for i in 1 2 3 4 5 6 7 8 9; do
+        primary_sql "
+            INSERT INTO a2_docs (content)
+                SELECT 'merge doc ' || j || ' alpha bravo'
+                FROM generate_series(1,100) j;
+            SELECT bm25_spill_index('a2_idx');
+        " >/dev/null
+    done
+    wait_for_standby_catchup
+
+    local total
+    total=$(primary_sql_quiet "SELECT count(*) FROM a2_docs;")
+
+    long_lived_open "${STANDBY_PORT}"
+    local before
+    before=$(long_lived_query "
+        SELECT count(*) FROM (
+            SELECT id FROM a2_docs
+            ORDER BY content <@> to_bm25query('alpha', 'a2_idx')
+            LIMIT 10000
+        ) t;")
+
+    # Trigger a merge by adding more segments. With default
+    # segments_per_level=8, we already have 9; further spills
+    # should compact.
+    primary_sql "
+        INSERT INTO a2_docs (content)
+            SELECT 'merge doc extra ' || j || ' alpha'
+            FROM generate_series(1,50) j;
+        SELECT bm25_spill_index('a2_idx');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local after
+    after=$(long_lived_query "
+        SELECT count(*) FROM (
+            SELECT id FROM a2_docs
+            ORDER BY content <@> to_bm25query('alpha', 'a2_idx')
+            LIMIT 10000
+        ) t;")
+    long_lived_close
+
+    local expected_after=$((total + 50))
+    log "before=${before}, after=${after}, expected_after=${expected_after}"
+
+    if [[ "${before}" == *ERROR* ]] || [[ "${after}" == *ERROR* ]] || \
+       [ "${before}" != "${total}" ] || \
+       [ "${after}" != "${expected_after}" ]; then
+        error "A2 BUG (expected): standby long-lived backend cannot read \
+WAL-replayed segments (before=${before}, after=${after}, \
+expected after=${expected_after})"
+    fi
+    log "A2 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test A3: Memtable+segment mix.
+# Primary has data both in a segment (post-spill) AND in the
+# memtable (post-spill inserts). Long-lived standby backend should
+# see ALL of it.
+# Expected: FAIL today — the segment portion replicates fine, but
+# the memtable portion is invisible to the long-lived backend.
+# -------------------------------------------------------------------
+test_long_lived_memtable_segment_mix() {
+    log "=== A3: memtable + segment mix (should FAIL today) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS a3_docs CASCADE;
+        CREATE TABLE a3_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO a3_docs (content)
+            SELECT 'spilled doc ' || i || ' alpha'
+            FROM generate_series(1,100) i;
+        CREATE INDEX a3_idx ON a3_docs USING bm25(content)
+            WITH (text_config='simple');
+        SELECT bm25_spill_index('a3_idx');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local query="
+        SELECT count(*) FROM (
+            SELECT id FROM a3_docs
+            ORDER BY content <@> to_bm25query('alpha', 'a3_idx')
+            LIMIT 1000
+        ) t;
+    "
+    long_lived_before_after "${STANDBY_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO a3_docs (content)
+                SELECT 'memtable doc ' || i || ' alpha'
+                FROM generate_series(1,50) i;
+        \" >/dev/null
+        wait_for_standby_catchup"
+
+    log "before=${LL_BEFORE} (expect 100), after=${LL_AFTER} (expect 150)"
+    if [ "${LL_BEFORE}" != "100" ]; then
+        error "A3: before count wrong (${LL_BEFORE})"
+    fi
+    if [ "${LL_AFTER}" != "150" ]; then
+        error "A3 BUG (expected): standby long-lived backend missed \
+memtable inserts (before=${LL_BEFORE}, after=${LL_AFTER}, expected=150)"
+    fi
+    log "A3 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test A4: UPDATE replication (HOT and non-HOT).
+# UPDATE on primary changes the indexed text. Long-lived standby
+# backend should see the new content searchable.
+# Expected: FAIL today.
+# -------------------------------------------------------------------
+test_long_lived_update_replication() {
+    log "=== A4: UPDATE replication (should FAIL today) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS a4_docs CASCADE;
+        CREATE TABLE a4_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO a4_docs (content)
+            SELECT 'original doc ' || i || ' xenon'
+            FROM generate_series(1,20) i;
+        CREATE INDEX a4_idx ON a4_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    long_lived_open "${STANDBY_PORT}"
+    local xenon_before zircon_before
+    xenon_before=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM a4_docs
+            ORDER BY content <@> to_bm25query('xenon', 'a4_idx')
+            LIMIT 100) t;")
+    zircon_before=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM a4_docs
+            ORDER BY content <@> to_bm25query('zircon', 'a4_idx')
+            LIMIT 100) t;")
+
+    primary_sql "
+        UPDATE a4_docs SET content = 'replaced doc ' || id || ' zircon'
+        WHERE id <= 10;
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local xenon_after zircon_after
+    xenon_after=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM a4_docs
+            ORDER BY content <@> to_bm25query('xenon', 'a4_idx')
+            LIMIT 100) t;")
+    zircon_after=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM a4_docs
+            ORDER BY content <@> to_bm25query('zircon', 'a4_idx')
+            LIMIT 100) t;")
+    long_lived_close
+
+    log "xenon: before=${xenon_before} (expect 20), after=${xenon_after} (expect 10)"
+    log "zircon: before=${zircon_before} (expect 0), after=${zircon_after} (expect 10)"
+
+    if [ "${xenon_after}" != "10" ] || [ "${zircon_after}" != "10" ]; then
+        error "A4 BUG (expected): standby long-lived backend missed \
+UPDATEs (xenon=${xenon_after}/expected 10, zircon=${zircon_after}/expected 10)"
+    fi
+    log "A4 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test A5: DELETE + VACUUM replication.
+# Deleted+vacuumed rows should not appear in standby search results.
+# Expected: FAIL today — same WAL-replayed-segment issue as A2.
+# Long-lived standby backend cannot read segments created by primary
+# spill+merge that arrived via WAL replay. Will pass once the rmgr-
+# based replication implementation lands.
+# -------------------------------------------------------------------
+test_long_lived_delete_vacuum() {
+    log "=== A5: DELETE + VACUUM ==="
+    primary_sql "
+        DROP TABLE IF EXISTS a5_docs CASCADE;
+        CREATE TABLE a5_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO a5_docs (content)
+            SELECT 'doc ' || i || ' alpha'
+            FROM generate_series(1,100) i;
+        CREATE INDEX a5_idx ON a5_docs USING bm25(content)
+            WITH (text_config='simple');
+        SELECT bm25_spill_index('a5_idx');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    long_lived_open "${STANDBY_PORT}"
+    local before
+    before=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM a5_docs
+            ORDER BY content <@> to_bm25query('alpha', 'a5_idx')
+            LIMIT 1000) t;")
+
+    primary_sql "DELETE FROM a5_docs WHERE id <= 30;" >/dev/null
+    primary_sql "VACUUM a5_docs;" >/dev/null
+    wait_for_standby_catchup
+
+    local after
+    after=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM a5_docs
+            ORDER BY content <@> to_bm25query('alpha', 'a5_idx')
+            LIMIT 1000) t;")
+    long_lived_close
+
+    log "before=${before} (expect 100), after=${after} (expect 70)"
+    if [[ "${before}" == *ERROR* ]] || [[ "${after}" == *ERROR* ]] || \
+       [ "${before}" != "100" ] || [ "${after}" != "70" ]; then
+        error "A5 BUG (expected): standby long-lived backend cannot read \
+WAL-replayed segments (before=${before}, after=${after}, \
+expected before=100 after=70)"
+    fi
+    log "A5 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test E1: Partitioned table replication.
+# Long-lived standby backend should see new inserts to a
+# partitioned table.
+# Expected: FAIL today.
+# -------------------------------------------------------------------
+test_long_lived_partitioned_table() {
+    log "=== E1: partitioned table (should FAIL today) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS e1_docs CASCADE;
+        CREATE TABLE e1_docs (
+            id INT,
+            tenant INT,
+            content TEXT
+        ) PARTITION BY RANGE (tenant);
+        CREATE TABLE e1_docs_t1 PARTITION OF e1_docs
+            FOR VALUES FROM (0) TO (10);
+        CREATE TABLE e1_docs_t2 PARTITION OF e1_docs
+            FOR VALUES FROM (10) TO (20);
+        INSERT INTO e1_docs (id, tenant, content)
+            SELECT i, i % 20, 'doc ' || i || ' alpha'
+            FROM generate_series(1,40) i;
+        CREATE INDEX e1_idx_t1 ON e1_docs_t1 USING bm25(content)
+            WITH (text_config='simple');
+        CREATE INDEX e1_idx_t2 ON e1_docs_t2 USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    # Query against one partition's index directly.
+    local query="
+        SELECT count(*) FROM (SELECT id FROM e1_docs_t1
+            ORDER BY content <@> to_bm25query('alpha', 'e1_idx_t1')
+            LIMIT 100) t;
+    "
+    long_lived_before_after "${STANDBY_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO e1_docs (id, tenant, content) VALUES
+                (101, 5, 'newdoc 101 alpha'),
+                (102, 7, 'newdoc 102 alpha');
+        \" >/dev/null
+        wait_for_standby_catchup"
+
+    log "before=${LL_BEFORE}, after=${LL_AFTER}"
+    if [[ "${LL_AFTER}" == *ERROR* ]] || \
+       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
+         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+        error "E1 BUG (expected): standby long-lived backend missed \
+partition insert (before=${LL_BEFORE}, after=${LL_AFTER})"
+    fi
+    log "E1 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test E2: Expression index.
+# Index on lower(content). Long-lived standby backend should see
+# new rows via the expression index.
+# Expected: FAIL today.
+# -------------------------------------------------------------------
+test_long_lived_expression_index() {
+    log "=== E2: expression index (should FAIL today) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS e2_docs CASCADE;
+        CREATE TABLE e2_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO e2_docs (content) VALUES
+            ('Initial Document ALPHA'),
+            ('Another Initial Doc BRAVO');
+        CREATE INDEX e2_idx ON e2_docs USING bm25(lower(content))
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local query="
+        SELECT count(*) FROM (SELECT id FROM e2_docs
+            ORDER BY lower(content) <@> to_bm25query('alpha', 'e2_idx')
+            LIMIT 100) t;
+    "
+    long_lived_before_after "${STANDBY_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO e2_docs (content) VALUES
+                ('Brand New Document ALPHA');
+        \" >/dev/null
+        wait_for_standby_catchup"
+
+    log "before=${LL_BEFORE} (expect 1), after=${LL_AFTER} (expect 2)"
+    if [[ "${LL_AFTER}" == *ERROR* ]] || \
+       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
+         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+        error "E2 BUG (expected): expression-index standby long-lived \
+backend missed insert (before=${LL_BEFORE}, after=${LL_AFTER})"
+    fi
+    log "E2 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test E3: Partial index.
+# Long-lived standby backend should see new rows that match the
+# WHERE predicate.
+# Expected: FAIL today.
+# -------------------------------------------------------------------
+test_long_lived_partial_index() {
+    log "=== E3: partial index (should FAIL today) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS e3_docs CASCADE;
+        CREATE TABLE e3_docs (id SERIAL PRIMARY KEY,
+                              content TEXT,
+                              published BOOL);
+        INSERT INTO e3_docs (content, published) VALUES
+            ('published initial alpha', true),
+            ('draft initial alpha', false);
+        CREATE INDEX e3_idx ON e3_docs USING bm25(content)
+            WITH (text_config='simple') WHERE published;
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local query="
+        SELECT count(*) FROM (SELECT id FROM e3_docs
+            WHERE published
+            ORDER BY content <@> to_bm25query('alpha', 'e3_idx')
+            LIMIT 100) t;
+    "
+    long_lived_before_after "${STANDBY_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO e3_docs (content, published) VALUES
+                ('newly published alpha', true);
+        \" >/dev/null
+        wait_for_standby_catchup"
+
+    log "before=${LL_BEFORE} (expect 1), after=${LL_AFTER} (expect 2)"
+    if [[ "${LL_AFTER}" == *ERROR* ]] || \
+       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
+         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+        error "E3 BUG (expected): partial-index standby long-lived \
+backend missed insert (before=${LL_BEFORE}, after=${LL_AFTER})"
+    fi
+    log "E3 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test E4: text[] (array) index.
+# Long-lived standby backend should see new array-column inserts.
+# Expected: FAIL today.
+# -------------------------------------------------------------------
+test_long_lived_text_array() {
+    log "=== E4: text[] index (should FAIL today) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS e4_docs CASCADE;
+        CREATE TABLE e4_docs (id SERIAL PRIMARY KEY,
+                              tags TEXT[]);
+        INSERT INTO e4_docs (tags) VALUES
+            (ARRAY['initial','alpha','bravo']);
+        CREATE INDEX e4_idx ON e4_docs USING bm25(tags)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local query="
+        SELECT count(*) FROM (SELECT id FROM e4_docs
+            ORDER BY tags <@> to_bm25query('alpha', 'e4_idx')
+            LIMIT 100) t;
+    "
+    long_lived_before_after "${STANDBY_PORT}" "${query}" \
+        "primary_sql \"
+            INSERT INTO e4_docs (tags) VALUES
+                (ARRAY['new','alpha','charlie']);
+        \" >/dev/null
+        wait_for_standby_catchup"
+
+    log "before=${LL_BEFORE} (expect 1), after=${LL_AFTER} (expect 2)"
+    if [[ "${LL_AFTER}" == *ERROR* ]] || \
+       { [[ "${LL_AFTER}" =~ ^[0-9]+$ ]] && \
+         [ "${LL_AFTER}" -le "${LL_BEFORE}" ]; }; then
+        error "E4 BUG (expected): text[]-index standby long-lived \
+backend missed insert (before=${LL_BEFORE}, after=${LL_AFTER})"
+    fi
+    log "E4 PASSED"
+}
+
+# -------------------------------------------------------------------
+# Test E5: Multiple indexes on same table.
+# Two indexes on the same table (different columns or different
+# text_configs). Both should reflect new inserts to a long-lived
+# backend.
+# Expected: FAIL today (both indexes have stale memtables).
+# -------------------------------------------------------------------
+test_long_lived_multiple_indexes_same_table() {
+    log "=== E5: multiple indexes on same table (should FAIL today) ==="
+    primary_sql "
+        DROP TABLE IF EXISTS e5_docs CASCADE;
+        CREATE TABLE e5_docs (id SERIAL PRIMARY KEY,
+                              title TEXT,
+                              body  TEXT);
+        INSERT INTO e5_docs (title, body) VALUES
+            ('initial title alpha', 'initial body bravo');
+        CREATE INDEX e5_title_idx ON e5_docs USING bm25(title)
+            WITH (text_config='simple');
+        CREATE INDEX e5_body_idx  ON e5_docs USING bm25(body)
+            WITH (text_config='simple');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    long_lived_open "${STANDBY_PORT}"
+    local title_before body_before
+    title_before=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM e5_docs
+            ORDER BY title <@> to_bm25query('alpha','e5_title_idx')
+            LIMIT 100) t;")
+    body_before=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM e5_docs
+            ORDER BY body <@> to_bm25query('bravo','e5_body_idx')
+            LIMIT 100) t;")
+
+    primary_sql "
+        INSERT INTO e5_docs (title, body) VALUES
+            ('new title alpha', 'new body bravo');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    local title_after body_after
+    title_after=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM e5_docs
+            ORDER BY title <@> to_bm25query('alpha','e5_title_idx')
+            LIMIT 100) t;")
+    body_after=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM e5_docs
+            ORDER BY body <@> to_bm25query('bravo','e5_body_idx')
+            LIMIT 100) t;")
+    long_lived_close
+
+    log "title: before=${title_before}, after=${title_after}"
+    log "body:  before=${body_before}, after=${body_after}"
+    if [[ "${title_after}" == *ERROR* ]] || \
+       [[ "${body_after}" == *ERROR* ]] || \
+       { [[ "${title_after}" =~ ^[0-9]+$ ]] && \
+         [[ "${body_after}" =~ ^[0-9]+$ ]] && \
+         { [ "${title_after}" -le "${title_before}" ] || \
+           [ "${body_after}" -le "${body_before}" ]; }; }; then
+        error "E5 BUG (expected): standby long-lived backend missed \
+inserts on one or both indexes (title=${title_after}, body=${body_after})"
+    fi
+    log "E5 PASSED"
+}
+
+main() {
+    log "Starting pg_textsearch replication correctness tests..."
+    check_required_tools
+    setup_primary
+
+    test_long_lived_read_after_primary_spill
+    test_long_lived_read_after_segment_merge
+    test_long_lived_memtable_segment_mix
+    test_long_lived_update_replication
+    test_long_lived_delete_vacuum
+    test_long_lived_partitioned_table
+    test_long_lived_expression_index
+    test_long_lived_partial_index
+    test_long_lived_text_array
+    test_long_lived_multiple_indexes_same_table
+
+    log "All replication correctness tests completed!"
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/test/scripts/replication_correctness.sh
+++ b/test/scripts/replication_correctness.sh
@@ -5,16 +5,23 @@
 # variations and primary write events (insert/update/delete/spill/
 # merge).
 #
-# Most tests in this file FAIL on current (un-fixed) code. Two bugs
-# are documented:
-#   1. Memtable staleness: long-lived standby backends miss new
-#      primary inserts because aminsert is never called on standby.
-#   2. WAL-replayed segments unreadable: long-lived standby backends
-#      error on segment reads when the segments were created via
-#      WAL replay (rather than included in the initial basebackup).
+# Failure mode tracked here: long-lived standby backend staleness
+# (#345). A standby backend that stays alive across primary inserts
+# rebuilds its in-memory view once on first scan and is never
+# invalidated by WAL replay; subsequent primary inserts and segment
+# merges are invisible to it. Surfaces in this file as "0 results"
+# (or undercount) for documents that ARE visible on disk to the
+# standby.
 #
-# A1 PASSES today — it reads segments that existed before basebackup.
-# All other tests FAIL today and document one of the two bug classes.
+# Before PR #343 there was a second surface here — long-lived
+# standby backends erroring on segment reads when the segments
+# arrived via WAL replay. That was #342 (page-index pages weren't
+# WAL-logged at all), fixed by PR #343. The remaining failures in
+# this file all map to #345.
+#
+# A1 PASSES today — it reads segments that existed in the initial
+# basebackup, so the long-lived backend's stale view is still
+# correct. All other tests FAIL today against #345.
 
 set -e
 

--- a/test/scripts/replication_failover.sh
+++ b/test/scripts/replication_failover.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+#
+# replication_failover.sh — standby-promotion tests under various
+# pre-promotion states.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55444
+STANDBY_PORT=55445
+TEST_DB=replication_failover
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_fail_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_fail_standby"
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+wait_for_promotion() {
+    local port=$1
+    local i=0
+    while [ $i -lt 15 ]; do
+        local in_recovery
+        in_recovery=$(node_sql_quiet "${port}" \
+            "SELECT pg_is_in_recovery();")
+        if [ "$in_recovery" = "f" ]; then
+            return 0
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+    error "Promotion did not complete on port ${port}"
+}
+
+# -------------------------------------------------------------------
+# D1: Promotion under steady write load.
+# Primary actively inserting; promote standby; verify the promoted
+# standby (a) sees pre-promotion data, (b) accepts new writes.
+# Expected: FAIL today — segments created by primary spill while
+# the standby is already running (WAL-replayed) are not enumerable
+# on the standby even after promotion. bm25_summarize_index shows
+# corpus stats (total_docs=100) but no segments. Same bug class as
+# replication_correctness.sh A2/A5. Will pass once the rmgr-based
+# replication implementation lands.
+# -------------------------------------------------------------------
+test_promotion_under_write_load() {
+    log "=== D1: promotion under write load ==="
+    primary_sql "
+        DROP TABLE IF EXISTS d1_docs CASCADE;
+        CREATE TABLE d1_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO d1_docs (content)
+            SELECT 'doc ' || i || ' alpha'
+            FROM generate_series(1,100) i;
+        CREATE INDEX d1_idx ON d1_docs USING bm25(content)
+            WITH (text_config='simple');
+        SELECT bm25_spill_index('d1_idx');
+    " >/dev/null
+    wait_for_standby_catchup
+
+    pg_ctl promote -D "${STANDBY_DIR}" -w
+    wait_for_promotion "${STANDBY_PORT}"
+
+    # Spilled docs should be visible (segment-on-disk).
+    local count
+    count=$(search_count "${STANDBY_PORT}" d1_docs content "alpha" \
+        "d1_idx")
+    log "  promoted-standby alpha count: ${count}"
+    if [[ "${count}" == *ERROR* ]] || [ "${count}" != "100" ]; then
+        error "D1 BUG (expected): WAL-replayed spilled segment not \
+enumerable on promoted standby (got ${count}/100)"
+    fi
+
+    # Writes work.
+    psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -c "
+        INSERT INTO d1_docs (content) VALUES
+            ('post-promotion alpha doc');
+    " >/dev/null
+    local count2
+    count2=$(search_count "${STANDBY_PORT}" d1_docs content "alpha" \
+        "d1_idx")
+    if [[ "${count2}" == *ERROR* ]] || \
+       ! [[ "${count2}" =~ ^[0-9]+$ ]] || \
+       [ "${count2}" -le "${count}" ]; then
+        error "D1: writes on promoted standby not visible \
+(${count} -> ${count2})"
+    fi
+    log "D1 PASSED"
+}
+
+# -------------------------------------------------------------------
+# D2: Promotion with unspilled data.
+# Primary has un-spilled data in memtable; standby is replicated
+# but its memtable was rebuilt from docid pages (so it has the
+# data). Promote standby; verify all data is visible after promotion.
+# Expected: PASS today — the long-lived backend opened before any
+# inserts has its first query trigger memtable rebuild, and the
+# promotion + subsequent query sees post-rebuild state. The memtable
+# staleness bug does not trigger in this sequence (compare with
+# replication.sh test_long_lived_backend_staleness, which DOES open
+# the long-lived backend before the first insert and sees staleness).
+# -------------------------------------------------------------------
+test_promotion_with_unspilled_memtable() {
+    log "=== D2: promotion with unspilled memtable ==="
+
+    # Reset: fresh primary+standby pair so this test is independent
+    # of D1's promoted standby (which is no longer in recovery).
+    pg_ctl stop -D "${STANDBY_DIR}" -m fast 2>/dev/null || true
+    pg_ctl stop -D "${PRIMARY_DIR}" -m fast 2>/dev/null || true
+    rm -rf "${PRIMARY_DIR}" "${STANDBY_DIR}"
+    setup_primary
+
+    primary_sql "
+        DROP TABLE IF EXISTS d2_docs CASCADE;
+        CREATE TABLE d2_docs (id SERIAL PRIMARY KEY, content TEXT);
+        INSERT INTO d2_docs (content)
+            SELECT 'doc ' || i || ' alpha'
+            FROM generate_series(1,50) i;
+        CREATE INDEX d2_idx ON d2_docs USING bm25(content)
+            WITH (text_config='simple');
+    " >/dev/null
+    setup_standby
+    wait_for_standby_catchup
+
+    long_lived_open "${STANDBY_PORT}"
+    local before
+    before=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM d2_docs
+            ORDER BY content <@> to_bm25query('alpha','d2_idx')
+            LIMIT 200) t;")
+    log "  pre-promotion long-lived count: ${before} (expect 50)"
+
+    # Insert more on primary — these stay in memtable, not spilled.
+    primary_sql "
+        INSERT INTO d2_docs (content)
+            SELECT 'late doc ' || i || ' alpha'
+            FROM generate_series(1,30) i;
+    " >/dev/null
+    wait_for_standby_catchup
+
+    pg_ctl promote -D "${STANDBY_DIR}" -w
+    wait_for_promotion "${STANDBY_PORT}"
+
+    local after
+    after=$(long_lived_query "
+        SELECT count(*) FROM (SELECT id FROM d2_docs
+            ORDER BY content <@> to_bm25query('alpha','d2_idx')
+            LIMIT 200) t;")
+    long_lived_close
+
+    log "  post-promotion long-lived count: ${after} (expect 80)"
+    if [ "${after}" != "80" ]; then
+        error "D2 BUG (likely): long-lived backend on promoted standby \
+missed pre-promotion memtable inserts (${after}/80)"
+    fi
+    log "D2 PASSED"
+}
+
+# -------------------------------------------------------------------
+# D3: Post-promotion writes + search via fresh backends.
+# Verify the standard "promoted standby is a normal primary" path
+# works for fresh psql connections.
+# Expected: PASS today.
+# -------------------------------------------------------------------
+test_post_promotion_writes_and_search() {
+    log "=== D3: post-promotion writes + search ==="
+    psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -c "
+        INSERT INTO d2_docs (content) VALUES
+            ('promoted-mode doc alpha bravo'),
+            ('another promoted doc alpha');
+    " >/dev/null
+    local count
+    count=$(search_count "${STANDBY_PORT}" d2_docs content "alpha" \
+        "d2_idx")
+    log "  search count after promotion-writes: ${count}"
+    if [[ "${count}" == *ERROR* ]] || \
+       ! [[ "${count}" =~ ^[0-9]+$ ]] || \
+       [ "${count}" -lt 82 ]; then
+        error "D3: post-promotion writes not visible (got ${count})"
+    fi
+    log "D3 PASSED"
+}
+
+main() {
+    log "Starting pg_textsearch replication failover tests..."
+    check_required_tools
+    setup_primary
+
+    primary_sql "
+        DROP TABLE IF EXISTS d_warmup CASCADE;
+        CREATE TABLE d_warmup (id INT, content TEXT);
+        INSERT INTO d_warmup VALUES (1, 'warmup');
+    " >/dev/null
+    setup_standby
+    wait_for_standby_catchup
+
+    test_promotion_under_write_load
+    test_promotion_with_unspilled_memtable
+    test_post_promotion_writes_and_search
+
+    log "All replication failover tests completed!"
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/test/scripts/replication_failover.sh
+++ b/test/scripts/replication_failover.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 #
-# replication_failover.sh — standby-promotion tests under various
-# pre-promotion states.
+# replication_failover.sh — standby-promotion tests. Brings up a
+# primary + streaming standby pair, leaves the standby in some
+# specific pre-promotion state, then promotes the standby and
+# checks the (new) primary still works.
+#
+# Tests:
+#   D1: Promotion under active primary write load — primary is
+#       still inserting when the standby is promoted. Post-
+#       promotion the new primary should accept reads + writes.
+#   D2: Promotion with an unspilled memtable on the primary — the
+#       standby's view of the index includes WAL-replayed memtable
+#       posting entries that have never been spilled to a segment.
+#       Post-promotion this state must still be queryable.
+#   D3: Post-promotion writes + searches — the new primary takes
+#       fresh inserts, search returns them.
 
 set -e
 

--- a/test/scripts/replication_issue_342.sh
+++ b/test/scripts/replication_issue_342.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# replication_issue_342.sh — targeted reproducers for issue #342:
+#   "BM25 index queries fail on streaming replicas with
+#    'ERROR: invalid page index at block N'"
+#
+# Root cause per issue: page-index pages are written via
+# MarkBufferDirty + FlushRelationBuffers without GenericXLog, so they
+# never reach the standby. Three code paths are listed in the issue:
+#
+#   1. Serial CREATE INDEX     — tp_write_segment_from_build_ctx
+#                                (src/access/build_context.c)
+#   2. Parallel CREATE INDEX   — leader path
+#                                (src/access/build_parallel.c)
+#   3. Memtable spill / merge  — write_page_index_internal
+#                                (src/segment/segment.c)
+#
+# At small data sizes (< ~150K docs) the serial-build path doesn't
+# trigger a visible failure because the segment's page-index fits in
+# a single block whose extension WAL covers the page implicitly. The
+# spill path triggers reliably because additional segment pages are
+# allocated post-build, exposing the missing GenericXLog coverage on
+# the page-index page.
+#
+# Broader coverage (UPDATE, partitioned, expression, partial, array,
+# multi-index) is in `replication_correctness.sh`. This file is the
+# minimal, focused reproducer pinned to the issue.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55454
+STANDBY_PORT=55455
+TEST_DB=replication_issue_342
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_342_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_342_standby"
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+# Count matching docs without the LIMIT 100 cap that search_count uses.
+search_count_full() {
+    local port=$1
+    local table=$2
+    local column=$3
+    local query=$4
+    local index=$5
+    local limit=${6:-100000}
+    psql -p "${port}" -d "${TEST_DB}" -tA -c "
+        SELECT count(*) FROM (
+            SELECT id FROM ${table}
+            ORDER BY ${column} <@> to_bm25query('${query}',
+                '${index}')
+            LIMIT ${limit}
+        ) t;" 2>/dev/null
+}
+
+expect_count() {
+    local label=$1
+    local got=$2
+    local expected=$3
+    if [[ "${got}" == *ERROR* ]] || \
+       [[ "${got}" == *"invalid page"* ]] || \
+       [[ "${got}" == *"invalid segment"* ]] || \
+       [[ "${got}" == *"could not read blocks"* ]] || \
+       ! [[ "${got}" =~ ^[0-9]+$ ]] || \
+       [ "${got}" != "${expected}" ]; then
+        error "${label} BUG (expected via #342): standby returned \
+'${got}', expected '${expected}'"
+    fi
+}
+
+# -------------------------------------------------------------------
+# Test: Memtable spill with standby streaming.
+#
+# Reproduces issue #342's "spill / level merge" path. Empty index is
+# built (replicates trivially via initial relation extension WAL),
+# then the primary inserts data and spills the memtable. The spill
+# exercises write_page_index_internal in segment.c, which today
+# writes the page-index page via MarkBufferDirty without GenericXLog.
+# The standby cannot read it.
+#
+# Symptom on un-fixed code: standby query errors with
+#   ERROR: could not read blocks N..N in file "base/X/Y": read only 0
+# (or the magic-byte variant if FSM recycled a stale page).
+# -------------------------------------------------------------------
+test_memtable_spill_with_standby() {
+    log "=== #342: memtable spill with standby streaming ==="
+
+    primary_sql "
+        DROP TABLE IF EXISTS chunks_contracts CASCADE;
+        CREATE TABLE chunks_contracts (
+            id SERIAL PRIMARY KEY,
+            content TEXT NOT NULL
+        );
+        CREATE INDEX idx_chunks_contracts_content_bm25
+            ON chunks_contracts USING bm25(content)
+            WITH (text_config='english');
+        INSERT INTO chunks_contracts (content)
+            SELECT 'document ' || i || ' alpha bravo charlie '
+                || repeat(md5(i::text), 8)
+            FROM generate_series(1, 3000) i;
+        SELECT bm25_spill_index('idx_chunks_contracts_content_bm25');
+    " >/dev/null
+
+    wait_for_standby_catchup
+
+    local primary_count
+    primary_count=$(search_count_full "${PRIMARY_PORT}" \
+        chunks_contracts content "alpha" \
+        "idx_chunks_contracts_content_bm25" 10000)
+    log "  primary count: ${primary_count}"
+    if [ "${primary_count}" != "3000" ]; then
+        error "#342: primary returned ${primary_count}/3000 — \
+test setup is broken"
+    fi
+
+    local standby_count
+    standby_count=$(search_count_full "${STANDBY_PORT}" \
+        chunks_contracts content "alpha" \
+        "idx_chunks_contracts_content_bm25" 10000)
+    log "  standby count: ${standby_count} (expect 3000)"
+    expect_count "#342" "${standby_count}" "3000"
+    log "#342 PASSED"
+}
+
+main() {
+    log "Starting issue #342 reproducer..."
+    check_required_tools
+    setup_primary
+    setup_standby
+    wait_for_standby_catchup
+
+    test_memtable_spill_with_standby
+
+    log "Issue #342 reproducer PASSED — bug is fixed."
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/test/scripts/replication_lib.sh
+++ b/test/scripts/replication_lib.sh
@@ -101,18 +101,21 @@ node_sql_quiet() {
 
 # Count search results using the index-scan pattern (CLAUDE.md says
 # WHERE-with-<@>-<-0 is an anti-pattern; ORDER BY ... LIMIT is right).
+# Optional 6th arg overrides the LIMIT (default 10000) for tests that
+# need to count more than 10K matching docs.
 search_count() {
     local port=$1
     local table=$2
     local column=$3
     local query=$4
     local index=$5
+    local limit=${6:-10000}
     psql -p "${port}" -d "${TEST_DB}" -tA -c "
         SELECT count(*) FROM (
             SELECT id FROM ${table}
             ORDER BY ${column} <@> to_bm25query('${query}',
                 '${index}')
-            LIMIT 100
+            LIMIT ${limit}
         ) t;" 2>/dev/null
 }
 

--- a/test/scripts/replication_lib.sh
+++ b/test/scripts/replication_lib.sh
@@ -2,10 +2,15 @@
 #
 # replication_lib.sh — shared helpers for physical-replication tests.
 #
-# Sourced by test/scripts/replication*.sh files. Provides two-node
-# setup primitives, query helpers, catchup waits, and long-lived
-# (persistent) psql session management used to expose the standby
-# memtable-staleness bug.
+# Sourced by test/scripts/replication*.sh files. Provides:
+#   - two- and three-node setup primitives (initdb + pg_basebackup),
+#   - one-shot SQL helpers against either node by port,
+#   - LSN-based catchup waits,
+#   - a FIFO-managed persistent psql session ("long-lived backend"),
+#     used to reproduce #345 — the bug only manifests when the same
+#     standby backend stays alive across primary inserts, since a
+#     fresh connection rebuilds its in-memory cache from current
+#     on-disk state on first scan.
 #
 # Required environment variables (set by the sourcing script BEFORE
 # this file is sourced):

--- a/test/scripts/replication_lib.sh
+++ b/test/scripts/replication_lib.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+#
+# replication_lib.sh — shared helpers for physical-replication tests.
+#
+# Sourced by test/scripts/replication*.sh files. Provides two-node
+# setup primitives, query helpers, catchup waits, and long-lived
+# (persistent) psql session management used to expose the standby
+# memtable-staleness bug.
+#
+# Required environment variables (set by the sourcing script BEFORE
+# this file is sourced):
+#
+#   PRIMARY_PORT, STANDBY_PORT
+#   PRIMARY_DIR, STANDBY_DIR
+#   TEST_DB
+#
+# Optional:
+#   STANDBY2_PORT, STANDBY2_DIR  — set by replication_cascading.sh
+#
+
+# Colors for output.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() {
+    echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"
+}
+
+warn() {
+    echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARNING: $1${NC}"
+}
+
+error() {
+    echo -e "${RED}[$(date '+%H:%M:%S')] ERROR: $1${NC}"
+    exit 1
+}
+
+# -------------------------------------------------------------------
+# Cleanup. Each script's main() should `trap repl_cleanup EXIT INT TERM`
+# AFTER setting PRIMARY_DIR/STANDBY_DIR/STANDBY2_DIR.
+# -------------------------------------------------------------------
+repl_cleanup() {
+    local exit_code=$?
+    log "Cleaning up replication test environment..."
+    if [ $exit_code -ne 0 ]; then
+        warn "Test failed - dumping logs:"
+        for d in "${PRIMARY_DIR:-}" "${STANDBY_DIR:-}" \
+                 "${STANDBY2_DIR:-}"; do
+            [ -z "$d" ] && continue
+            if [ -f "${d}/log/postgres.log" ]; then
+                echo "=== $(basename "$d") LOG (last 80 lines) ==="
+                tail -80 "${d}/log/postgres.log" 2>/dev/null || true
+            fi
+        done
+    fi
+    for dir in "${STANDBY2_DIR:-}" "${STANDBY_DIR:-}" \
+               "${PRIMARY_DIR:-}"; do
+        [ -z "$dir" ] && continue
+        if [ -f "${dir}/postmaster.pid" ]; then
+            pg_ctl stop -D "${dir}" -m fast 2>/dev/null ||
+                pg_ctl stop -D "${dir}" -m immediate 2>/dev/null || \
+                true
+        fi
+    done
+    for dir in "${PRIMARY_DIR:-}" "${STANDBY_DIR:-}" \
+               "${STANDBY2_DIR:-}"; do
+        [ -z "$dir" ] || rm -rf "${dir}"
+    done
+    exit $exit_code
+}
+
+# -------------------------------------------------------------------
+# SQL helpers. Each takes either a port (for arbitrary node) or
+# uses a default (PRIMARY_PORT / STANDBY_PORT).
+# -------------------------------------------------------------------
+primary_sql() {
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -c "$1" 2>&1
+}
+
+primary_sql_quiet() {
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c "$1" 2>/dev/null
+}
+
+standby_sql() {
+    psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -c "$1" 2>&1
+}
+
+standby_sql_quiet() {
+    psql -p "${STANDBY_PORT}" -d "${TEST_DB}" -tA -c "$1" 2>/dev/null
+}
+
+standby2_sql_quiet() {
+    psql -p "${STANDBY2_PORT}" -d "${TEST_DB}" -tA -c "$1" 2>/dev/null
+}
+
+node_sql_quiet() {
+    psql -p "$1" -d "${TEST_DB}" -tA -c "$2" 2>/dev/null
+}
+
+# Count search results using the index-scan pattern (CLAUDE.md says
+# WHERE-with-<@>-<-0 is an anti-pattern; ORDER BY ... LIMIT is right).
+search_count() {
+    local port=$1
+    local table=$2
+    local column=$3
+    local query=$4
+    local index=$5
+    psql -p "${port}" -d "${TEST_DB}" -tA -c "
+        SELECT count(*) FROM (
+            SELECT id FROM ${table}
+            ORDER BY ${column} <@> to_bm25query('${query}',
+                '${index}')
+            LIMIT 100
+        ) t;" 2>/dev/null
+}
+
+# -------------------------------------------------------------------
+# Wait for a target node's pg_last_wal_replay_lsn to catch up to the
+# primary's pg_current_wal_lsn.
+# -------------------------------------------------------------------
+wait_for_node_catchup() {
+    local target_port=$1
+    local max_wait=${2:-15}
+    local i=0
+    log "Waiting for node ${target_port} to catch up (max ${max_wait}s)..."
+    while [ $i -lt $max_wait ]; do
+        local primary_lsn
+        primary_lsn=$(node_sql_quiet "${PRIMARY_PORT}" \
+            "SELECT pg_current_wal_lsn();")
+        local target_lsn
+        target_lsn=$(node_sql_quiet "${target_port}" \
+            "SELECT pg_last_wal_replay_lsn();")
+        if [ -n "$primary_lsn" ] && [ -n "$target_lsn" ]; then
+            local caught_up
+            caught_up=$(node_sql_quiet "${target_port}" \
+                "SELECT '${target_lsn}'::pg_lsn >= '${primary_lsn}'::pg_lsn;")
+            if [ "$caught_up" = "t" ]; then
+                log "Node ${target_port} caught up at LSN ${target_lsn}"
+                return 0
+            fi
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+    warn "Node ${target_port} may not have caught up after ${max_wait}s"
+    return 1
+}
+
+# Compatibility shim for the existing replication.sh.
+wait_for_standby_catchup() {
+    wait_for_node_catchup "${STANDBY_PORT}" "${1:-15}"
+}
+
+# -------------------------------------------------------------------
+# Two-node setup helpers. setup_primary uses the script-supplied
+# PRIMARY_DIR/PRIMARY_PORT.
+# -------------------------------------------------------------------
+setup_primary() {
+    log "Setting up primary instance on port ${PRIMARY_PORT}..."
+    rm -rf "${PRIMARY_DIR}"
+    mkdir -p "${PRIMARY_DIR}"
+
+    initdb -D "${PRIMARY_DIR}" --auth-local=trust --auth-host=trust \
+        >/dev/null 2>&1
+
+    cat >> "${PRIMARY_DIR}/postgresql.conf" <<EOF
+port = ${PRIMARY_PORT}
+shared_buffers = 128MB
+max_connections = 30
+log_min_messages = notice
+logging_collector = on
+log_filename = 'postgres.log'
+shared_preload_libraries = 'pg_textsearch'
+wal_level = replica
+max_wal_senders = 8
+hot_standby = on
+EOF
+
+    echo "local replication all trust" >> "${PRIMARY_DIR}/pg_hba.conf"
+    echo "host replication all 127.0.0.1/32 trust" >> \
+        "${PRIMARY_DIR}/pg_hba.conf"
+
+    pg_ctl start -D "${PRIMARY_DIR}" \
+        -l "${PRIMARY_DIR}/postgres.log" -w
+    createdb -p "${PRIMARY_PORT}" "${TEST_DB}"
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" \
+        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+}
+
+# Standby is built from primary via pg_basebackup. Caller must
+# already have run setup_primary (and optionally loaded data).
+setup_standby() {
+    log "Creating standby via pg_basebackup..."
+    rm -rf "${STANDBY_DIR}"
+
+    pg_basebackup -D "${STANDBY_DIR}" -p "${PRIMARY_PORT}" -R \
+        -X stream --checkpoint=fast >/dev/null 2>&1
+
+    cat >> "${STANDBY_DIR}/postgresql.conf" <<EOF
+port = ${STANDBY_PORT}
+EOF
+
+    pg_ctl start -D "${STANDBY_DIR}" \
+        -l "${STANDBY_DIR}/postgres.log" -w
+
+    local in_recovery
+    in_recovery=$(node_sql_quiet "${STANDBY_PORT}" \
+        "SELECT pg_is_in_recovery();")
+    if [ "$in_recovery" != "t" ]; then
+        error "Standby is not in recovery mode!"
+    fi
+    log "Standby running on port ${STANDBY_PORT} (in recovery)"
+}
+
+# Cascading: standby2 takes its basebackup from standby1 (which is
+# in recovery). Postgres supports this since 9.x.
+setup_standby2() {
+    log "Creating standby2 via pg_basebackup from standby1..."
+    rm -rf "${STANDBY2_DIR}"
+
+    pg_basebackup -D "${STANDBY2_DIR}" -p "${STANDBY_PORT}" -R \
+        -X stream --checkpoint=fast >/dev/null 2>&1
+
+    cat >> "${STANDBY2_DIR}/postgresql.conf" <<EOF
+port = ${STANDBY2_PORT}
+EOF
+
+    pg_ctl start -D "${STANDBY2_DIR}" \
+        -l "${STANDBY2_DIR}/postgres.log" -w
+
+    local in_recovery
+    in_recovery=$(node_sql_quiet "${STANDBY2_PORT}" \
+        "SELECT pg_is_in_recovery();")
+    if [ "$in_recovery" != "t" ]; then
+        error "Standby2 is not in recovery mode!"
+    fi
+    log "Standby2 running on port ${STANDBY2_PORT} (in recovery)"
+}
+
+# -------------------------------------------------------------------
+# Long-lived (persistent) psql session.
+#
+# The standby memtable-staleness bug only manifests for backends that
+# stay alive across primary inserts (one-shot psql -c reconnects
+# each time and hits the rebuild path). These helpers manage a
+# persistent psql process via FIFOs, with a sentinel-line protocol
+# so we know when each query's output has fully arrived.
+#
+# Usage:
+#   long_lived_open <port>
+#   result=$(long_lived_query "SELECT count(*) FROM ...;")
+#   long_lived_close
+#
+# Only one long-lived session per shell at a time.
+# -------------------------------------------------------------------
+long_lived_open() {
+    local port=$1
+    LL_TMP_DIR=$(mktemp -d -t pg_ts_repl.XXXXXX)
+    LL_IN_FIFO="${LL_TMP_DIR}/in"
+    LL_OUT_FIFO="${LL_TMP_DIR}/out"
+    mkfifo "${LL_IN_FIFO}" "${LL_OUT_FIFO}"
+
+    # -tA: tuples-only, unaligned. -q: quiet (no banners between cmds).
+    psql -p "${port}" -d "${TEST_DB}" -tAq \
+        < "${LL_IN_FIFO}" > "${LL_OUT_FIFO}" 2>&1 &
+    LL_PID=$!
+
+    # Hold input fifo open via fd 9 so psql doesn't see EOF.
+    exec 9>"${LL_IN_FIFO}"
+
+    # Open output FIFO on fd 8 so reads don't block on writer churn.
+    exec 8<"${LL_OUT_FIFO}"
+}
+
+# Send SQL, read until sentinel. Returns query output (may be
+# multiple lines, may be empty). Caller checks for ERROR: lines.
+long_lived_query() {
+    local sql=$1
+    local sentinel="__pg_ts_sentinel_$$_${RANDOM}__"
+    echo "$sql" >&9
+    echo "SELECT '${sentinel}';" >&9
+
+    local result=""
+    local line
+    while IFS= read -r line <&8; do
+        if [ "$line" = "$sentinel" ]; then
+            break
+        fi
+        if [ -n "$result" ]; then
+            result="${result}"$'\n'"${line}"
+        else
+            result="$line"
+        fi
+    done
+    printf '%s' "$result"
+}
+
+long_lived_close() {
+    exec 9>&-
+    exec 8<&-
+    wait "${LL_PID}" 2>/dev/null || true
+    rm -rf "${LL_TMP_DIR}"
+    LL_PID=""
+}
+
+# Helper that wraps the full pattern: open standby, query before,
+# do something on primary, query after on the SAME backend, return
+# both counts via globals LL_BEFORE and LL_AFTER, close.
+#
+# Args:
+#   $1: port to open long-lived session on
+#   $2: query to run before+after (must return a single value)
+#   $3: bash command to execute between the two queries
+long_lived_before_after() {
+    local port=$1
+    local query=$2
+    local between=$3
+
+    long_lived_open "${port}"
+    LL_BEFORE=$(long_lived_query "${query}")
+    eval "${between}"
+    LL_AFTER=$(long_lived_query "${query}")
+    long_lived_close
+}
+
+# -------------------------------------------------------------------
+# Misc utilities.
+# -------------------------------------------------------------------
+check_required_tools() {
+    command -v pg_ctl >/dev/null 2>&1 || error "pg_ctl not found"
+    command -v psql >/dev/null 2>&1 || error "psql not found"
+    command -v pg_basebackup >/dev/null 2>&1 || \
+        error "pg_basebackup not found"
+    command -v initdb >/dev/null 2>&1 || error "initdb not found"
+}

--- a/test/scripts/replication_parallel_build.sh
+++ b/test/scripts/replication_parallel_build.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#
+# replication_parallel_build.sh — parallel CREATE INDEX replication
+# test for issue #342.
+#
+# PR #343 fixed three WAL-silent paths. The
+# tp_write_segment_from_build_ctx (serial build) and
+# write_page_index_internal (spill / merge) paths are exercised by
+# replication_issue_342.sh and replication_correctness.sh at small
+# data scales. The parallel-build leader path
+# (src/access/build_parallel.c, write_merged_segment_to_sink + new
+# FULL_IMAGE pass) only runs for tables of >= TP_MIN_PARALLEL_TUPLES
+# (100K) rows when max_parallel_maintenance_workers > 0.
+#
+# This test inserts 150K rows on the primary, runs parallel CREATE
+# INDEX, waits for the standby to catch up, and asserts the standby
+# returns the same row count as the primary.
+#
+# On the un-fixed code path, the standby would either ERROR with
+# "could not read blocks" / "invalid page index" or return 0 results
+# from the un-WAL-logged merged segment.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55456
+STANDBY_PORT=55457
+TEST_DB=replication_parallel_build
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_pbuild_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_repl_pbuild_standby"
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+# Count matching docs without the LIMIT 100 cap that search_count
+# uses (we have 150K rows).
+search_count_full() {
+    local port=$1
+    local table=$2
+    local column=$3
+    local query=$4
+    local index=$5
+    local limit=${6:-200000}
+    psql -p "${port}" -d "${TEST_DB}" -tA -c "
+        SELECT count(*) FROM (
+            SELECT id FROM ${table}
+            ORDER BY ${column} <@> to_bm25query('${query}',
+                '${index}')
+            LIMIT ${limit}
+        ) t;" 2>/dev/null
+}
+
+expect_count() {
+    local label=$1
+    local got=$2
+    local expected=$3
+    if [[ "${got}" == *ERROR* ]] || \
+       [[ "${got}" == *"invalid page"* ]] || \
+       [[ "${got}" == *"invalid segment"* ]] || \
+       [[ "${got}" == *"could not read blocks"* ]] || \
+       ! [[ "${got}" =~ ^[0-9]+$ ]] || \
+       [ "${got}" != "${expected}" ]; then
+        error "${label} BUG (expected via #343): standby returned \
+'${got}', expected '${expected}'"
+    fi
+}
+
+# -------------------------------------------------------------------
+# Test: parallel CREATE INDEX with standby streaming.
+#
+# Reproduces the parallel-build leg of issue #342. >=100K rows
+# triggers parallel CREATE INDEX (TP_MIN_PARALLEL_TUPLES). The leader
+# merges N worker segments via write_merged_segment_to_sink; before
+# PR #343 the merged data pages reached disk on the primary but
+# never made it into WAL.
+# -------------------------------------------------------------------
+test_parallel_create_index_with_standby() {
+    log "=== parallel CREATE INDEX with standby streaming ==="
+
+    primary_sql "
+        DROP TABLE IF EXISTS pbuild_docs CASCADE;
+        CREATE TABLE pbuild_docs (
+            id SERIAL PRIMARY KEY,
+            content TEXT NOT NULL
+        );
+        INSERT INTO pbuild_docs (content)
+            SELECT 'document ' || i || ' alpha bravo charlie '
+                || repeat(md5(i::text), 4)
+            FROM generate_series(1, 150000) i;
+        ANALYZE pbuild_docs;
+    " >/dev/null
+
+    # Force parallel build. pg_textsearch's heuristic is gated on
+    # reltuples >= TP_MIN_PARALLEL_TUPLES (100K) and on the planner
+    # assigning workers via plan_create_index_workers. ANALYZE above
+    # ensures reltuples reflects reality; min_parallel_table_scan_size
+    # = 0 keeps the planner from declining parallelism for the small
+    # heap.
+    primary_sql "
+        SET max_parallel_maintenance_workers = 4;
+        SET maintenance_work_mem = '256MB';
+        SET min_parallel_table_scan_size = 0;
+        CREATE INDEX pbuild_idx ON pbuild_docs
+            USING bm25(content)
+            WITH (text_config='english');
+    " >/dev/null
+
+    # Sanity: the index build must have launched parallel workers,
+    # otherwise we are testing the serial path (already covered by
+    # other replication tests) and not the build_parallel.c fix.
+    # pg_textsearch emits a NOTICE "parallel index build: launched
+    # N of M requested workers" when tp_build_parallel runs; the
+    # NOTICE goes to the server log at log_min_messages = notice.
+    local launched
+    launched=$(grep -oE "parallel index build: launched [0-9]+" \
+            "${PRIMARY_DIR}/log/postgres.log" 2>/dev/null | tail -1)
+    if [ -z "${launched}" ] || \
+       [[ "${launched}" =~ launched\ 0$ ]]; then
+        error "parallel build: primary did not launch parallel \
+workers (log line: '${launched:-<missing>}'); test is not \
+exercising build_parallel.c. Check max_parallel_maintenance_workers \
+and reltuples on pbuild_docs."
+    fi
+    log "  ${launched}"
+
+    wait_for_standby_catchup 30
+
+    local primary_count
+    primary_count=$(search_count_full "${PRIMARY_PORT}" \
+        pbuild_docs content "alpha" pbuild_idx 200000)
+    log "  primary count: ${primary_count}"
+    if [ "${primary_count}" != "150000" ]; then
+        error "parallel build: primary returned \
+${primary_count}/150000 — test setup is broken"
+    fi
+
+    local standby_count
+    standby_count=$(search_count_full "${STANDBY_PORT}" \
+        pbuild_docs content "alpha" pbuild_idx 200000)
+    log "  standby count: ${standby_count} (expect 150000)"
+    expect_count "parallel-build" "${standby_count}" "150000"
+    log "parallel CREATE INDEX replication PASSED"
+}
+
+main() {
+    log "Starting parallel-build replication test..."
+    check_required_tools
+    setup_primary
+    setup_standby
+    wait_for_standby_catchup
+
+    test_parallel_create_index_with_standby
+
+    log "Parallel-build replication test PASSED — \
+build_parallel.c WAL fix verified."
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/test/scripts/replication_pitr.sh
+++ b/test/scripts/replication_pitr.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 #
-# replication_pitr.sh — recovery-target-LSN test.
+# replication_pitr.sh — point-in-time-recovery test.
 #
-# Replays WAL up to a target LSN partway through an insert burst,
-# then queries. Validates that bm25 index state at any LSN is
-# coherent (not just at the tail).
+# Sets up a primary, takes a basebackup, runs an insert burst on the
+# primary, captures an LSN partway through the burst, runs more
+# inserts, then brings up a SECOND Postgres instance from the
+# basebackup with recovery_target_lsn = that captured LSN. The
+# recovered instance replays archived WAL up to the target and is
+# promoted; queries run against it.
+#
+# The bm25 index on the PITR-recovered instance should return
+# exactly the rows that were inserted before the recovery target —
+# i.e., the index's view must agree with the heap's view at that
+# LSN. Today it does not: see PITR-1's failure note for the
+# corpus-stats-not-WAL-replayed root cause.
 
 set -e
 

--- a/test/scripts/replication_pitr.sh
+++ b/test/scripts/replication_pitr.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+#
+# replication_pitr.sh — recovery-target-LSN test.
+#
+# Replays WAL up to a target LSN partway through an insert burst,
+# then queries. Validates that bm25 index state at any LSN is
+# coherent (not just at the tail).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55452
+TEST_DB=replication_pitr
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_repl_pitr_primary"
+RECOVERED_DIR="${SCRIPT_DIR}/../tmp_repl_pitr_recovered"
+ARCHIVE_DIR="${SCRIPT_DIR}/../tmp_repl_pitr_archive"
+
+# Custom: only one node, but reuse logging/etc.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+log() { echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"; }
+warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARNING: $1${NC}"; }
+error() { echo -e "${RED}[$(date '+%H:%M:%S')] ERROR: $1${NC}"; exit 1; }
+
+pitr_cleanup() {
+    for d in "${RECOVERED_DIR}" "${PRIMARY_DIR}"; do
+        if [ -f "${d}/postmaster.pid" ]; then
+            pg_ctl stop -D "${d}" -m fast 2>/dev/null \
+                || pg_ctl stop -D "${d}" -m immediate 2>/dev/null \
+                || true
+        fi
+    done
+    rm -rf "${PRIMARY_DIR}" "${RECOVERED_DIR}" "${ARCHIVE_DIR}"
+}
+if [ "${PITR_KEEP:-0}" != "1" ]; then
+    trap pitr_cleanup EXIT INT TERM
+fi
+
+setup_archive_primary() {
+    log "Setting up archive-mode primary on port ${PRIMARY_PORT}..."
+    rm -rf "${PRIMARY_DIR}" "${ARCHIVE_DIR}"
+    mkdir -p "${PRIMARY_DIR}" "${ARCHIVE_DIR}"
+    initdb -D "${PRIMARY_DIR}" --auth-local=trust --auth-host=trust \
+        >/dev/null 2>&1
+    cat >> "${PRIMARY_DIR}/postgresql.conf" <<EOF
+port = ${PRIMARY_PORT}
+shared_buffers = 128MB
+log_min_messages = notice
+logging_collector = on
+log_filename = 'postgres.log'
+shared_preload_libraries = 'pg_textsearch'
+wal_level = replica
+archive_mode = on
+archive_command = 'cp %p ${ARCHIVE_DIR}/%f'
+EOF
+    pg_ctl start -D "${PRIMARY_DIR}" \
+        -l "${PRIMARY_DIR}/postgres.log" -w
+    createdb -p "${PRIMARY_PORT}" "${TEST_DB}"
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" \
+        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+}
+
+# -------------------------------------------------------------------
+# PITR-1: Recover to LSN partway through insert burst.
+# Replays WAL up to a target LSN partway through an insert burst,
+# then queries the recovered cluster.
+#
+# Expected: FAIL today — exposes a third bug class beyond the
+# memtable-staleness and WAL-replayed-segment-unreadable bugs.
+# pg_textsearch's WAL replay path rebuilds memtable posting entries
+# but does NOT restore index-level corpus statistics (total_docs,
+# total_len). With those counters at 0, BM25 IDF and BMW pivot
+# selection produce 0 results even though the heap and memtable are
+# correctly populated. A REINDEX rebuilds the counters and produces
+# a working index. Will pass once WAL records cover the corpus
+# statistics, or once the rmgr-based replication implementation
+# rebuilds them on first scan.
+# -------------------------------------------------------------------
+test_recover_to_intermediate_lsn() {
+    log "=== PITR-1: recover to mid-burst LSN ==="
+
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -c "
+        DROP TABLE IF EXISTS p1_docs CASCADE;
+        CREATE TABLE p1_docs (id SERIAL PRIMARY KEY, content TEXT);
+        CREATE INDEX p1_idx ON p1_docs USING bm25(content)
+            WITH (text_config='simple');
+        SELECT pg_switch_wal();
+    " >/dev/null
+
+    # Take basebackup BEFORE the inserts. PITR replays WAL forward
+    # from the backup's consistent recovery point, so the target LSN
+    # must be >= that point. Taking the backup here keeps the
+    # consistent recovery point below the first batch of inserts.
+    rm -rf "${RECOVERED_DIR}"
+    pg_basebackup -D "${RECOVERED_DIR}" -p "${PRIMARY_PORT}" \
+        -X stream --checkpoint=fast >/dev/null 2>&1
+
+    # First half of inserts.
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -c "
+        INSERT INTO p1_docs (content)
+            SELECT 'first ' || i || ' alpha'
+            FROM generate_series(1,200) i;
+        SELECT pg_switch_wal();
+    " >/dev/null
+
+    # Capture the target LSN here.
+    local target_lsn
+    target_lsn=$(psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c "
+        SELECT pg_current_wal_lsn();")
+    log "  target LSN: ${target_lsn}"
+
+    # Second half of inserts (these should NOT be visible in the
+    # PITR-recovered cluster).
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -c "
+        INSERT INTO p1_docs (content)
+            SELECT 'second ' || i || ' alpha'
+            FROM generate_series(1,200) i;
+        SELECT pg_switch_wal();
+    " >/dev/null
+
+    # Force archive of the WAL containing target_lsn.
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -c "
+        SELECT pg_switch_wal();
+        CHECKPOINT;
+    " >/dev/null
+    sleep 2
+
+    # Configure the recovered cluster for PITR.
+    cat >> "${RECOVERED_DIR}/postgresql.conf" <<EOF
+port = $((PRIMARY_PORT + 1))
+restore_command = 'cp ${ARCHIVE_DIR}/%f %p'
+recovery_target_lsn = '${target_lsn}'
+recovery_target_action = 'pause'
+EOF
+    touch "${RECOVERED_DIR}/recovery.signal"
+
+    pg_ctl start -D "${RECOVERED_DIR}" \
+        -l "${RECOVERED_DIR}/postgres.log" -w
+
+    # Wait for it to reach the target and pause.
+    local i=0
+    while [ $i -lt 20 ]; do
+        local paused
+        paused=$(psql -p "$((PRIMARY_PORT + 1))" -d "${TEST_DB}" -tA \
+            -c "SELECT pg_get_wal_replay_pause_state();" 2>/dev/null)
+        if [ "${paused}" = "paused" ]; then break; fi
+        sleep 1; i=$((i + 1))
+    done
+
+    # Promote (resume) so we can query.
+    psql -p "$((PRIMARY_PORT + 1))" -d "${TEST_DB}" -c "
+        SELECT pg_wal_replay_resume();
+    " >/dev/null
+    pg_ctl promote -D "${RECOVERED_DIR}" -w
+    sleep 2
+
+    local count
+    count=$(psql -p "$((PRIMARY_PORT + 1))" -d "${TEST_DB}" -tA -c "
+        SELECT count(*) FROM (SELECT id FROM p1_docs
+            ORDER BY content <@> to_bm25query('alpha','p1_idx')
+            LIMIT 1000) t;" 2>/dev/null)
+    log "  PITR-recovered count: ${count} (expect 200, was 400 \
+before recovery cutoff)"
+
+    if [[ "${count}" == *ERROR* ]] || [ "${count}" != "200" ]; then
+        error "PITR-1 BUG (expected): recovered count=${count}, \
+expected 200. Likely cause: corpus stats (total_docs, total_len) \
+not replayed via WAL — BM25 IDF returns 0 results."
+    fi
+    log "PITR-1 PASSED"
+}
+
+main() {
+    command -v pg_ctl >/dev/null 2>&1 || error "pg_ctl not found"
+    command -v psql >/dev/null 2>&1 || error "psql not found"
+    command -v pg_basebackup >/dev/null 2>&1 || \
+        error "pg_basebackup not found"
+    command -v initdb >/dev/null 2>&1 || error "initdb not found"
+
+    setup_archive_primary
+    test_recover_to_intermediate_lsn
+
+    log "All PITR tests completed!"
+    exit 0
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary

Fixes #342 — pg_textsearch's segment writes weren't reaching streaming standbys, so replica queries errored with `invalid page index at block N`. Three code paths needed to emit WAL; this PR adds it. Bundled with a physical-replication test suite that pinned down the bug, surfaced two of the three affected paths, and verifies the fix end-to-end.

## The fix

Three previously WAL-silent paths now emit WAL:

| File / function | WAL added |
|---|---|
| `src/segment/segment.c` `write_page_index_internal` (covers serial CREATE INDEX, parallel-build leader, memtable spill, level merge — all flow through `write_page_index`) | `log_newpage_buffer(buf, false)` inside `START_CRIT_SECTION()`. `page_std=false` because page-index entries live in the pd_lower/pd_upper "hole" — `REGBUF_STANDARD` would zero them on replay. |
| `src/access/build_context.c` `tp_write_segment_from_build_ctx` (serial CREATE INDEX data pages) | Post-hoc `GenericXLog FULL_IMAGE` pass over `writer.pages`, mirroring the existing pass in `tp_write_segment`. |
| `src/access/build_parallel.c` `tp_build_parallel` (parallel CREATE INDEX merged data pages — caught by @upirr's review) | Same `GenericXLog FULL_IMAGE` pass over `sink.writer.pages`. |

## Verification

| Script | Path exercised | Before fix → After fix |
|---|---|---|
| `test/scripts/replication_issue_342.sh` | 3000-doc memtable spill → `write_page_index_internal` | standby `could not read blocks` → 3000/3000 |
| `test/scripts/replication_parallel_build.sh` | 150K rows + 4 parallel workers → `tp_build_parallel` | standby `invalid segment header at block 1` → 150000/150000 |

Both verified locally by reverting the corresponding fix and re-running.

## Suite

30 tests across 9 scripts (`make test-replication-extended`). After this PR: **18 pass, 11 fail, 1 skip**. All 11 failures map to a separate bug — long-lived standby backend staleness — tracked in **#345**; the PITR test fails on a third issue (corpus stats not WAL-replayed). Out of scope here.