### PR TITLE
Pair WAL emission with buffer dirtying for segment pages

### DIFF
--- a/src/access/build_context.c
+++ b/src/access/build_context.c
@@ -551,10 +551,16 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	 * Write dictionary entries with real skip_index_offset
 	 * values. This must happen BEFORE tp_segment_writer_finish
 	 * so writer.pages is still valid.
+	 *
+	 * Logged as GenericXLog deltas (not full-page images) since
+	 * each batch only mutates a handful of 16-byte dict entries
+	 * in pages that the writer flush already WAL-logged in full.
 	 */
 	{
-		Buffer dict_buf		= InvalidBuffer;
-		uint32 current_page = UINT32_MAX;
+		Buffer			  dict_buf	   = InvalidBuffer;
+		Page			  dict_page	   = NULL;
+		GenericXLogState *xlog_state   = NULL;
+		uint32			  current_page = UINT32_MAX;
 
 		for (i = 0; i < num_terms; i++)
 		{
@@ -590,35 +596,35 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 			{
 				if (current_page != UINT32_MAX)
 				{
-					MarkBufferDirty(dict_buf);
+					GenericXLogFinish(xlog_state);
 					UnlockReleaseBuffer(dict_buf);
 				}
 				physical_block = writer.pages[logical_page];
 				dict_buf	   = ReadBuffer(index, physical_block);
 				LockBuffer(dict_buf, BUFFER_LOCK_EXCLUSIVE);
+				xlog_state = GenericXLogStart(index);
+				dict_page = GenericXLogRegisterBuffer(xlog_state, dict_buf, 0);
 				current_page = logical_page;
 			}
 
-			/* Write entry — handle page boundary spanning */
+			/* Write entry to working copy - handle page boundary spanning */
 			{
 				uint32 bytes_remaining = SEGMENT_DATA_PER_PAGE - page_offset;
 
 				if (bytes_remaining >= sizeof(TpDictEntry))
 				{
-					Page  page = BufferGetPage(dict_buf);
-					char *dest = (char *)page + SizeOfPageHeaderData +
+					char *dest = (char *)dict_page + SizeOfPageHeaderData +
 								 page_offset;
 					memcpy(dest, &entry, sizeof(TpDictEntry));
 				}
 				else
 				{
-					Page  page = BufferGetPage(dict_buf);
-					char *dest = (char *)page + SizeOfPageHeaderData +
+					char *dest = (char *)dict_page + SizeOfPageHeaderData +
 								 page_offset;
 					char *src = (char *)&entry;
 
 					memcpy(dest, src, bytes_remaining);
-					MarkBufferDirty(dict_buf);
+					GenericXLogFinish(xlog_state);
 					UnlockReleaseBuffer(dict_buf);
 
 					logical_page++;
@@ -630,10 +636,12 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 					physical_block = writer.pages[logical_page];
 					dict_buf	   = ReadBuffer(index, physical_block);
 					LockBuffer(dict_buf, BUFFER_LOCK_EXCLUSIVE);
+					xlog_state = GenericXLogStart(index);
+					dict_page =
+							GenericXLogRegisterBuffer(xlog_state, dict_buf, 0);
 					current_page = logical_page;
 
-					page = BufferGetPage(dict_buf);
-					dest = (char *)page + SizeOfPageHeaderData;
+					dest = (char *)dict_page + SizeOfPageHeaderData;
 					memcpy(dest,
 						   src + bytes_remaining,
 						   sizeof(TpDictEntry) - bytes_remaining);
@@ -643,7 +651,7 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 
 		if (current_page != UINT32_MAX)
 		{
-			MarkBufferDirty(dict_buf);
+			GenericXLogFinish(xlog_state);
 			UnlockReleaseBuffer(dict_buf);
 		}
 	}
@@ -653,66 +661,38 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	/* Flush all pages to disk */
 	FlushRelationBuffers(index);
 
-	/* Write final header */
-	header_buf = ReadBuffer(index, header_block);
-	LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
-	header_page = BufferGetPage(header_buf);
-	{
-		TpSegmentHeader *hdr = (TpSegmentHeader *)PageGetContents(header_page);
-		hdr->strings_offset	 = header.strings_offset;
-		hdr->entries_offset	 = header.entries_offset;
-		hdr->postings_offset = header.postings_offset;
-		hdr->skip_index_offset	 = header.skip_index_offset;
-		hdr->fieldnorm_offset	 = header.fieldnorm_offset;
-		hdr->ctid_pages_offset	 = header.ctid_pages_offset;
-		hdr->ctid_offsets_offset = header.ctid_offsets_offset;
-		hdr->alive_bitset_offset = header.alive_bitset_offset;
-		hdr->alive_count		 = header.alive_count;
-		hdr->num_docs			 = header.num_docs;
-		hdr->data_size			 = header.data_size;
-		hdr->num_pages			 = header.num_pages;
-		hdr->page_index			 = header.page_index;
-	}
-	MarkBufferDirty(header_buf);
-	UnlockReleaseBuffer(header_buf);
-
 	/*
-	 * WAL-log all segment content pages via GenericXLog FULL_IMAGE so
-	 * they reach the standby. (Issue #342: prior code wrote these
-	 * pages via MarkBufferDirty alone. Page-index pages are covered
-	 * by log_newpage_buffer inside write_page_index_internal.)
-	 *
-	 * Mirrors the equivalent post-hoc pass in segment.c's
-	 * tp_write_segment.
+	 * Write final header.  The header page already received a full-page
+	 * WAL image during the writer flush, so this final patch is logged
+	 * as a small GenericXLog delta.
 	 */
 	{
-		uint32 pg_idx = 0;
+		GenericXLogState *xlog_state;
 
-		while (pg_idx < writer.pages_allocated)
+		header_buf = ReadBuffer(index, header_block);
+		LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
+
+		xlog_state	= GenericXLogStart(index);
+		header_page = GenericXLogRegisterBuffer(xlog_state, header_buf, 0);
 		{
-			GenericXLogState *state;
-			Buffer			  bufs[MAX_GENERIC_XLOG_PAGES];
-			uint32			  n = 0;
-			uint32			  j;
-
-			state = GenericXLogStart(index);
-
-			for (j = 0;
-				 j < MAX_GENERIC_XLOG_PAGES && pg_idx < writer.pages_allocated;
-				 j++, pg_idx++)
-			{
-				bufs[n] = ReadBuffer(index, writer.pages[pg_idx]);
-				LockBuffer(bufs[n], BUFFER_LOCK_EXCLUSIVE);
-				GenericXLogRegisterBuffer(
-						state, bufs[n], GENERIC_XLOG_FULL_IMAGE);
-				n++;
-			}
-
-			GenericXLogFinish(state);
-
-			for (j = 0; j < n; j++)
-				UnlockReleaseBuffer(bufs[j]);
+			TpSegmentHeader *hdr = (TpSegmentHeader *)PageGetContents(
+					header_page);
+			hdr->strings_offset		 = header.strings_offset;
+			hdr->entries_offset		 = header.entries_offset;
+			hdr->postings_offset	 = header.postings_offset;
+			hdr->skip_index_offset	 = header.skip_index_offset;
+			hdr->fieldnorm_offset	 = header.fieldnorm_offset;
+			hdr->ctid_pages_offset	 = header.ctid_pages_offset;
+			hdr->ctid_offsets_offset = header.ctid_offsets_offset;
+			hdr->alive_bitset_offset = header.alive_bitset_offset;
+			hdr->alive_count		 = header.alive_count;
+			hdr->num_docs			 = header.num_docs;
+			hdr->data_size			 = header.data_size;
+			hdr->num_pages			 = header.num_pages;
+			hdr->page_index			 = header.page_index;
 		}
+		GenericXLogFinish(xlog_state);
+		UnlockReleaseBuffer(header_buf);
 	}
 
 	FlushRelationBuffers(index);

--- a/src/access/build_parallel.c
+++ b/src/access/build_parallel.c
@@ -787,44 +787,6 @@ tp_build_parallel(
 					true /* disjoint_sources */);
 
 			/*
-			 * Issue #342: WAL-log all merged segment data pages via
-			 * GenericXLog FULL_IMAGE so they reach the standby.
-			 * Mirrors the equivalent pass in segment_merge.c's
-			 * tp_merge_level_segments. Page-index pages are covered
-			 * separately by log_newpage_buffer inside
-			 * write_page_index_internal.
-			 */
-			{
-				uint32 pg_idx = 0;
-
-				while (pg_idx < sink.writer.pages_allocated)
-				{
-					GenericXLogState *xstate;
-					Buffer			  xbufs[MAX_GENERIC_XLOG_PAGES];
-					uint32			  xn = 0, xj;
-
-					xstate = GenericXLogStart(index);
-
-					for (xj = 0; xj < MAX_GENERIC_XLOG_PAGES &&
-								 pg_idx < sink.writer.pages_allocated;
-						 xj++, pg_idx++)
-					{
-						xbufs[xn] =
-								ReadBuffer(index, sink.writer.pages[pg_idx]);
-						LockBuffer(xbufs[xn], BUFFER_LOCK_EXCLUSIVE);
-						GenericXLogRegisterBuffer(
-								xstate, xbufs[xn], GENERIC_XLOG_FULL_IMAGE);
-						xn++;
-					}
-
-					GenericXLogFinish(xstate);
-
-					for (xj = 0; xj < xn; xj++)
-						UnlockReleaseBuffer(xbufs[xj]);
-				}
-			}
-
-			/*
 			 * Flush dirty buffers before updating the metapage,
 			 * ensuring merged segment data is durable first.
 			 */

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -67,7 +67,12 @@ merge_sink_write(TpMergeSink *sink, const void *data, uint32 size)
 
 /*
  * Positioned write for backpatching (dict entries, header).
- * For pages backend, reads/writes through buffer manager.
+ *
+ * Each per-page chunk is logged as a small GenericXLog delta against the
+ * page that the writer flush already wrote.  This keeps backpatch WAL
+ * traffic proportional to the number of bytes actually changed (a few
+ * dict entries or the segment header struct), rather than emitting a
+ * full-page image for every visited page.
  */
 static void
 merge_sink_write_at(
@@ -79,22 +84,24 @@ merge_sink_write_at(
 
 	while (remaining > 0)
 	{
-		uint32		logical_pg = tp_logical_page(pos);
-		uint32		pg_off	   = tp_page_offset(pos);
-		uint32		avail	   = SEGMENT_DATA_PER_PAGE - pg_off;
-		uint32		chunk	   = Min(remaining, avail);
-		BlockNumber physical_block;
-		Buffer		buf;
-		Page		page;
+		uint32			  logical_pg = tp_logical_page(pos);
+		uint32			  pg_off	 = tp_page_offset(pos);
+		uint32			  avail		 = SEGMENT_DATA_PER_PAGE - pg_off;
+		uint32			  chunk		 = Min(remaining, avail);
+		BlockNumber		  physical_block;
+		Buffer			  buf;
+		Page			  page;
+		GenericXLogState *xlog_state;
 
 		Assert(logical_pg < sink->writer.pages_allocated);
 		physical_block = sink->writer.pages[logical_pg];
 
 		buf = ReadBuffer(sink->index, physical_block);
 		LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
-		page = BufferGetPage(buf);
+		xlog_state = GenericXLogStart(sink->index);
+		page	   = GenericXLogRegisterBuffer(xlog_state, buf, 0);
 		memcpy((char *)page + SizeOfPageHeaderData + pg_off, src, chunk);
-		MarkBufferDirty(buf);
+		GenericXLogFinish(xlog_state);
 		UnlockReleaseBuffer(buf);
 
 		src += chunk;
@@ -1651,36 +1658,6 @@ tp_merge_level_segments(Relation index, uint32 level, uint32 max_merge)
 				level + 1,
 				total_tokens,
 				false);
-
-		/* WAL-log all merged segment pages */
-		{
-			uint32 pg_idx = 0;
-
-			while (pg_idx < sink.writer.pages_allocated)
-			{
-				GenericXLogState *xstate;
-				Buffer			  xbufs[MAX_GENERIC_XLOG_PAGES];
-				uint32			  xn = 0, xj;
-
-				xstate = GenericXLogStart(index);
-
-				for (xj = 0; xj < MAX_GENERIC_XLOG_PAGES &&
-							 pg_idx < sink.writer.pages_allocated;
-					 xj++, pg_idx++)
-				{
-					xbufs[xn] = ReadBuffer(index, sink.writer.pages[pg_idx]);
-					LockBuffer(xbufs[xn], BUFFER_LOCK_EXCLUSIVE);
-					GenericXLogRegisterBuffer(
-							xstate, xbufs[xn], GENERIC_XLOG_FULL_IMAGE);
-					xn++;
-				}
-
-				GenericXLogFinish(xstate);
-
-				for (xj = 0; xj < xn; xj++)
-					UnlockReleaseBuffer(xbufs[xj]);
-			}
-		}
 
 		/* Free writer pages array */
 		if (sink.writer.pages)

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
+#include <utils/rel.h>
 #include <utils/timestamp.h>
 
 #include "debug/dump.h"
@@ -43,6 +44,16 @@
 
 /* External: compression GUC from mod.c */
 extern bool tp_compress_segments;
+
+void
+tp_segment_log_dirty_buffer(Relation index, Buffer buffer)
+{
+	START_CRIT_SECTION();
+	MarkBufferDirty(buffer);
+	if (RelationNeedsWAL(index))
+		log_newpage_buffer(buffer, false);
+	END_CRIT_SECTION();
+}
 
 /*
  * Note: We previously had a global page map cache here, but it was removed
@@ -735,6 +746,19 @@ tp_segment_release_direct(TpSegmentDirectAccess *access)
 /*
  * Allocate a single page for segment.
  * Checks FSM for recycled pages first, then extends the relation if needed.
+ *
+ * The returned page is intentionally left uninitialized and unlogged.  The
+ * first writer to populate the page (tp_segment_writer_flush or
+ * write_page_index_internal) is responsible for PageInit, laying out the
+ * segment-specific header fields (e.g. pd_lower = BLCKSZ for content pages),
+ * marking the buffer dirty, and emitting a WAL record for the new contents.
+ *
+ * Doing the page setup at content-write time — rather than here — avoids a
+ * redundant alloc-time WAL image for every newly extended or recycled page.
+ * Pages that are reached only by code that never writes them (e.g. an error
+ * path that bails out before flushing) remain unmodified on disk; that is
+ * safe because we never reference such pages from any persisted segment
+ * structure.
  */
 static BlockNumber
 allocate_segment_page(Relation index)
@@ -745,25 +769,16 @@ allocate_segment_page(Relation index)
 	/* Try to get a free page from FSM (recycled from compaction) */
 	block = GetFreeIndexPage(index);
 	if (block != InvalidBlockNumber)
-	{
-		buffer = ReadBuffer(index, block);
-		LockBuffer(buffer, BUFFER_LOCK_EXCLUSIVE);
-		PageInit(BufferGetPage(buffer), BLCKSZ, 0);
-		/* Ensure pd_lower covers content for GenericXLog */
-		((PageHeader)BufferGetPage(buffer))->pd_lower = BLCKSZ;
-		MarkBufferDirty(buffer);
-		UnlockReleaseBuffer(buffer);
 		return block;
-	}
 
-	/* No free pages available, extend the relation */
+	/*
+	 * No free pages available, extend the relation.  RBM_ZERO_AND_LOCK
+	 * gives us a zero-filled page; the first content writer will overwrite
+	 * the header and content area before logging it.
+	 */
 	buffer = ReadBufferExtended(
 			index, MAIN_FORKNUM, P_NEW, RBM_ZERO_AND_LOCK, NULL);
 	block = BufferGetBlockNumber(buffer);
-	PageInit(BufferGetPage(buffer), BLCKSZ, 0);
-	/* Ensure pd_lower covers content for GenericXLog */
-	((PageHeader)BufferGetPage(buffer))->pd_lower = BLCKSZ;
-	MarkBufferDirty(buffer);
 	UnlockReleaseBuffer(buffer);
 	return block;
 }
@@ -879,30 +894,7 @@ write_page_index_internal(Relation index, BlockNumber *pages, uint32 num_pages)
 		for (j = 0; j < entries_to_write; j++)
 			page_data[j] = pages[start_idx + j];
 
-		/*
-		 * Issue #342: WAL-log the page-index page so it reaches the
-		 * standby. Prior code wrote these pages via MarkBufferDirty
-		 * alone, bypassing WAL — the post-hoc FULL_IMAGE pass over
-		 * writer.pages in the segment write paths excludes page-index
-		 * blocks, since these are allocated via allocate_segment_page
-		 * rather than tp_segment_writer_allocate_page.
-		 *
-		 * page_std=false because pd_lower on this page does not cover
-		 * the data area — the page-index entries are written between
-		 * pd_lower (= SizeOfPageHeaderData) and pd_upper (= pd_special).
-		 * REGBUF_STANDARD would treat that as a hole and zero it on
-		 * replay, dropping the actual page-index contents. With
-		 * page_std=false we log the entire BLCKSZ.
-		 *
-		 * log_newpage_buffer asserts CritSectionCount > 0; the
-		 * MarkBufferDirty + WAL-log pair must be inside a critical
-		 * section so a failure between them PANICs rather than
-		 * leaving a dirty page un-WAL-logged.
-		 */
-		START_CRIT_SECTION();
-		MarkBufferDirty(buffer);
-		log_newpage_buffer(buffer, false);
-		END_CRIT_SECTION();
+		tp_segment_log_dirty_buffer(index, buffer);
 		UnlockReleaseBuffer(buffer);
 
 		prev_block = index_pages[i];
@@ -1344,11 +1336,18 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	/*
 	 * Now write the dictionary entries with correct skip_index_offset values.
 	 * Do this BEFORE tp_segment_writer_finish so writer.pages is still valid.
+	 *
+	 * Each per-page batch of patches is logged as a GenericXLog delta record
+	 * against the page that the writer flush already wrote, so we don't pay
+	 * the cost of a full-page WAL image for what amounts to a small number
+	 * of 16-byte dict-entry updates per page.
 	 */
 	{
-		Buffer dict_buf = InvalidBuffer;
-		uint32 entry_logical_page;
-		uint32 current_page = UINT32_MAX;
+		Buffer			  dict_buf	 = InvalidBuffer;
+		Page			  dict_page	 = NULL;
+		GenericXLogState *xlog_state = NULL;
+		uint32			  entry_logical_page;
+		uint32			  current_page = UINT32_MAX;
 
 		for (i = 0; i < num_terms; i++)
 		{
@@ -1387,17 +1386,19 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 			{
 				if (current_page != UINT32_MAX)
 				{
-					MarkBufferDirty(dict_buf);
+					GenericXLogFinish(xlog_state);
 					UnlockReleaseBuffer(dict_buf);
 				}
 
 				physical_block = writer.pages[entry_logical_page];
 				dict_buf	   = ReadBuffer(index, physical_block);
 				LockBuffer(dict_buf, BUFFER_LOCK_EXCLUSIVE);
+				xlog_state = GenericXLogStart(index);
+				dict_page = GenericXLogRegisterBuffer(xlog_state, dict_buf, 0);
 				current_page = entry_logical_page;
 			}
 
-			/* Write entry to page - handle page boundary spanning */
+			/* Write entry to working copy - handle page boundary spanning */
 			{
 				uint32 bytes_on_this_page = SEGMENT_DATA_PER_PAGE -
 											page_offset;
@@ -1405,24 +1406,22 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 				if (bytes_on_this_page >= sizeof(TpDictEntry))
 				{
 					/* Entry fits entirely on this page */
-					Page  page = BufferGetPage(dict_buf);
-					char *dest = (char *)page + SizeOfPageHeaderData +
+					char *dest = (char *)dict_page + SizeOfPageHeaderData +
 								 page_offset;
 					memcpy(dest, &entry, sizeof(TpDictEntry));
 				}
 				else
 				{
 					/* Entry spans two pages */
-					Page  page = BufferGetPage(dict_buf);
-					char *dest = (char *)page + SizeOfPageHeaderData +
+					char *dest = (char *)dict_page + SizeOfPageHeaderData +
 								 page_offset;
 					char *src = (char *)&entry;
 
-					/* Write first part to current page */
+					/* Write first part to current working copy */
 					memcpy(dest, src, bytes_on_this_page);
 
-					/* Move to next page */
-					MarkBufferDirty(dict_buf);
+					/* Commit current page's delta and move to next page */
+					GenericXLogFinish(xlog_state);
 					UnlockReleaseBuffer(dict_buf);
 
 					entry_logical_page++;
@@ -1434,11 +1433,13 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 					physical_block = writer.pages[entry_logical_page];
 					dict_buf	   = ReadBuffer(index, physical_block);
 					LockBuffer(dict_buf, BUFFER_LOCK_EXCLUSIVE);
+					xlog_state = GenericXLogStart(index);
+					dict_page =
+							GenericXLogRegisterBuffer(xlog_state, dict_buf, 0);
 					current_page = entry_logical_page;
 
-					/* Write remaining part to next page */
-					page = BufferGetPage(dict_buf);
-					dest = (char *)page + SizeOfPageHeaderData;
+					/* Write remaining part to next page's working copy */
+					dest = (char *)dict_page + SizeOfPageHeaderData;
 					memcpy(dest,
 						   src + bytes_on_this_page,
 						   sizeof(TpDictEntry) - bytes_on_this_page);
@@ -1449,7 +1450,7 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 		/* Release last buffer */
 		if (current_page != UINT32_MAX)
 		{
-			MarkBufferDirty(dict_buf);
+			GenericXLogFinish(xlog_state);
 			UnlockReleaseBuffer(dict_buf);
 		}
 	}
@@ -1459,68 +1460,39 @@ tp_write_segment(TpLocalIndexState *state, Relation index)
 	/* Flush to disk */
 	FlushRelationBuffers(index);
 
-	/* Update header on disk */
-	header_buf = ReadBuffer(index, header_block);
-	LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
-	header_page = BufferGetPage(header_buf);
-
-	existing_header = (TpSegmentHeader *)PageGetContents(header_page);
-	existing_header->strings_offset		 = header.strings_offset;
-	existing_header->entries_offset		 = header.entries_offset;
-	existing_header->postings_offset	 = header.postings_offset;
-	existing_header->skip_index_offset	 = header.skip_index_offset;
-	existing_header->fieldnorm_offset	 = header.fieldnorm_offset;
-	existing_header->ctid_pages_offset	 = header.ctid_pages_offset;
-	existing_header->ctid_offsets_offset = header.ctid_offsets_offset;
-	existing_header->alive_bitset_offset = header.alive_bitset_offset;
-	existing_header->alive_count		 = header.alive_count;
-	existing_header->num_docs			 = header.num_docs;
-	existing_header->total_tokens		 = header.total_tokens;
-	existing_header->data_size			 = header.data_size;
-	existing_header->num_pages			 = header.num_pages;
-	existing_header->page_index			 = header.page_index;
-
-	/* Ensure pd_lower covers content for GenericXLog */
-	((PageHeader)header_page)->pd_lower = BLCKSZ;
-
-	MarkBufferDirty(header_buf);
-	UnlockReleaseBuffer(header_buf);
-
 	/*
-	 * WAL-log all segment content pages via GenericXLog
-	 * FULL_IMAGE.  All modifications (content, dictionary
-	 * patches, header) have already been applied to the real
-	 * buffer pages above.  This pass generates WAL records so
-	 * the pages survive crash recovery.
+	 * Update header on disk.  The header page was already written and
+	 * WAL-logged in full during the writer flush above; this final patch
+	 * touches only the small TpSegmentHeader struct, so we use a
+	 * GenericXLog delta to avoid emitting another full-page image.
 	 */
 	{
-		uint32 pg_idx = 0;
+		GenericXLogState *xlog_state;
 
-		while (pg_idx < writer.pages_allocated)
-		{
-			GenericXLogState *state;
-			Buffer			  bufs[MAX_GENERIC_XLOG_PAGES];
-			uint32			  n = 0;
-			uint32			  j;
+		header_buf = ReadBuffer(index, header_block);
+		LockBuffer(header_buf, BUFFER_LOCK_EXCLUSIVE);
 
-			state = GenericXLogStart(index);
+		xlog_state	= GenericXLogStart(index);
+		header_page = GenericXLogRegisterBuffer(xlog_state, header_buf, 0);
 
-			for (j = 0;
-				 j < MAX_GENERIC_XLOG_PAGES && pg_idx < writer.pages_allocated;
-				 j++, pg_idx++)
-			{
-				bufs[n] = ReadBuffer(index, writer.pages[pg_idx]);
-				LockBuffer(bufs[n], BUFFER_LOCK_EXCLUSIVE);
-				GenericXLogRegisterBuffer(
-						state, bufs[n], GENERIC_XLOG_FULL_IMAGE);
-				n++;
-			}
+		existing_header = (TpSegmentHeader *)PageGetContents(header_page);
+		existing_header->strings_offset		 = header.strings_offset;
+		existing_header->entries_offset		 = header.entries_offset;
+		existing_header->postings_offset	 = header.postings_offset;
+		existing_header->skip_index_offset	 = header.skip_index_offset;
+		existing_header->fieldnorm_offset	 = header.fieldnorm_offset;
+		existing_header->ctid_pages_offset	 = header.ctid_pages_offset;
+		existing_header->ctid_offsets_offset = header.ctid_offsets_offset;
+		existing_header->alive_bitset_offset = header.alive_bitset_offset;
+		existing_header->alive_count		 = header.alive_count;
+		existing_header->num_docs			 = header.num_docs;
+		existing_header->total_tokens		 = header.total_tokens;
+		existing_header->data_size			 = header.data_size;
+		existing_header->num_pages			 = header.num_pages;
+		existing_header->page_index			 = header.page_index;
 
-			GenericXLogFinish(state);
-
-			for (j = 0; j < n; j++)
-				UnlockReleaseBuffer(bufs[j]);
-		}
+		GenericXLogFinish(xlog_state);
+		UnlockReleaseBuffer(header_buf);
 	}
 
 	FlushRelationBuffers(index);
@@ -2165,15 +2137,25 @@ tp_segment_writer_flush(TpSegmentWriter *writer)
 	page = BufferGetPage(buffer);
 
 	/*
-	 * Copy only the data portion of the page, preserving the page header
-	 * that the buffer manager has set up. This avoids corrupting the LSN
-	 * and other buffer manager state.
+	 * Lay out the standard page header before populating the content area.
+	 * allocate_segment_page intentionally returns uninitialized pages, so
+	 * the first writer to touch a buffer is responsible for PageInit and
+	 * for setting pd_lower to cover the custom segment content area.
+	 */
+	PageInit(page, BLCKSZ, 0);
+	((PageHeader)page)->pd_lower = BLCKSZ;
+
+	/*
+	 * Copy only the data portion of the page, leaving the header we just
+	 * laid out in place.  writer->buffer's first SizeOfPageHeaderData
+	 * bytes are scratch and must not overwrite the buffer manager's page
+	 * header on disk.
 	 */
 	memcpy((char *)page + SizeOfPageHeaderData,
 		   (char *)writer->buffer + SizeOfPageHeaderData,
 		   BLCKSZ - SizeOfPageHeaderData);
 
-	MarkBufferDirty(buffer);
+	tp_segment_log_dirty_buffer(writer->index, buffer);
 	UnlockReleaseBuffer(buffer);
 }
 

--- a/src/segment/segment.h
+++ b/src/segment/segment.h
@@ -90,3 +90,20 @@ extern void tp_batch_get_segment_doc_freq(
 		char	  **terms,
 		int			term_count,
 		uint32	   *doc_freqs);
+
+/*
+ * Mark a segment buffer dirty and immediately emit a full-page WAL image when
+ * WAL is required for the relation.  Segment pages use custom layouts, so the
+ * full image must not use REGBUF_STANDARD hole compression.
+ *
+ * This helper is intended for callers that have just populated an entire
+ * segment page from scratch (e.g. tp_segment_writer_flush,
+ * write_page_index_internal), where a full-page image is necessary anyway.
+ * For small in-place updates to an already-written segment page (dict-entry
+ * backpatches, header patches), prefer GenericXLog delta logging — it
+ * produces much smaller WAL records.
+ *
+ * Callers must hold an exclusive buffer lock and must not perform any
+ * ERROR-capable work between the final page modification and this call.
+ */
+extern void tp_segment_log_dirty_buffer(Relation index, Buffer buffer);


### PR DESCRIPTION
## Summary

Pair WAL emission with buffer dirtying for segment pages, so each page's
LSN is assigned before the buffer is unlocked and before any
flush/eviction path can observe it.

- New helper `tp_segment_log_dirty_buffer` (segment.c) — inside a
  critical section, marks the buffer dirty and (when
  `RelationNeedsWAL(index)`) emits `log_newpage_buffer(buf, false)`.
- Full-page-content writers (`tp_segment_writer_flush`,
  `write_page_index_internal`) call the helper at the same point they
  dirty the buffer.
- Small in-place backpatches (dict-entry `skip_index_offset` patches,
  segment-header finalization, `merge_sink_write_at`) emit
  GenericXLog **delta** records covering only the modified bytes,
  applied to pages that have already been WAL-logged in full by the
  writer flush above them.
- `allocate_segment_page` no longer does a speculative `PageInit` /
  `MarkBufferDirty`. The first content writer is responsible for
  `PageInit`, `pd_lower = BLCKSZ` (for content pages), marking dirty,
  and WAL emission.
- The previous post-hoc `GenericXLog FULL_IMAGE` sweeps in
  `build_context.c`, `build_parallel.c`, and `merge.c` are removed —
  replaced by per-page emission at content-write time.

## Motivation: correctness, not performance

`pg_textsearch` segment pages use custom page layouts and are updated
through direct buffer access. The previous code dirtied those buffers
first and emitted full-page WAL images later in a separate
end-of-segment sweep. That left a real window where a buffer was dirty
but its LSN did not yet cover its current contents. In vanilla
PostgreSQL this is hard to notice because the later sweep still makes
the final on-disk state recoverable, but the gap is observable:

1. **Flush or eviction before the deferred WAL pass.** Buffer eviction,
   checkpoint/writeback, or another storage layer can flush/evict a
   dirty page before the deferred sweep reaches it. The page is then on
   disk with no LSN, or with an LSN that does not cover the latest
   contents.
2. **Disaggregated or LSN-validating storage.** Storage systems that
   require every evictable page to have a valid LSN can reject or PANIC
   on such a page. This was observed downstream as a zero-LSN page
   eviction during ad-hoc BM25 index creation. The underlying issue is
   not specific to that environment — the page was dirty before
   WAL/LSN assignment.
3. **Crash/restart or replication timing around segment visibility.**
   The old code intended to make segment data durable before linking it
   from metadata, but the WAL record for a data page could be delayed
   relative to the first dirtying of that page. If a flush /
   checkpoint / storage interaction happened in that gap, recovery or
   replica state could depend on ordering the code did not explicitly
   enforce.

This patch closes the window by emitting WAL at the same point each
buffer is dirtied.

## Page-image flags

The full-page image uses `page_std = false`
(`log_newpage_buffer(buf, false)`):

- Writer-flush content pages set `pd_lower = BLCKSZ` (no hole), so
  REGBUF_STANDARD would be harmless but buys nothing.
- Page-index pages store entries between
  `pd_lower = SizeOfPageHeaderData` and `pd_upper = pd_special`.
  REGBUF_STANDARD would treat that range as a hole and zero it on
  replay, dropping the page-index contents. `page_std = false` logs
  the entire BLCKSZ unchanged.

## WAL-volume effect

This is a correctness fix; expect a small net **increase** in WAL
volume, not a decrease.

- `tp_segment_writer_flush` now emits one `log_newpage_buffer` record
  per page (≈ `BLCKSZ` + record header) instead of batching up to
  four page images per record in the deferred sweep. Net change:
  about +60 bytes of WAL record header per page.
- Dict-entry backpatches emit a GenericXLog delta record per
  dict-touched page in addition to the full-page image emitted earlier
  by `writer_flush`. The delta is small for sparse patches but can
  approach a full page when the dict-entry region is densely
  populated.
- Header finalization adds one small GenericXLog delta record.
- `merge_sink_write_at` emits one GenericXLog delta per chunk; on
  `main` it was `MarkBufferDirty` only, with the result folded into
  the deferred FPI sweep at no incremental WAL cost.

For a 64-page segment with ~1000 terms (so ~2 dict pages), the
increase is on the order of **~3 % (~16 KB) per segment** — negligible
relative to the segment data itself, and the price for getting WAL /
LSN ordering right.

There is no expected end-to-end performance improvement from this PR.
Query paths are unchanged; the build / merge paths do marginally more
WAL bookkeeping work.

## Tradeoffs

- WAL record count goes up. Per-record sizes are still dominated by
  the page images that have to be emitted anyway; record headers add
  a few tens of bytes per page.
- Caller discipline matters. The helper assumes callers hold the
  buffer exclusive lock and call it immediately after the final page
  modification, with no ERROR-capable work between the modification
  and the helper call. Backpatch sites use `GenericXLogStart` /
  `Finish`, which enforces the equivalent discipline.

## Why this approach

An alternative would be to rewrite the segment writers to use
GenericXLog page images as the primary mutation target throughout.
That is a larger refactor and still needs special care for custom page
layouts. This patch makes the existing buffer-mutation model safe by
ensuring each dirtying operation is paired with immediate WAL / LSN
assignment, while exploiting GenericXLog deltas where a delta is
genuinely smaller than a full page.

## Validation

- `git diff --check`
- `make` (clean, no warnings on changed files)
- `make installcheck` against PostgreSQL 18 — all 59 tests pass
- Focused code review of WAL / LSN ordering and custom page-layout
  handling

Not yet covered: the standby / replication suite from #342 / #343 has
not been re-run end-to-end against this branch. Worth wiring up before
merge.
