### PR TITLE
ci(benchmark): add step timeouts + diagnostic capture so hangs are debuggable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1985,36 +1985,58 @@ jobs:
     # If anything above failed (e.g. a step-level timeout), capture
     # diagnostics so we can root-cause hangs from the artifact alone.
     # Runs only on failure to avoid noise on successful runs.
+    #
+    # `timeout-minutes` here is critical: without it, a hanging gdb attach
+    # or unresponsive psql could consume the remaining job budget, the
+    # job would be CANCELLED (not failed), and `if: always()` upload
+    # would be skipped — defeating the entire point of this PR.
     - name: Capture diagnostics on failure
       if: failure()
+      timeout-minutes: 5
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
+        # Bound each sub-tool individually so one stuck call can't burn
+        # the whole 5-minute budget.
+        export PGCONNECT_TIMEOUT=5
         echo "=== Failure diagnostics @ $(date -Iseconds) ===" \
             | tee diagnostics.log
         # pg_stat_activity: which queries are running, for how long, are
-        # they waiting on a lock?
-        psql -P pager=off -c "
-            SELECT pid, backend_type, state, wait_event_type, wait_event,
-                   xact_start, query_start,
-                   now() - query_start AS query_runtime,
-                   left(query, 200) AS query
-              FROM pg_stat_activity
-             WHERE datname = current_database()
-                OR backend_type IS NOT NULL
-             ORDER BY query_start NULLS LAST;" \
-            >> diagnostics.log 2>&1 || true
+        # they waiting on a lock? `datname IS NULL` includes background
+        # workers (checkpointer / walwriter / autovacuum launcher /
+        # logical replication launcher / parallel workers) which have
+        # NULL datname; we deliberately scope to the bench_test database
+        # plus those bgworkers rather than dumping every database.
+        timeout 30 psql -P pager=off \
+            -v ON_ERROR_STOP=0 \
+            -c "SET statement_timeout = '10s';
+                SELECT pid, backend_type, state,
+                       wait_event_type, wait_event,
+                       xact_start, query_start,
+                       now() - query_start AS query_runtime,
+                       left(query, 200) AS query
+                  FROM pg_stat_activity
+                 WHERE datname = current_database()
+                    OR datname IS NULL
+                 ORDER BY query_start NULLS LAST;" \
+            >> diagnostics.log 2>&1 || \
+            echo "(pg_stat_activity dump failed/timed out)" \
+                >> diagnostics.log
         # pg_locks: blockers / waiters
-        psql -P pager=off -c "
-            SELECT locktype, relation::regclass, mode, granted,
-                   pid, fastpath
-              FROM pg_locks
-             WHERE NOT granted
-                OR locktype IN ('relation', 'extend', 'page', 'tuple')
-             ORDER BY granted, pid;" \
-            >> diagnostics.log 2>&1 || true
-        # postgres.log tail (full file is uploaded too, but tail makes the
-        # GitHub UI summary readable without downloading the artifact)
+        timeout 30 psql -P pager=off \
+            -v ON_ERROR_STOP=0 \
+            -c "SET statement_timeout = '10s';
+                SELECT locktype, relation::regclass, mode, granted,
+                       pid, fastpath
+                  FROM pg_locks
+                 WHERE NOT granted
+                    OR locktype IN ('relation', 'extend', 'page', 'tuple')
+                 ORDER BY granted, pid;" \
+            >> diagnostics.log 2>&1 || \
+            echo "(pg_locks dump failed/timed out)" >> diagnostics.log
+        # postgres.log tail (full file is uploaded too, but tail makes
+        # the GitHub UI summary readable without downloading the
+        # artifact).
         echo "" >> diagnostics.log
         echo "=== tmp_bench/postgres.log (last 500 lines) ===" \
             >> diagnostics.log
@@ -2023,19 +2045,27 @@ jobs:
         else
             echo "(no postgres.log found)" >> diagnostics.log
         fi
