### PR TITLE
fix(ci): validate_queries.sql — propagate LIMIT 10 to BMW index scan; document #365 trap

### DIFF
--- a/benchmarks/datasets/msmarco/validate_queries.sql
+++ b/benchmarks/datasets/msmarco/validate_queries.sql
@@ -5,10 +5,27 @@
 --   run_benchmark.sh from the versioned ground_truth_pgNN.tsv files)
 -- Usage: psql -p PORT -f validate_queries.sql
 --
--- Validates:
---   1. Same documents appear in top-10 (order may vary for ties)
---   2. BM25 scores match within absolute tolerance (0.001)
---      This accounts for float4 vs float8 precision in the index
+-- Validates: the score at each rank (1..10) in the index's result
+-- matches the score at the same rank in ground truth, within absolute
+-- tolerance (0.001).
+--
+-- Why per-rank score comparison rather than per-doc:
+--
+-- BM25 scoring can produce *tied* docs (often clusters of 3+ docs at
+-- the rank-10 boundary on real corpora). Tie-break ordering is
+-- undefined and varies between:
+--   - single-writer COPY vs concurrent INSERT (different CTID order)
+--   - BMW top-k vs sequential scan
+--   - across pgbench runs (timing-dependent ordering)
+--
+-- A naive doc-set comparison flags these tie-break differences as
+-- correctness failures. Per-rank score comparison treats them as the
+-- same result -- which they are, since BM25 ranking by score is what
+-- the index actually promises.
+--
+-- For diagnostic purposes the doc set is still reported when scores
+-- diverge or as supplementary info, but pass/fail is decided on
+-- scores.
 
 \set ON_ERROR_STOP on
 \timing on
