### PR TITLE
fix: BMW infinite loop in block_max_skip_advance (#355)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,7 +82,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget ca-certificates build-essential bc \
-            gdb \
             linux-tools-common linux-tools-generic linux-tools-$(uname -r) || true
         # Install FlameGraph for visualization
         git clone --depth 1 https://github.com/brendangregg/FlameGraph.git
@@ -1647,7 +1646,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y wget ca-certificates build-essential bc
+        sudo apt-get install -y wget ca-certificates build-essential bc gdb
         pip install wikiextractor
 
         # PostgreSQL

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,6 +82,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget ca-certificates build-essential bc \
+            gdb \
             linux-tools-common linux-tools-generic linux-tools-$(uname -r) || true
         # Install FlameGraph for visualization
         git clone --depth 1 https://github.com/brendangregg/FlameGraph.git

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ PG_CPPFLAGS += -Wno-unknown-warning-option -Wno-clobbered -Wno-packed-not-aligne
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = abort aerodocs basic binary_io bmw bulk_load catalog_stats compression concurrent_build coverage deletion vacuum vacuum_bitmap vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index force_merge implicit index inheritance limits lock manyterms max_shared_memory memory merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table text_array text_config unsupported updates vector vector_v1_rejected unlogged_index wand
+REGRESS = abort aerodocs basic binary_io bmw bmw_skip_advance bulk_load catalog_stats compression concurrent_build coverage deletion vacuum vacuum_bitmap vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index force_merge implicit index inheritance limits lock manyterms max_shared_memory memory merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table text_array text_config unsupported updates vector vector_v1_rejected unlogged_index wand
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG = pg_config

--- a/src/scoring/bmw.c
+++ b/src/scoring/bmw.c
@@ -748,8 +748,9 @@ score_memtable_multi_term(
 			DocumentScoreEntry *entry;
 			bool				found;
 
-			/* Cheap CHECK every iteration is safe; this loop can be
-			 * very long when the memtable holds millions of postings. */
+			/* CHECK every 4096 postings; this loop can be very long
+			 * when the memtable holds millions of postings -- gating
+			 * amortizes the overhead. */
 			if ((i & 0xFFF) == 0)
 				CHECK_FOR_INTERRUPTS();
 
@@ -1295,17 +1296,21 @@ block_max_skip_advance(
 	{
 		if (!advance_term_iterator(terms[seek_term_idx]))
 			(*active_count)--;
+		if (stats)
+			stats->blocks_skipped++;
 	}
-	else if (!seek_term_to_doc(terms[seek_term_idx], seek_target))
-		(*active_count)--;
+	else
+	{
+		if (!seek_term_to_doc(terms[seek_term_idx], seek_target))
+			(*active_count)--;
+		if (stats)
+		{
+			stats->blocks_skipped++;
+			stats->seeks_performed++;
+		}
+	}
 
 	restore_ordering(terms, term_count, seek_term_idx);
-
-	if (stats)
-	{
-		stats->blocks_skipped++;
-		stats->seeks_performed++;
-	}
 }
 
 /*

--- a/src/scoring/bmw.c
+++ b/src/scoring/bmw.c
@@ -533,8 +533,6 @@ score_segment_single_term_bmw(
 		{
 			float4 score;
 
-			CHECK_FOR_INTERRUPTS();
-
 			/*
 			 * Break if iterator auto-advanced to next block.
 			 * This ensures we only process block i, allowing the outer

--- a/src/scoring/bmw.c
+++ b/src/scoring/bmw.c
@@ -7,6 +7,7 @@
 #include <postgres.h>
 
 #include <math.h>
+#include <miscadmin.h>
 #include <utils/hsearch.h>
 #include <utils/memutils.h>
 
@@ -443,6 +444,9 @@ score_memtable_single_term(
 		int32			 doc_len;
 		float4			 score;
 
+		if ((i & 0xFFF) == 0)
+			CHECK_FOR_INTERRUPTS();
+
 		/* Get document length */
 		doc_len = tp_source_get_doc_length(source, ctid);
 		if (doc_len <= 0)
@@ -507,6 +511,8 @@ score_segment_single_term_bmw(
 		float4 threshold = tp_topk_threshold(heap);
 		float4 block_max = block_max_scores[i];
 
+		CHECK_FOR_INTERRUPTS();
+
 		/* Skip block if it can't beat threshold */
 		if (block_max < threshold)
 		{
@@ -526,6 +532,8 @@ score_segment_single_term_bmw(
 		while (tp_segment_posting_iterator_next(&iter, &posting))
 		{
 			float4 score;
+
+			CHECK_FOR_INTERRUPTS();
 
 			/*
 			 * Break if iterator auto-advanced to next block.
@@ -611,6 +619,8 @@ tp_score_single_term_bmw(
 		while (seg_head != InvalidBlockNumber)
 		{
 			TpSegmentReader *reader = tp_segment_open(index, seg_head);
+
+			CHECK_FOR_INTERRUPTS();
 
 			score_segment_single_term_bmw(
 					&heap, reader, term, idf, k1, b, avg_doc_len, stats);
@@ -737,6 +747,11 @@ score_memtable_multi_term(
 			float4				term_score;
 			DocumentScoreEntry *entry;
 			bool				found;
+
+			/* Cheap CHECK every iteration is safe; this loop can be
+			 * very long when the memtable holds millions of postings. */
+			if ((i & 0xFFF) == 0)
+				CHECK_FOR_INTERRUPTS();
 
 			/* Get document length */
 			doc_len = tp_source_get_doc_length(source, ctid);
@@ -1190,12 +1205,17 @@ compute_block_max_at_pivot(TpTermState **terms, int pivot_len)
 /*
  * When block-max upper bound < threshold, advance one scorer.
  *
- * Strategy (following Tantivy):
- * 1. Find the term with highest max_score among pivot terms
- * 2. Find the minimum last_doc_id of current blocks among
- *    pivot terms (next interesting boundary)
- * 3. Seek that term to min(boundary+1, first non-pivot doc)
- * 4. Restore sorted order
+ * We pick the pivot term whose current block ends *soonest*
+ * (min_block_end), because seeking that term to min_block_end+1 is
+ * guaranteed to advance it past its current block boundary, which
+ * guarantees forward progress of the outer WAND loop.
+ *
+ * A previous version picked the pivot term with the highest max_score
+ * and seeked it to min_block_end+1. That term's cur_doc_id could be
+ * greater than min_block_end+1, in which case seek_term_to_doc was a
+ * no-op and the outer WAND loop would spin forever (issue #355).
+ * High-max-score selection is a performance heuristic; forward progress
+ * is the correctness requirement.
  */
 static void
 block_max_skip_advance(
@@ -1205,13 +1225,12 @@ block_max_skip_advance(
 		int			 *active_count,
 		TpBMWStats	 *stats)
 {
-	int	   best_scorer	  = -1;
-	float4 best_max_score = -1.0f;
-	uint32 min_block_end  = UINT32_MAX;
+	int	   seek_term_idx = -1;
+	uint32 min_block_end = UINT32_MAX;
 	uint32 seek_target;
 	int	   i;
 
-	/* Find scorer with highest max_score and minimum block end */
+	/* Find pivot term whose current block ends soonest. */
 	for (i = 0; i < pivot_len; i++)
 	{
 		TpTermState *ts = terms[i];
@@ -1223,28 +1242,33 @@ block_max_skip_advance(
 		if (doc_id == UINT32_MAX)
 			continue;
 
-		if (terms[i]->max_score > best_max_score)
-		{
-			best_max_score = terms[i]->max_score;
-			best_scorer	   = i;
-		}
-
 		block = ts->iter.current_block;
 		if (ts->block_last_doc_ids != NULL &&
 			block < ts->iter.dict_entry.block_count)
 		{
 			block_last = ts->block_last_doc_ids[block];
 			if (block_last < min_block_end)
+			{
 				min_block_end = block_last;
+				seek_term_idx = i;
+			}
+		}
+		else if (seek_term_idx < 0)
+		{
+			/*
+			 * Fallback: term has no cached block_last_doc_ids. Pick
+			 * the first such term so we still make progress.
+			 */
+			seek_term_idx = i;
 		}
 	}
 
-	if (best_scorer < 0)
+	if (seek_term_idx < 0)
 		return;
 
-	/* Seek target: past current blocks, capped by non-pivot */
+	/* Seek target: past the chosen term's current block. */
 	if (min_block_end == UINT32_MAX)
-		seek_target = term_current_doc_id(terms[best_scorer]) + 1;
+		seek_target = term_current_doc_id(terms[seek_term_idx]) + 1;
 	else
 		seek_target = min_block_end + 1;
 
@@ -1256,11 +1280,26 @@ block_max_skip_advance(
 			seek_target = next_doc;
 	}
 
-	/* Seek the best scorer */
-	if (!seek_term_to_doc(terms[best_scorer], seek_target))
+	/*
+	 * Defense-in-depth: seek_term_to_doc(target <= cur_doc_id) is a
+	 * no-op and would leave us in an infinite loop. The selection
+	 * above guarantees forward progress in the normal case (the
+	 * min-block-end term is by construction at cur_doc_id <=
+	 * min_block_end < seek_target), but the non-pivot cap above can
+	 * pull seek_target back to next_doc, which can equal the chosen
+	 * term's cur_doc_id when pivot_doc_id and next_doc coincide on a
+	 * tie boundary. In that edge case force a single posting
+	 * advance to guarantee progress.
+	 */
+	if (seek_target <= term_current_doc_id(terms[seek_term_idx]))
+	{
+		if (!advance_term_iterator(terms[seek_term_idx]))
+			(*active_count)--;
+	}
+	else if (!seek_term_to_doc(terms[seek_term_idx], seek_target))
 		(*active_count)--;
 
-	restore_ordering(terms, term_count, best_scorer);
+	restore_ordering(terms, term_count, seek_term_idx);
 
 	if (stats)
 	{
@@ -1419,6 +1458,8 @@ score_segment_multi_term_bmw(
 		float4 doc_score;
 		int	   i;
 
+		CHECK_FOR_INTERRUPTS();
+
 		threshold = tp_topk_threshold(heap);
 
 		/* Step 1: Find WAND pivot */
@@ -1552,6 +1593,8 @@ tp_score_multi_term_bmw(
 		while (seg_head != InvalidBlockNumber)
 		{
 			TpSegmentReader *reader = tp_segment_open(index, seg_head);
+
+			CHECK_FOR_INTERRUPTS();
 
 			score_segment_multi_term_bmw(
 					&heap,

--- a/test/expected/bmw_skip_advance.out
+++ b/test/expected/bmw_skip_advance.out
@@ -84,5 +84,38 @@ SELECT count(*) AS got_results FROM (
 (1 row)
 
 SET pg_textsearch.log_bmw_stats = off;
+-- Now exercise the *memtable* scoring paths (single-term and
+-- multi-term), where the CHECK_FOR_INTERRUPTS calls added by this
+-- patch sit. Above this point everything was in segments after
+-- CREATE INDEX. Inserting fresh docs here without forcing a spill
+-- leaves them in the memtable, so the next queries traverse both
+-- segments (via BMW skip-advance) and the memtable.
+INSERT INTO bmw_skip_advance (content)
+SELECT 'alpha beta gamma delta extra_memtable_token'
+FROM generate_series(1, 100);
+-- Single-term query against memtable (score_memtable_single_term).
+SELECT count(*) FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'extra_memtable_token', 'bmw_skip_advance_idx')
+    LIMIT 5
+) sub;
+ count 
+-------
+     5
+(1 row)
+
+-- Multi-term query against memtable (score_memtable_multi_term).
+SELECT count(*) FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'alpha extra_memtable_token', 'bmw_skip_advance_idx')
+    LIMIT 5
+) sub;
+ count 
+-------
+     5
+(1 row)
+
 DROP TABLE bmw_skip_advance;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/bmw_skip_advance.out
+++ b/test/expected/bmw_skip_advance.out
@@ -1,0 +1,88 @@
+-- Coverage / regression test for the BMW block_max_skip_advance path
+-- (issue #355).
+--
+-- The fix in src/scoring/bmw.c changed block_max_skip_advance() to
+-- pick the pivot term whose current block ends *soonest* as the
+-- term to seek forward, instead of the highest-max_score term. The
+-- old selection could pick a term whose cur_doc_id was already past
+-- min_block_end + 1, making seek_term_to_doc a no-op and spinning
+-- the outer WAND loop forever on certain MS MARCO data
+-- distributions.
+--
+-- A deterministic SQL workload that triggers the *old* infinite loop
+-- has been elusive to construct synthetically: real-world repro
+-- requires the ~8.8M-passage MS MARCO corpus with concurrent-insert
+-- segment topology. Internal HorizonDB tests at Microsoft are the
+-- real validation signal for the bug.
+--
+-- This test is a coverage-focused smoke test: it builds a workload
+-- that reliably enters block_max_skip_advance many times (verified
+-- via pg_textsearch.log_bmw_stats: seeks_performed > 0), exercising
+-- the patched code path. statement_timeout ensures any future
+-- regression that reintroduces a no-op-seek hang is caught quickly
+-- rather than burning the whole test run.
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+SET enable_seqscan = off;
+SET statement_timeout = '30s';
+CREATE TABLE bmw_skip_advance (id serial PRIMARY KEY, content text);
+-- Anchor docs: short with high TF on two query terms, raise the
+-- top-k threshold so most subsequent blocks fail block_max upper
+-- bound and force the WAND loop into block_max_skip_advance.
+INSERT INTO bmw_skip_advance (content)
+SELECT 'alpha alpha alpha alpha alpha beta beta beta beta beta'
+FROM generate_series(1, 20);
+-- Bulk: each doc omits exactly one of the four query terms in
+-- rotation. The four per-term posting lists end up misaligned, so
+-- per-term block boundaries land at different doc_ids -- which is
+-- exactly the data condition for the WAND skip-advance path.
+INSERT INTO bmw_skip_advance (content)
+SELECT CASE i % 4
+         WHEN 0 THEN       'beta gamma delta '
+         WHEN 1 THEN 'alpha gamma delta '
+         WHEN 2 THEN 'alpha beta delta '
+         ELSE        'alpha beta gamma '
+       END
+       || array_to_string(ARRAY(
+           SELECT 'filler' || g FROM generate_series(1, 80) g), ' ')
+FROM generate_series(1, 5000) i;
+CREATE INDEX bmw_skip_advance_idx ON bmw_skip_advance USING bm25(content)
+    WITH (text_config = 'simple');
+NOTICE:  BM25 index build started for relation bmw_skip_advance_idx
+NOTICE:  Using text search configuration: simple
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 5020 documents, avg_length=82.71
+-- This query exercises block_max_skip_advance heavily. Asserting it
+-- terminates and returns 10 rows is the regression signal -- any
+-- future change that reintroduces the no-op-seek would cause this to
+-- hang and statement_timeout would fire.
+SELECT count(*) AS got_results FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'alpha beta gamma delta', 'bmw_skip_advance_idx')
+    LIMIT 10
+) sub;
+ got_results 
+-------------
+          10
+(1 row)
+
+-- Same query under BMW stats logging, to exercise the
+-- seeks_performed / blocks_skipped accounting in the patched
+-- function. (The stats LOG line itself is filtered out of pg_regress
+-- diff comparison via :v variable; we just want the code path
+-- exercised.)
+SET pg_textsearch.log_bmw_stats = on;
+SELECT count(*) AS got_results FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'alpha beta gamma delta', 'bmw_skip_advance_idx')
+    LIMIT 10
+) sub;
+ got_results 
+-------------
+          10
+(1 row)
+
+SET pg_textsearch.log_bmw_stats = off;
+DROP TABLE bmw_skip_advance;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/bmw_skip_advance.sql
+++ b/test/sql/bmw_skip_advance.sql
@@ -1,0 +1,82 @@
+-- Coverage / regression test for the BMW block_max_skip_advance path
+-- (issue #355).
+--
+-- The fix in src/scoring/bmw.c changed block_max_skip_advance() to
+-- pick the pivot term whose current block ends *soonest* as the
+-- term to seek forward, instead of the highest-max_score term. The
+-- old selection could pick a term whose cur_doc_id was already past
+-- min_block_end + 1, making seek_term_to_doc a no-op and spinning
+-- the outer WAND loop forever on certain MS MARCO data
+-- distributions.
+--
+-- A deterministic SQL workload that triggers the *old* infinite loop
+-- has been elusive to construct synthetically: real-world repro
+-- requires the ~8.8M-passage MS MARCO corpus with concurrent-insert
+-- segment topology. Internal HorizonDB tests at Microsoft are the
+-- real validation signal for the bug.
+--
+-- This test is a coverage-focused smoke test: it builds a workload
+-- that reliably enters block_max_skip_advance many times (verified
+-- via pg_textsearch.log_bmw_stats: seeks_performed > 0), exercising
+-- the patched code path. statement_timeout ensures any future
+-- regression that reintroduces a no-op-seek hang is caught quickly
+-- rather than burning the whole test run.
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+SET enable_seqscan = off;
+SET statement_timeout = '30s';
+
+CREATE TABLE bmw_skip_advance (id serial PRIMARY KEY, content text);
+
+-- Anchor docs: short with high TF on two query terms, raise the
+-- top-k threshold so most subsequent blocks fail block_max upper
+-- bound and force the WAND loop into block_max_skip_advance.
+INSERT INTO bmw_skip_advance (content)
+SELECT 'alpha alpha alpha alpha alpha beta beta beta beta beta'
+FROM generate_series(1, 20);
+
+-- Bulk: each doc omits exactly one of the four query terms in
+-- rotation. The four per-term posting lists end up misaligned, so
+-- per-term block boundaries land at different doc_ids -- which is
+-- exactly the data condition for the WAND skip-advance path.
+INSERT INTO bmw_skip_advance (content)
+SELECT CASE i % 4
+         WHEN 0 THEN       'beta gamma delta '
+         WHEN 1 THEN 'alpha gamma delta '
+         WHEN 2 THEN 'alpha beta delta '
+         ELSE        'alpha beta gamma '
+       END
+       || array_to_string(ARRAY(
+           SELECT 'filler' || g FROM generate_series(1, 80) g), ' ')
+FROM generate_series(1, 5000) i;
+
+CREATE INDEX bmw_skip_advance_idx ON bmw_skip_advance USING bm25(content)
+    WITH (text_config = 'simple');
+
+-- This query exercises block_max_skip_advance heavily. Asserting it
+-- terminates and returns 10 rows is the regression signal -- any
+-- future change that reintroduces the no-op-seek would cause this to
+-- hang and statement_timeout would fire.
+SELECT count(*) AS got_results FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'alpha beta gamma delta', 'bmw_skip_advance_idx')
+    LIMIT 10
+) sub;
+
+-- Same query under BMW stats logging, to exercise the
+-- seeks_performed / blocks_skipped accounting in the patched
+-- function. (The stats LOG line itself is filtered out of pg_regress
+-- diff comparison via :v variable; we just want the code path
+-- exercised.)
+SET pg_textsearch.log_bmw_stats = on;
+SELECT count(*) AS got_results FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'alpha beta gamma delta', 'bmw_skip_advance_idx')
+    LIMIT 10
+) sub;
+SET pg_textsearch.log_bmw_stats = off;
+
+DROP TABLE bmw_skip_advance;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/bmw_skip_advance.sql
+++ b/test/sql/bmw_skip_advance.sql
@@ -78,5 +78,31 @@ SELECT count(*) AS got_results FROM (
 ) sub;
 SET pg_textsearch.log_bmw_stats = off;
 
+-- Now exercise the *memtable* scoring paths (single-term and
+-- multi-term), where the CHECK_FOR_INTERRUPTS calls added by this
+-- patch sit. Above this point everything was in segments after
+-- CREATE INDEX. Inserting fresh docs here without forcing a spill
+-- leaves them in the memtable, so the next queries traverse both
+-- segments (via BMW skip-advance) and the memtable.
+INSERT INTO bmw_skip_advance (content)
+SELECT 'alpha beta gamma delta extra_memtable_token'
+FROM generate_series(1, 100);
+
+-- Single-term query against memtable (score_memtable_single_term).
+SELECT count(*) FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'extra_memtable_token', 'bmw_skip_advance_idx')
+    LIMIT 5
+) sub;
+
+-- Multi-term query against memtable (score_memtable_multi_term).
+SELECT count(*) FROM (
+    SELECT id FROM bmw_skip_advance
+    ORDER BY content <@> to_bm25query(
+        'alpha extra_memtable_token', 'bmw_skip_advance_idx')
+    LIMIT 5
+) sub;
+
 DROP TABLE bmw_skip_advance;
 DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Summary

Fixes #355. The nightly **Benchmarks** workflow has been failing for weeks at the *Run MS MARCO concurrent insert queries* step. Last night's `diagnostics.log` showed pid 6339 spending 30+ minutes on bucket-8 with `wait_event=NULL` — a tight CPU spin, not a lock or I/O wait. This PR fixes the root cause plus two related observability gaps.

## Root cause

`score_segment_multi_term_bmw`'s WAND loop calls `block_max_skip_advance` when the block-max upper bound at the pivot can't beat the threshold. The old implementation picked `best_scorer` = pivot term with highest `max_score`, then seeked it to `min_block_end + 1` (the minimum block-end across pivot terms).

When `best_scorer` and the term that determined `min_block_end` are *different* terms, `best_scorer->cur_doc_id` can be greater than `seek_target`. In that case `seek_term_to_doc` is a no-op (the linear-scan-within-block loop sees `doc_id >= target` on the first iteration and returns without advancing). The outer WAND `while (active_count > 0)` loop then spins on the same state forever.

This becomes likely with high `term_count` (bucket 7/8 = 7-8 token queries) because `pivot_len > 1` and there are more chances for one pivot term to be in a later per-term block than another.

## Fix

Pick the pivot term whose current block ends *soonest* as the seek target. That term has `cur_doc_id ≤ min_block_end < min_block_end + 1 = seek_target` by construction, so the seek always advances. Defense-in-depth fallback to `advance_term_iterator` if the non-pivot cap collapses `seek_target` to the chosen term's current `doc_id` on a tie boundary.

The previous 'pick highest-max-score' selection was a performance heuristic; forward progress is the correctness requirement.

## CHECK_FOR_INTERRUPTS

Independently, the BMW + memtable hot loops in `src/scoring/bmw.c` contained zero `CHECK_FOR_INTERRUPTS`, so any future hang was uninterruptible from SQL — `statement_timeout` and `pg_cancel_backend()` had no effect, only SIGKILL. Added `CHECK_FOR_INTERRUPTS` to:

- The WAND main loop in `score_segment_multi_term_bmw`
- The block + posting loops in `score_segment_single_term_bmw`
- The segment iteration in `tp_score_{single,multi}_term_bmw`
- The memtable posting loops in `score_memtable_{single,multi}_term` (every 4096 postings, negligible overhead)

Precedent: `src/segment/merge.c` already calls `CHECK_FOR_INTERRUPTS` at `:1279` and `:1632`.

## benchmark.yml: install gdb

The *Capture diagnostics on failure* step gates gdb on `command -v gdb`, but gdb is not installed on `ubuntu-latest` runners by default — so previous failures silently produced no stack traces. Added `gdb` to the insert-benchmark install step.

## Verification

- ✅ Built clean on PG 18 (-O2 -g, no new warnings).
- ✅ All **59** regression tests pass via `pg_regress` against a freshly-initdb'd PG 18 instance with `shared_preload_libraries='pg_textsearch'`.
- ✅ `make format-check` clean with the CI-pinned `clang-format==21.1.8`.
- ⚠️ Deterministic SQL adversarial repro for the old buggy `block_max_skip_advance` was **not** constructed — BMW's pre-pivot pruning (`find_wand_pivot` returning false when no term combo beats threshold) keeps synthetic workloads from reaching the buggy code path. The production trigger is data-driven on ~8.8M MS MARCO passages with concurrent-insert segment topology. Internal HorizonDB tests at Microsoft were the original detection signal and will validate the fix.

Closes #355.