-        # Stack traces from any postgres backends still running. Useful
+        # Stack traces from any postgres processes still running. Useful
         # when the BMW scan loop is hung in C code (no
         # CHECK_FOR_INTERRUPTS) and statement_timeout cannot abort it.
+        # `pgrep -x postgres` matches by exact process name, so it
+        # captures the postmaster, all backends, and aux processes
+        # (walwriter / checkpointer / bgwriter / autovacuum / parallel
+        # workers) — not just user backends whose proc title contains
+        # the database name.
         if command -v gdb >/dev/null && command -v pgrep >/dev/null; then
             echo "" >> diagnostics.log
             echo "=== Backend stack traces ===" >> diagnostics.log
-            for pid in $(pgrep -f "postgres.*bench_test" || true); do
+            for pid in $(pgrep -x postgres || true); do
                 echo "--- pid $pid ---" >> diagnostics.log
-                sudo gdb -p "$pid" -batch \
+                # Bound each gdb attach so a stuck process can't stall
+                # the whole diagnostic capture.
+                timeout 30 sudo gdb -p "$pid" -batch \
                     -ex "set pagination off" \
                     -ex "thread apply all bt 30" 2>/dev/null \
                     >> diagnostics.log || \
-                    echo "(gdb attach failed)" >> diagnostics.log
+                    echo "(gdb attach failed or timed out)" \
+                        >> diagnostics.log
             done
         fi
         echo "Diagnostics captured: $(wc -l < diagnostics.log) lines"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1727,8 +1727,14 @@ jobs:
         ./download.sh ${{ steps.datasets.outputs.wiki_size }}
 
     # Phase 1: Single-transaction inserts
+    #
+    # NOTE: Each long-running step has a step-level `timeout-minutes` so a
+    # hang fails the step rather than cancelling the whole job. Cancellation
+    # skips `if: always()` cleanup/upload steps, so we lose artifacts; a
+    # step failure does not. See PR adding these timeouts for context.
     - name: Run Cranfield insert benchmark
       if: steps.datasets.outputs.dataset == 'cranfield' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 10
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1746,6 +1752,7 @@ jobs:
 
     - name: Run MS MARCO insert benchmark
       if: steps.datasets.outputs.dataset == 'msmarco' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 45
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1763,6 +1770,7 @@ jobs:
 
     - name: Validate MS MARCO insert results
       if: steps.datasets.outputs.dataset == 'msmarco' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 15
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1791,6 +1799,7 @@ jobs:
 
     - name: Run Wikipedia insert benchmark
       if: steps.datasets.outputs.dataset == 'wikipedia' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 30
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1810,6 +1819,7 @@ jobs:
       if: |
         (steps.datasets.outputs.dataset == 'wikipedia' || steps.datasets.outputs.dataset == 'all') &&
         steps.datasets.outputs.wiki_size == '100K'
+      timeout-minutes: 15
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1829,6 +1839,7 @@ jobs:
     # Phase 2: Concurrent inserts (pgbench)
     - name: Run Cranfield concurrent insert
       if: steps.datasets.outputs.dataset == 'cranfield' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 15
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1855,6 +1866,7 @@ jobs:
 
     - name: Run Cranfield concurrent insert queries
       if: steps.datasets.outputs.dataset == 'cranfield' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 15
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1864,6 +1876,7 @@ jobs:
 
     - name: Run MS MARCO concurrent insert
       if: steps.datasets.outputs.dataset == 'msmarco' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 60
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1887,8 +1900,15 @@ jobs:
         echo "CONCURRENT_INSERT_TIME: ${MS}ms" | tee -a insert_results.txt
         echo "End: $(date)" | tee -a insert_results.txt
 
