### PR TITLE
Restore standard installcheck behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         rm -rf tmp_check_shared
 
     - name: Run shell-based tests
-      timeout-minutes: 15
+      timeout-minutes: 25
       run: |
         export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
 
@@ -129,6 +129,48 @@ jobs:
           echo "✓ Segment tests passed"
         else
           echo "✗ Segment tests failed"
+          exit 1
+        fi
+        echo "Running crash recovery tests..."
+        if (cd test/scripts && ./recovery.sh); then
+          echo "✓ Crash recovery tests passed"
+        else
+          echo "✗ Crash recovery tests failed"
+          exit 1
+        fi
+        echo "Running docid chain recovery tests..."
+        if (cd test/scripts && ./docid_chain_recovery.sh); then
+          echo "✓ Docid chain recovery tests passed"
+        else
+          echo "✗ Docid chain recovery tests failed"
+          exit 1
+        fi
+        echo "Running shutdown spill tests..."
+        if (cd test/scripts && ./shutdown_spill.sh); then
+          echo "✓ Shutdown spill tests passed"
+        else
+          echo "✗ Shutdown spill tests failed"
+          exit 1
+        fi
+        echo "Running CREATE INDEX CONCURRENTLY tests..."
+        if (cd test/scripts && ./cic.sh); then
+          echo "✓ CIC tests passed"
+        else
+          echo "✗ CIC tests failed"
+          exit 1
+        fi
+        echo "Running memory accounting tests..."
+        if (cd test/scripts && ./memory_accounting.sh); then
+          echo "✓ Memory accounting tests passed"
+        else
+          echo "✗ Memory accounting tests failed"
+          exit 1
+        fi
+        echo "Running multi-index / multi-user / multi-schema tests..."
+        if (cd test/scripts && ./multi_index.sh); then
+          echo "✓ Multi-index tests passed"
+        else
+          echo "✗ Multi-index tests failed"
           exit 1
         fi
         echo "Running replication tests..."
@@ -461,6 +503,54 @@ jobs:
           cd test/scripts && ./recovery.sh
         "
 
+        echo "Running docid chain recovery tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./docid_chain_recovery.sh
+        "
+
+        echo "Running shutdown spill tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./shutdown_spill.sh
+        "
+
+        echo "Running multi-backend segment tests under sanitizer..."
+        timeout 1200s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./segment.sh
+        "
+
+        echo "Running CREATE INDEX CONCURRENTLY tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./cic.sh
+        "
+
+        echo "Running memory accounting tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./memory_accounting.sh
+        "
+
+        echo "Running multi-index / multi-user / multi-schema tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./multi_index.sh
+        "
+
         # Clean up
         pg_ctl stop -D tmp_sanitizer_test/data -l tmp_sanitizer_test/data/logfile
 
@@ -574,6 +664,7 @@ jobs:
         (cd test/scripts && ./shutdown_spill.sh) || true
         (cd test/scripts && ./cic.sh) || true
         (cd test/scripts && ./memory_accounting.sh) || true
+        (cd test/scripts && ./multi_index.sh) || true
         (cd test/scripts && ./replication.sh) || true
         (cd test/scripts && ./replication_spill_paths.sh) || true
         (cd test/scripts && ./wal_audit.sh) || true

--- a/.github/workflows/sanitizer-build-and-test.yml
+++ b/.github/workflows/sanitizer-build-and-test.yml
@@ -180,6 +180,54 @@ jobs:
           cd test/scripts && ./recovery.sh
         "
 
+        echo "Running docid chain recovery tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./docid_chain_recovery.sh
+        "
+
+        echo "Running shutdown spill tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./shutdown_spill.sh
+        "
+
+        echo "Running multi-backend segment tests under sanitizer..."
+        timeout 1200s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./segment.sh
+        "
+
+        echo "Running CREATE INDEX CONCURRENTLY tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./cic.sh
+        "
+
+        echo "Running memory accounting tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./memory_accounting.sh
+        "
+
+        echo "Running multi-index / multi-user / multi-schema tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./multi_index.sh
+        "
+
         # Clean up
         pg_ctl stop -D tmp_sanitizer_test/data -l tmp_sanitizer_test/data/logfile
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,8 @@ details):
 make                   # build extension
 make install           # install to Postgres
 make test              # run SQL regression tests only
-make installcheck      # run all tests (SQL + shell scripts)
-make test-all          # same as installcheck
+make installcheck      # run SQL regression tests
+make test-all          # run all tests (SQL + shell scripts)
 
 # Run a single test
 $(pg_config --pgxs | xargs dirname)/../../src/test/regress/pg_regress \
@@ -335,12 +335,12 @@ tables.
 
 **ALWAYS complete these steps before committing changes:**
 1. `make` - Compile the extension
-2. `make installcheck` - Run all tests
+2. `make installcheck` - Run SQL regression tests
 3. **Check test/regression.diffs** - Examine diffs to ensure your changes
    didn't introduce failures
 4. If you modified error messages, update corresponding test/expected/*.out
 5. `make format-check` - Verify code formatting
-6. Re-run `make installcheck` after fixing any test expectation files
+6. Re-run `make installcheck` after fixing any SQL test expectation files
 
 ### Git Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -186,11 +186,6 @@ test-shell: test-concurrency test-recovery test-segment test-cic test-memory tes
 test-all: test test-shell
 	@echo "All tests (SQL regression + shell scripts) completed successfully"
 
-# Override installcheck to run all tests (SQL regression + shell scripts)
-installcheck:
-	@$(MAKE) test
-	@$(MAKE) test-shell
-
 # Generate expected output files from current test results
 expected:
 	@echo "Generating expected output files from current results..."
@@ -326,7 +321,7 @@ help:
 	@echo ""
 	@echo "Testing targets:"
 	@echo "  make test         - Run SQL regression tests only"
-	@echo "  make installcheck - Run all tests (SQL + shell scripts)"
+	@echo "  make installcheck - Run SQL regression tests"
 	@echo "  make test-local   - Run tests with dedicated PostgreSQL instance"
 	@echo "  make test-all     - Run all tests (SQL regression + shell scripts)"
 	@echo "  make test-shell   - Run shell-based tests (all shell scripts)"

--- a/test/README.md
+++ b/test/README.md
@@ -182,9 +182,14 @@ plus a bounded shared-memory pending list drained on `tp_beginscan`.
 
 ## Running Tests
 
-### All Tests
+### SQL Regression Tests
 ```bash
 make installcheck
+```
+
+### All Local Tests
+```bash
+make test-all
 ```
 
 ### Individual Tests


### PR DESCRIPTION
## Summary
- remove the custom `installcheck` override so PGXS owns the target again
- keep SQL regression coverage available through `make installcheck` / `make test`
- keep shell-script coverage available through `make test-shell` and `make test-all`
- update Makefile help, CLAUDE.md, and test README to describe the target split

## Motivation
Downstream consumers expect PGXS `installcheck` to run SQL regression tests without triggering extension-specific shell scripts. The previous override made `installcheck` run both SQL regression and shell tests, which forced downstream harnesses to avoid the standard target.

Upstream shell-script coverage remains explicit through local targets and existing GitHub Actions steps.

## Validation
- `git diff --check`
- `make -n installcheck` shows PGXS pg_regress only
- `make -n test-all` shows SQL regression plus shell-script targets
- searched for stale docs claiming `installcheck` runs all tests
- code review + re-review
