### PR TITLE
Fix arena page boundary assertion in expull tail pointer

### DIFF
--- a/src/memtable/expull.c
+++ b/src/memtable/expull.c
@@ -102,8 +102,8 @@ tp_expull_append(
 	}
 	else
 	{
-		uint32 page = arena_addr_page(expull->tail);
-		uint32 off  = arena_addr_offset(expull->tail);
+		uint32 page	 = arena_addr_page(expull->tail);
+		uint32 off	 = arena_addr_offset(expull->tail);
 		expull->tail = arena_addr_make(page, off + TP_EXPULL_ENTRY_SIZE);
 	}
 	expull->num_entries++;

--- a/src/memtable/expull.c
+++ b/src/memtable/expull.c
@@ -84,14 +84,28 @@ tp_expull_append(
 	entry_ptr->frequency = frequency;
 	entry_ptr->fieldnorm = fieldnorm;
 
-	/* Advance tail */
+	/*
+	 * Advance tail pointer and decrement remaining capacity.
+	 *
+	 * When remaining_cap would become 0 (block exhausted), we must avoid
+	 * creating a potentially invalid ArenaAddr. This can happen when a
+	 * block is placed at the very end of an arena page and filled
+	 * completely -- the "next" tail offset would equal ARENA_PAGE_SIZE,
+	 * violating the arena addressing invariant. Instead, set tail to
+	 * ARENA_ADDR_INVALID to indicate the block is exhausted. The next
+	 * append will allocate a fresh block and reset the tail.
+	 */
+	expull->remaining_cap -= TP_EXPULL_ENTRY_SIZE;
+	if (expull->remaining_cap < TP_EXPULL_ENTRY_SIZE)
+	{
+		expull->tail = ARENA_ADDR_INVALID;
+	}
+	else
 	{
 		uint32 page = arena_addr_page(expull->tail);
-		uint32 off	= arena_addr_offset(expull->tail);
-
+		uint32 off  = arena_addr_offset(expull->tail);
 		expull->tail = arena_addr_make(page, off + TP_EXPULL_ENTRY_SIZE);
 	}
-	expull->remaining_cap -= TP_EXPULL_ENTRY_SIZE;
 	expull->num_entries++;
 }
 


### PR DESCRIPTION
## Problem

When building a BM25 index on large datasets with varied text (e.g., MS-MARCO 8.8M passages), parallel workers can crash with:

```
TRAP: failed Assert("offset < ARENA_PAGE_SIZE"), File: "src/memtable/arena.h", Line: 43
```

## Root Cause

Certain EXPULL block sizes (32B, 256B, 2KB, 16KB) have data capacity exactly divisible by `TP_EXPULL_ENTRY_SIZE` (7 bytes). When such a block is allocated at the very end of an arena page and completely filled, the tail pointer advances to offset `ARENA_PAGE_SIZE` (1MB), which is out of range.

The math:
- `ARENA_PAGE_SIZE` = 1,048,576 bytes (1MB)
- Block at offset 1,048,544 with size 32B ends at 1,048,576
- Data capacity = 28 bytes = 4 entries × 7 bytes (exactly)
- After writing 4th entry, tail advances to offset 1,048,576 = ARENA_PAGE_SIZE ❌

## Fix

When `remaining_cap` drops below entry size (block exhausted), set tail to `ARENA_ADDR_INVALID` instead of computing an invalid address. The next append allocates a fresh block anyway, so this is safe.

## Testing

- Reproduced crash with MS-MARCO v1 (8.8M passages) on debug build
- Existing regression tests pass
- Index build now completes successfully with the fix