+    # NOTE: This step has historically been the most common hang (bucket-7
+    # MS MARCO queries hang indefinitely on certain segment topologies, and
+    # the BMW scan loop has no CHECK_FOR_INTERRUPTS so neither
+    # statement_timeout nor pg_cancel_backend can stop it). The 30-minute
+    # step timeout lets GitHub Actions kill the runner cleanly so the
+    # diagnostic / upload steps below still run with `if: always()`.
     - name: Run MS MARCO concurrent insert queries
       if: steps.datasets.outputs.dataset == 'msmarco' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 30
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1897,6 +1917,7 @@ jobs:
 
     - name: Validate MS MARCO concurrent results
       if: steps.datasets.outputs.dataset == 'msmarco' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 15
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1911,6 +1932,7 @@ jobs:
 
     - name: Run Wikipedia concurrent insert
       if: steps.datasets.outputs.dataset == 'wikipedia' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 30
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1936,6 +1958,7 @@ jobs:
 
     - name: Run Wikipedia concurrent insert queries
       if: steps.datasets.outputs.dataset == 'wikipedia' || steps.datasets.outputs.dataset == 'all'
+      timeout-minutes: 30
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1946,6 +1969,7 @@ jobs:
       if: |
         (steps.datasets.outputs.dataset == 'wikipedia' || steps.datasets.outputs.dataset == 'all') &&
         steps.datasets.outputs.wiki_size == '100K'
+      timeout-minutes: 15
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
         export PGDATABASE=bench_test
@@ -1957,6 +1981,64 @@ jobs:
             echo "ERROR: Wikipedia concurrent validation FAILED!" | tee -a insert_results.txt
             exit 1
         fi
+
+    # If anything above failed (e.g. a step-level timeout), capture
+    # diagnostics so we can root-cause hangs from the artifact alone.
+    # Runs only on failure to avoid noise on successful runs.
+    - name: Capture diagnostics on failure
+      if: failure()
+      run: |
+        export PATH="/usr/lib/postgresql/17/bin:$PATH"
+        export PGDATABASE=bench_test
+        echo "=== Failure diagnostics @ $(date -Iseconds) ===" \
+            | tee diagnostics.log
+        # pg_stat_activity: which queries are running, for how long, are
+        # they waiting on a lock?
+        psql -P pager=off -c "
+            SELECT pid, backend_type, state, wait_event_type, wait_event,
+                   xact_start, query_start,
+                   now() - query_start AS query_runtime,
+                   left(query, 200) AS query
+              FROM pg_stat_activity
+             WHERE datname = current_database()
+                OR backend_type IS NOT NULL
+             ORDER BY query_start NULLS LAST;" \
+            >> diagnostics.log 2>&1 || true
+        # pg_locks: blockers / waiters
+        psql -P pager=off -c "
+            SELECT locktype, relation::regclass, mode, granted,
+                   pid, fastpath
+              FROM pg_locks
+             WHERE NOT granted
+                OR locktype IN ('relation', 'extend', 'page', 'tuple')
+             ORDER BY granted, pid;" \
+            >> diagnostics.log 2>&1 || true
+        # postgres.log tail (full file is uploaded too, but tail makes the
+        # GitHub UI summary readable without downloading the artifact)
+        echo "" >> diagnostics.log
+        echo "=== tmp_bench/postgres.log (last 500 lines) ===" \
+            >> diagnostics.log
+        if [ -f tmp_bench/postgres.log ]; then
+            tail -n 500 tmp_bench/postgres.log >> diagnostics.log
+        else
+            echo "(no postgres.log found)" >> diagnostics.log
+        fi
+        # Stack traces from any postgres backends still running. Useful
+        # when the BMW scan loop is hung in C code (no
+        # CHECK_FOR_INTERRUPTS) and statement_timeout cannot abort it.
+        if command -v gdb >/dev/null && command -v pgrep >/dev/null; then
+            echo "" >> diagnostics.log
+            echo "=== Backend stack traces ===" >> diagnostics.log
+            for pid in $(pgrep -f "postgres.*bench_test" || true); do
+                echo "--- pid $pid ---" >> diagnostics.log
+                sudo gdb -p "$pid" -batch \
+                    -ex "set pagination off" \
+                    -ex "thread apply all bt 30" 2>/dev/null \
+                    >> diagnostics.log || \
+                    echo "(gdb attach failed)" >> diagnostics.log
+            done
+        fi
+        echo "Diagnostics captured: $(wc -l < diagnostics.log) lines"
 
     - name: Extract insert metrics
       if: always()