@@ -31,40 +48,31 @@ CREATE TABLE ground_truth (
 SELECT 'Loaded ' || COUNT(DISTINCT query_id) || ' queries, ' || COUNT(*) || ' result rows' as status
 FROM ground_truth;
 
--- Validation function that handles ties properly.
--- Uses absolute tolerance (default 0.001) to account for float4 vs float8
--- precision differences between index scoring and ground truth.
--- Rank-boundary ties (missing/extra docs with scores within tolerance of
--- the rank-10 cutoff) are counted separately from real mismatches.
+-- Score-based validation: compare score at each rank between index
+-- and ground truth.
 CREATE OR REPLACE FUNCTION validate_single_query(
     p_query_id int,
     p_query_text text,
     p_tolerance float8 DEFAULT 0.001
 ) RETURNS TABLE(
     query_id int,
-    docs_match boolean,
     scores_match boolean,
-    missing_docs int,
-    extra_docs int,
+    docs_match boolean,
     max_score_diff float8,
+    worst_rank int,
     details text
 ) AS $$
 DECLARE
-    v_gt_docs int[];
-    v_tapir_docs int[];
-    v_missing int[];
-    v_extra int[];
     v_max_score_diff float8 := 0;
-    v_all_scores_match boolean := true;
+    v_worst_rank int := 0;
+    v_all_match boolean := true;
+    v_docs_match boolean;
     v_details text := '';
-    v_gt_min_score float8;
-    v_tapir_min_score float8;
-    v_boundary_tolerance float8;
-    v_real_missing int := 0;
     r record;
 BEGIN
     -- Get Tapir's top-10 results
     CREATE TEMP TABLE IF NOT EXISTS tapir_results (
+        rank int,
         doc_id int,
         score float8
     );
@@ -72,104 +80,56 @@ BEGIN
 
     INSERT INTO tapir_results
     SELECT
+        row_number() OVER (ORDER BY passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx'))::int as rank,
         passage_id,
         -(passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx'))::float8 as score
     FROM msmarco_passages
     ORDER BY passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx')
     LIMIT 10;
 
-    -- Get document sets
-    SELECT array_agg(gt.doc_id ORDER BY gt.doc_id) INTO v_gt_docs
-    FROM ground_truth gt WHERE gt.query_id = p_query_id;
-
-    SELECT array_agg(doc_id ORDER BY doc_id) INTO v_tapir_docs
-    FROM tapir_results;
-
-    -- Find missing and extra documents
-    SELECT array_agg(d) INTO v_missing
-    FROM unnest(v_gt_docs) d
-    WHERE d NOT IN (SELECT doc_id FROM tapir_results);
-
-    SELECT array_agg(d) INTO v_extra
-    FROM unnest(v_tapir_docs) d
-    WHERE d NOT IN (SELECT gt2.doc_id FROM ground_truth gt2
-                    WHERE gt2.query_id = p_query_id);
-
-    -- Compare scores for matching documents using absolute tolerance
+    -- Compare score at each rank
     FOR r IN
         SELECT
-            gt.doc_id,
+            gt.rank,
             gt.score as gt_score,
             t.score as tapir_score,
+            gt.doc_id as gt_doc,
+            t.doc_id as tapir_doc,
             ABS(gt.score - t.score) as abs_diff
         FROM ground_truth gt
-        JOIN tapir_results t ON gt.doc_id = t.doc_id
+        JOIN tapir_results t ON t.rank = gt.rank
         WHERE gt.query_id = p_query_id
+        ORDER BY gt.rank
     LOOP
         IF r.abs_diff > p_tolerance THEN
-            v_all_scores_match := false;
-            v_details := v_details || 'doc ' || r.doc_id::text ||
-                ': gt=' || ROUND(r.gt_score::numeric, 4)::text ||
-                ', tapir=' || ROUND(r.tapir_score::numeric, 4)::text ||
-                '; ';
+            v_all_match := false;
+            IF r.abs_diff > v_max_score_diff THEN
+                v_max_score_diff := r.abs_diff;
+                v_worst_rank := r.rank;
+            END IF;
+            v_details := v_details || 'rank ' || r.rank ||
+                ': gt=' || round(r.gt_score::numeric, 4)::text ||
+                ' (doc ' || r.gt_doc || '), tapir=' ||
+                round(r.tapir_score::numeric, 4)::text ||
+                ' (doc ' || r.tapir_doc || '); ';
+        ELSE
+            v_max_score_diff := GREATEST(v_max_score_diff, r.abs_diff);
         END IF;
-        v_max_score_diff := GREATEST(v_max_score_diff, r.abs_diff);
     END LOOP;
 
-    -- Check if missing/extra docs are rank-boundary ties.
-    -- If the missing doc's gt score is within tolerance of the rank-10
-    -- boundary score, it's a benign tie-break difference.
-    --
-    -- Use the LARGER of (gt.min_score, tapir.min_score) as the boundary
-    -- reference, and a slightly wider tie-break tolerance than the
-    -- per-doc score-match tolerance: at the rank-10 boundary many docs
-    -- can cluster with scores within a few thousandths, and the choice
-    -- of which subset makes the top-10 cut becomes data-dependent
-    -- (e.g., differs between single-txn COPY and concurrent-insert
-    -- builds due to doc_id assignment order). Both sides agreeing on
-    -- scores within tolerance for overlapping docs is the real
-    -- correctness signal; which arbitrary tie-break wins is not.
-    IF v_missing IS NOT NULL AND array_length(v_missing, 1) > 0 THEN
-        SELECT MIN(score) INTO v_gt_min_score FROM ground_truth
-        WHERE ground_truth.query_id = p_query_id;
-        SELECT MIN(score) INTO v_tapir_min_score FROM tapir_results;
-        v_boundary_tolerance := GREATEST(p_tolerance, 0.01);
+    -- Also check doc set as supplementary info (not part of pass/fail)
+    SELECT COALESCE(
+        (SELECT array_agg(gt.doc_id ORDER BY gt.doc_id) FROM ground_truth gt
+         WHERE gt.query_id = p_query_id) =
+        (SELECT array_agg(doc_id ORDER BY doc_id) FROM tapir_results),
+        false
+    ) INTO v_docs_match;
 
-        FOR r IN
-            SELECT d as doc_id, gt.score as gt_score
-            FROM unnest(v_missing) d
-            JOIN ground_truth gt ON gt.doc_id = d
-                AND gt.query_id = p_query_id
-        LOOP
-            -- Benign if the missing doc's gt score is within tolerance
-            -- of EITHER rank-10 boundary (gt's or tapir's) -- both
-            -- mean we're in the tied cluster at the cutoff.
-            IF ABS(r.gt_score - v_tapir_min_score) > v_boundary_tolerance
-               AND ABS(r.gt_score - v_gt_min_score) > v_boundary_tolerance
-            THEN
-                v_real_missing := v_real_missing + 1;
-            END IF;
-        END LOOP;
-    END IF;
-
-    -- Build result
     query_id := p_query_id;
-    -- docs_match is false only for non-tie missing docs
-    docs_match := (v_real_missing = 0);
-    scores_match := v_all_scores_match;
-    missing_docs := COALESCE(array_length(v_missing, 1), 0);
-    extra_docs := COALESCE(array_length(v_extra, 1), 0);
+    scores_match := v_all_match;
+    docs_match := v_docs_match;
     max_score_diff := v_max_score_diff;
-
-    IF v_missing IS NOT NULL AND array_length(v_missing, 1) > 0 THEN
-        v_details := v_details || 'Missing: ' ||
-            array_to_string(v_missing, ',') || '; ';
-    END IF;
-    IF v_extra IS NOT NULL AND array_length(v_extra, 1) > 0 THEN
-        v_details := v_details || 'Extra: ' ||
-            array_to_string(v_extra, ',') || '; ';
-    END IF;
-
+    worst_rank := v_worst_rank;
     details := CASE WHEN v_details = '' THEN 'OK'
                ELSE trim(trailing '; ' from v_details) END;
 
@@ -193,18 +153,18 @@ LATERAL validate_single_query(q.query_id, q.query_text) v;
 
 SELECT
     COUNT(*) as total_queries,
-    SUM(CASE WHEN docs_match THEN 1 ELSE 0 END) as docs_match_count,
     SUM(CASE WHEN scores_match THEN 1 ELSE 0 END) as scores_match_count,
-    round(100.0 * SUM(CASE WHEN docs_match THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0), 1) as docs_match_pct,
+    SUM(CASE WHEN docs_match THEN 1 ELSE 0 END) as docs_match_count,
     round(100.0 * SUM(CASE WHEN scores_match THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0), 1) as scores_match_pct,
+    round(100.0 * SUM(CASE WHEN docs_match THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0), 1) as docs_match_pct,
     round(MAX(max_score_diff)::numeric, 6) as worst_abs_diff
 FROM validation_results;
 
 -- Known-mismatch allowlist.
--- These queries have stable, pre-existing score discrepancies against
--- ground_truth.tsv that are tracked separately and excluded from the
--- pass/fail signal so the watchdog can still catch *new* regressions.
--- Each entry must reference a tracking issue.
+-- Entries here have stable, pre-existing per-rank score discrepancies
+-- against ground_truth.tsv that are tracked separately and excluded
+-- from the pass/fail signal so the watchdog can still catch new
+-- regressions. Each entry must reference a tracking issue.
 DROP TABLE IF EXISTS known_mismatches;
 CREATE TABLE known_mismatches (
     query_id int PRIMARY KEY,
@@ -213,38 +173,31 @@ CREATE TABLE known_mismatches (
 );
 
 INSERT INTO known_mismatches (query_id, issue, note) VALUES
-    -- See #361. doc 1838655 scores ~1.5 below ground truth on this
-    -- query; root cause not yet isolated (predates #360, likely a
-    -- tokenization or corpus-stats edge case specific to the leading
-    -- '+' / double-space pattern).
+    -- See #361. Per-rank scores diverge by ~1.5 on this query; root
+    -- cause not yet isolated (predates #360, likely a tokenization
+    -- or corpus-stats edge case specific to the leading '+' /
+    -- double-space pattern). NOT a tie-break issue -- this is a
+    -- genuine score-at-rank discrepancy.
     (158, 'https://github.com/timescale/pg_textsearch/issues/361',
-     '+how to add differnt names on labels in word: doc 1838655 score diff ~1.5'),
-    -- See #363. Concurrent-INSERT path only: doc 1956260 (rank 5 in
-    -- ground truth, score 20.297) absent from the index's top-10.
-    -- Overlapping docs match scores within 3e-6, so it's not a
-    -- scoring-formula bug -- either pgbench failed to insert that
-    -- specific row, or another concurrent-path indexing quirk is at
-    -- play. Single-txn COPY path passes this query cleanly.
-    (1267, 'https://github.com/timescale/pg_textsearch/issues/363',
-     '3 ways a log can move when bucking on side hill: doc 1956260 missing on concurrent path only');
+     '+how to add differnt names on labels in word: per-rank score diff ~1.5');
 
 -- Check for failures and report
 DO $$
 DECLARE
     v_total int;
     v_failures int;
-    v_match_pct numeric;
     v_known int;
 BEGIN
     SELECT COUNT(*) INTO v_total FROM validation_results;
 
-    -- A query fails validation if scores differ beyond tolerance
-    -- OR if docs differ for non-tie-break reasons.
-    -- Allowlisted queries (known pre-existing discrepancies) are
-    -- counted separately and do NOT trigger VALIDATION FAILED.
+    -- A query fails validation if any per-rank score differs beyond
+    -- tolerance. Doc-set differences (tied-cluster ordering) do not
+    -- fail validation as long as scores match. Allowlisted queries
+    -- (known pre-existing score discrepancies) are counted
+    -- separately and do NOT trigger VALIDATION FAILED.
     SELECT COUNT(*) INTO v_failures
     FROM validation_results vr
-    WHERE (NOT scores_match OR NOT docs_match)
+    WHERE NOT scores_match
       AND NOT EXISTS (
           SELECT 1 FROM known_mismatches km
           WHERE km.query_id = vr.query_id
@@ -253,17 +206,15 @@ BEGIN
     SELECT COUNT(*) INTO v_known
     FROM validation_results vr
     JOIN known_mismatches km ON km.query_id = vr.query_id
-    WHERE NOT scores_match OR NOT docs_match;
-
-    v_match_pct := 100.0 * (v_total - v_failures - v_known) / NULLIF(v_total, 0);
+    WHERE NOT scores_match;
 
     IF v_known > 0 THEN
         RAISE NOTICE 'VALIDATION: % allowlisted known mismatch(es) ignored (see known_mismatches table)', v_known;
     END IF;
 
     IF v_failures > 0 THEN
-        RAISE NOTICE 'VALIDATION FAILED: % of % queries failed (scores differ beyond 0.001 tolerance or non-tie doc mismatches, excluding allowlist)',
-            v_failures, v_total;
+        RAISE NOTICE 'VALIDATION FAILED: % of % queries failed (per-rank scores differ beyond % tolerance, excluding allowlist)',
+            v_failures, v_total, 0.001;
     ELSE
         RAISE NOTICE 'VALIDATION PASSED: All % queries match within tolerance (% allowlisted known mismatches)',
             v_total - v_known, v_known;
@@ -276,15 +227,14 @@ $$;
 \echo '=== Validation Details (failures only) ==='
 SELECT
     query_id,
-    docs_match,
     scores_match,
-    missing_docs,
-    extra_docs,
+    docs_match,
     round(max_score_diff::numeric, 6) as max_abs_diff,
-    left(details, 200) as details
+    worst_rank,
+    left(details, 300) as details
 FROM validation_results
-WHERE NOT docs_match OR NOT scores_match
-ORDER BY missing_docs DESC, max_score_diff DESC
+WHERE NOT scores_match
+ORDER BY max_score_diff DESC
 LIMIT 20;
 
 -- Cleanup

--- a/benchmarks/datasets/msmarco/validate_queries.sql
+++ b/benchmarks/datasets/msmarco/validate_queries.sql
@@ -79,13 +79,28 @@ BEGIN
     TRUNCATE tapir_results;
 
     INSERT INTO tapir_results
-    SELECT
-        row_number() OVER (ORDER BY passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx'))::int as rank,
-        passage_id,
-        -(passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx'))::float8 as score
-    FROM msmarco_passages
-    ORDER BY passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx')
-    LIMIT 10;
+    -- IMPORTANT: keep the LIMIT 10 in the inner subquery so it
+    -- propagates to the BM25 index scan and BMW runs with K=10.
+    -- If LIMIT 10 sits above a window function in the outer SELECT
+    -- (the previous shape), the planner can't push it past the
+    -- WindowAgg and the index scan falls back to
+    -- pg_textsearch.default_limit (1000). BMW with K=1000 reports
+    -- subtly-wrong scores for some docs on real corpora -- see
+    -- https://github.com/timescale/pg_textsearch/issues/365. That
+    -- false-positive misrouting was the source of the
+    -- "concurrent-INSERT-only" validation failures repeatedly hit
+    -- after #360 (queries 1267, 130, 1517, 222, 9351, 9340 across
+    -- runs); they're not real correctness regressions, just BMW
+    -- being asked to score 1000 docs where it should have been
+    -- asked for 10.
+    SELECT row_number() OVER ()::int as rank, t.passage_id, t.score FROM (
+        SELECT
+            passage_id,
+            -(passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx'))::float8 as score
+        FROM msmarco_passages
+        ORDER BY passage_text <@> to_bm25query(p_query_text, 'msmarco_bm25_idx')
+        LIMIT 10
+    ) t;
 
     -- Compare score at each rank
     FOR r IN
@@ -173,13 +188,15 @@ CREATE TABLE known_mismatches (
 );
 
 INSERT INTO known_mismatches (query_id, issue, note) VALUES
-    -- See #361. Per-rank scores diverge by ~1.5 on this query; root
-    -- cause not yet isolated (predates #360, likely a tokenization
-    -- or corpus-stats edge case specific to the leading '+' /
-    -- double-space pattern). NOT a tie-break issue -- this is a
-    -- genuine score-at-rank discrepancy.
+    -- See #361. Doc 1838655 contains "Adding" which stems to "ad"
+    -- on current pg17 but stemmed to "add" on the pg17 minor that
+    -- generated ground_truth_pg17.tsv in Feb 2026 (libstemmer/snowball
+    -- rule drift). The index is correct against current stemmer
+    -- rules; the committed GT file is stale. Fix is to regenerate
+    -- ground_truth_pg17.tsv against current pg17 -- when that lands,
+    -- remove this allowlist entry.
     (158, 'https://github.com/timescale/pg_textsearch/issues/361',
-     '+how to add differnt names on labels in word: per-rank score diff ~1.5');
+     '+how to add differnt names on labels in word: stale pg17 GT (stemmer drift on "Adding")');
 
 -- Check for failures and report
 DO $$


### PR DESCRIPTION
Follow-up to #360, #364. Closes #363 (was a tied-cluster + K=1000 false-positive, not a real concurrent-insert bug).

## Root cause

The validation watchdog kept producing non-deterministic concurrent-INSERT-only failures on MS MARCO (queries 1267, 130, 1517, 222, 9351, 9340 across runs), and no amount of investigation could pin them on the index. Turned out the validator itself had this shape:

```sql
SELECT
    row_number() OVER (ORDER BY content <@> q)::int as rank,
    passage_id,
    -(content <@> q)::float8 as score
FROM msmarco_passages
ORDER BY content <@> q
LIMIT 10;
```

Postgres can't push the outer `LIMIT 10` past the WindowAgg, so the BM25 index scan is asked for `pg_textsearch.default_limit` (1000) rows. BMW with K=1000 reports subtly wrong scores for some docs on real corpora — see #365 for the full reproducer and code-level hypotheses. Validation then compares the standalone-recomputed per-rank score against ground truth and sees a mismatch — for ranks whose order BMW got wrong because of the under-reported scores.

## Repro evidence

Local pg17 + concurrent-pgbench-built 8.8M MS MARCO corpus, doc 3906880 / query 1267:

|  | BMW K | BMW score | Standalone score |
|---|---|---|---|
| Query A: `SELECT ... ORDER BY <@> LIMIT 10` | 10 | **-23.0376** ✅ | 23.0376 |
| Query B: `SELECT row_number() OVER (...), ... FROM ... ORDER BY <@> LIMIT 10` | 1000 | **-20.6486** ❌ | 23.0376 |
| Query B with `SET default_limit=10` | 10 | -23.0376 ✅ | 23.0376 |

Same query, same data, same backend session. Only K differs.

## The fix

Wrap `ORDER BY ... LIMIT 10` in a subquery so the LIMIT actually reaches the index scan. `row_number()` runs on the resulting 10-row materialized output. Output identical to the buggy shape on healthy data, but K=10 is now used for the index scan, so BMW returns correct scores.

```sql
SELECT row_number() OVER ()::int as rank, t.passage_id, t.score FROM (
    SELECT passage_id, -(content <@> q)::float8 as score
    FROM msmarco_passages
    ORDER BY content <@> q
    LIMIT 10
) t;
```

Inline comment in the file explains why this shape matters.

## Verification

Local pg17 + concurrent-pgbench 8.8M corpus, run the 80 validation queries:

| | Failing queries | Worst diff |
|---|---|---|
| Before this fix | 9 (1267, 1977, 158, 1522, 222, 807, 9351, 215, 9340) | 1.46 |
| After this fix | 1 (158, allowlisted in #361) | 0.62 (the genuine stemmer-drift) |

The 8 queries that disappear were all false positives from BMW K=1000 underscoring. The single remaining failure (158) is the stale-pg17-ground-truth / Snowball stemmer drift case tracked in #361 — regenerating `ground_truth_pg17.tsv` against current pg17 will close it; that regen is running locally and will be a follow-up commit / PR.

## Allowlist update

Allowlist entry for query 158 has its note updated to reflect the now-confirmed Snowball drift root cause (was previously "root cause not yet isolated").

## Refs

- #360 — segment-sort fix; also added the validation watchdog hardening that surfaced this
- #364 — score-rank validation; tie-cluster handling
- #361 — stale ground_truth_pg17.tsv (regen pending)
- #363 — "concurrent-only failures"; now closeable as a duplicate of #365
- #365 — BMW K-dependent score under-reporting; the real underlying bug, to be fixed separately