@@ -1991,19 +2073,9 @@ jobs:
               ${DATASET}_concurrent_metrics.json "${DATASET}_concurrent" "${DD} Concurrent" || true
         fi
 
-    - name: Upload insert benchmark results
-      uses: actions/upload-artifact@v4
-      with:
-        name: insert-benchmark-results-${{ github.run_id }}
-        path: |
-          insert_results.txt
-          *_insert_metrics.json
-          *_concurrent_metrics.json
-          *_action.json
-          *_validation.log
-          tmp_bench/postgres.log
-        retention-days: 90
-
+    # Format runs BEFORE Upload so generated *_action.json files are
+    # included in the artifact. (Was previously after Upload, which meant
+    # the *_action.json files were never archived.)
     - name: Format insert metrics
       if: always()
       run: |
@@ -2014,6 +2086,25 @@ jobs:
             ./benchmarks/runner/format_for_action.sh "$f" "${base}_action.json"
           fi
         done
+
+    # `if: always()` is critical: when a step above times out (or fails)
+    # we still need postgres.log + diagnostics.log to root-cause the hang.
+    # Without it, GitHub Actions skips this step and we lose all evidence.
+    - name: Upload insert benchmark results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: insert-benchmark-results-${{ github.run_id }}
+        path: |
+          insert_results.txt
+          *_insert_metrics.json
+          *_concurrent_metrics.json
+          *_action.json
+          *_validation.log
+          diagnostics.log
+          tmp_bench/postgres.log
+        retention-days: 90
+        if-no-files-found: warn
 
     - name: Publish Cranfield insert benchmark
       if: always() && hashFiles('cranfield_insert_action.json') != '' && github.event.inputs.dry_run != 'true'

--- a/benchmarks/datasets/msmarco/queries.sql
+++ b/benchmarks/datasets/msmarco/queries.sql
@@ -5,10 +5,11 @@
 \set ON_ERROR_STOP on
 \timing on
 
--- Soft cap on per-statement runtime so a pathological query fails fast
--- instead of hanging the benchmark for hours. Each LATENCY_BUCKET_n
--- INSERT runs `benchmark_bucket(n)` which loops 100 sub-queries, so
--- this is sized to comfortably accommodate a slow but healthy bucket.
+-- Soft cap on per-statement runtime so a top-level psql query (e.g. the
+-- warmup DO block) can't hang forever. The benchmark loop functions
+-- (`benchmark_bucket`, `benchmark_throughput`) opt out of this cap
+-- locally so a slow-but-healthy run can complete and emit results;
+-- the workflow's step-level timeout-minutes is the real hang backstop.
 -- NOTE: statement_timeout cannot interrupt scans hung in pg_textsearch's
 -- BMW C-loop (no CHECK_FOR_INTERRUPTS) — for that case the workflow
 -- relies on a step-level timeout in benchmark.yml.
@@ -74,6 +75,14 @@ DECLARE
     result_count bigint;
     results_sum bigint := 0;
 BEGIN
+    -- The script-level statement_timeout caps a *single* outer
+    -- statement; inside this function's loop it would cap the cumulative
+    -- runtime of the whole bucket and abort partway through, throwing
+    -- away every per-query timing already collected. Disable it locally
+    -- so a slow-but-healthy bucket can finish; the workflow's
+    -- step-level timeout-minutes is the real backstop for hangs.
+    PERFORM set_config('statement_timeout', '0', true);
+
     times := ARRAY[]::numeric[];
 
     FOR q IN SELECT query_text FROM benchmark_queries WHERE token_bucket = bucket ORDER BY query_id LOOP
@@ -198,6 +207,14 @@ DECLARE
     sorted_times numeric[];
     query_count int;
 BEGIN
+    -- Throughput runs ~3,200 sub-queries inside one outer SELECT
+    -- (800 warmup + 3 × 800 timed by default). The script-level
+    -- statement_timeout would cap that cumulative runtime, aborting the
+    -- benchmark before THROUGHPUT_RESULT is emitted — a regression
+    -- that's slow-but-healthy still loses all signal. Opt out locally;
+    -- the workflow's step-level timeout-minutes is the real backstop.
+    PERFORM set_config('statement_timeout', '0', true);
+
     SELECT COUNT(*) INTO query_count FROM benchmark_queries;
 
     -- Warmup: run all queries once

--- a/benchmarks/datasets/msmarco/queries.sql
+++ b/benchmarks/datasets/msmarco/queries.sql
@@ -5,6 +5,15 @@
 \set ON_ERROR_STOP on
 \timing on
 
+-- Soft cap on per-statement runtime so a pathological query fails fast
+-- instead of hanging the benchmark for hours. Each LATENCY_BUCKET_n
+-- INSERT runs `benchmark_bucket(n)` which loops 100 sub-queries, so
+-- this is sized to comfortably accommodate a slow but healthy bucket.
+-- NOTE: statement_timeout cannot interrupt scans hung in pg_textsearch's
+-- BMW C-loop (no CHECK_FOR_INTERRUPTS) — for that case the workflow
+-- relies on a step-level timeout in benchmark.yml.
+SET statement_timeout = '5min';
+
 \echo '=== MS MARCO Query Benchmarks ==='
 \echo ''
 

--- a/benchmarks/datasets/wikipedia/queries.sql
+++ b/benchmarks/datasets/wikipedia/queries.sql
@@ -274,6 +274,11 @@ DECLARE
     result_count bigint;
     results_sum bigint := 0;
 BEGIN
+    -- Disable the script-level statement_timeout for the duration of
+    -- this function so the cap can't abort partway through and discard
+    -- the per-query timings. See msmarco/queries.sql for context.
+    PERFORM set_config('statement_timeout', '0', true);
+
     times := ARRAY[]::numeric[];
 
     FOR q IN SELECT query_text FROM benchmark_queries

--- a/benchmarks/datasets/wikipedia/queries.sql
+++ b/benchmarks/datasets/wikipedia/queries.sql
@@ -5,6 +5,10 @@
 \set ON_ERROR_STOP on
 \timing on
 
+-- Soft cap on per-statement runtime so a pathological query fails fast
+-- instead of hanging the benchmark. See msmarco/queries.sql for context.
+SET statement_timeout = '5min';
+
 \echo '=== Wikipedia Query Benchmarks ==='
 \echo ''
 

--- a/benchmarks/sql/cranfield/02-queries.sql
+++ b/benchmarks/sql/cranfield/02-queries.sql
@@ -5,6 +5,10 @@
 \set ON_ERROR_STOP on
 \timing on
 
+-- Soft cap on per-statement runtime so a pathological query fails fast
+-- instead of hanging the benchmark. See msmarco/queries.sql for context.
+SET statement_timeout = '5min';
+
 \echo '=== Cranfield BM25 Benchmark - Query Phase ==='
 \echo ''
 


### PR DESCRIPTION
## Problem

The nightly **Benchmarks** workflow has been failing intermittently for weeks, all hanging on the same step (`Run MS MARCO concurrent insert queries`) on **bucket-7 (7-token) MS MARCO queries**:

| Date | SHA | Result |
|---|---|---|
| 2026-04-27 | `35a2dc63` | ❌ cancelled (pre-rmgr) |
| 2026-05-01 | `142b32d8` | ❌ cancelled (pre-rmgr) |
| 2026-05-02–03 | `7f7bd41a` | ❌ × 2 |
| 2026-05-06 | `bdd3b317` | ✅ |
| 2026-05-07–08 | `bdd3b317` | ❌ × 2 |
| 2026-05-09 | `67af30f9` | ❌ |

Each run waited the full **6-hour job-level timeout**, was then cancelled by GitHub Actions, and because cancellation skips `if: always()` cleanup/upload steps, **no `postgres.log`, `pg_stat_activity`, or `pg_locks` was ever uploaded**. We have zero diagnostic data to root-cause the underlying hang.

## What this PR changes

This PR makes the workflow fail fast on hangs and preserve evidence so the next failure tells us exactly what is stuck.

### 1. Step-level `timeout-minutes` on all long-running insert-benchmark steps

Sized at **~2–3× observed durations** from the last successful run (May 6):

| Step | Observed | Timeout | Headroom |
|---|---|---|---|
| Run MS MARCO insert benchmark | 13 min | 45 min | 3.4× |
| Run MS MARCO concurrent insert | 26 min | 60 min | 2.3× |
| **Run MS MARCO concurrent insert queries** (the hang-prone step) | 37 s | 30 min | huge |
| Run Wikipedia insert / concurrent | <1 min ea. | 30 min | huge |
| Validate / Cranfield steps | <1 min ea. | 10–15 min | huge |

When a step hits its timeout it **FAILS** (rather than the whole job being cancelled), which lets subsequent `if: always()` steps run.

### 2. New `Capture diagnostics on failure` step (`if: failure()`)

Dumps `pg_stat_activity`, `pg_locks`, `tail -n 500 tmp_bench/postgres.log`, and **gdb stack traces of any still-running backends** to `diagnostics.log`. The gdb stacks are especially important here because pg_textsearch's BMW scan loop currently has no `CHECK_FOR_INTERRUPTS`, so `statement_timeout` / `pg_cancel_backend()` cannot interrupt a hung scan — gdb is the only way to see where it's stuck.

### 3. Reorder `Format insert metrics` before `Upload insert benchmark results`

The generated `*_action.json` files were previously listed in the upload `path:` but produced *after* the upload step ran, so they were never actually archived. Pure bug.

### 4. Add `if: always()` to the upload step

**The single most important change for next-time debuggability.** Without it, GitHub Actions skips this step on cancellation/failure and we lose `postgres.log` + `diagnostics.log`.

### 5. Add `SET statement_timeout = 5min` to query SQL files

Defense in depth in `benchmarks/datasets/{msmarco,wikipedia}/queries.sql` and `benchmarks/sql/cranfield/02-queries.sql`. Note: this **cannot** interrupt a C-loop hang in BMW (no `CHECK_FOR_INTERRUPTS` there) but does catch plpgsql / planner-side runaways.

## What this PR explicitly does **not** fix

The underlying bucket-7 BMW hang itself. That bug:
- **Pre-dates** the rmgr/replication work (pre-rmgr commits `35a2dc63`, `7f7bd41a` cancelled in the same step before any WAL/replication PR landed).
- Is intermittent / data-dependent (same SHA `bdd3b317` succeeded once and hung twice on subsequent runs).
- Cannot be debugged from current run logs because we have no artifact.

I will file a tracking issue documenting the symptom and the missing `CHECK_FOR_INTERRUPTS` in `src/access/scan.c` / `src/scoring/bmw.c` (which is the reason hangs are uninterruptible — likely worth a separate small PR independently of root-causing the bucket-7 case).

## Verification

- [x] `actionlint .github/workflows/benchmark.yml` — clean.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — parses.
- [x] All `timeout-minutes` values comfortably fit within the 6h job timeout (sum ≈ 5h 25min worst case).
- [x] Step ordering verified: extract → format → upload → publish.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>