### PR TITLE
fix(bmw): include non-pivot term max scores in block-skip safety check (#365)

### DIFF
--- a/src/scoring/bmw.c
+++ b/src/scoring/bmw.c
@@ -1528,14 +1528,49 @@ score_segment_multi_term_bmw(
 		/*
 		 * Step 3: Block-max refinement.
 		 * Check if block-level upper bound still beats threshold.
+		 *
+		 * Correctness note (#365): block_max_skip_advance() advances
+		 * a pivot term past its current block via seek_term_to_doc.
+		 * Docs in the skipped block that exist in *non-pivot* terms'
+		 * posting lists too can still be top-K candidates -- their
+		 * total true score includes non-pivot term contributions
+		 * that the pivot's block_upper alone doesn't capture.
+		 *
+		 * The safe-skip condition is therefore:
+		 *   block_upper(pivot) + max_score_sum(non-pivot) <= threshold
+		 * (an upper bound on a hypothetical doc's score using
+		 * pivot terms' actual block-max plus non-pivot terms' global
+		 * max). Only then can we skip without losing a top-K
+		 * candidate -- or under-scoring one we later see via another
+		 * pivot, after a relevant term already jumped over it.
+		 *
+		 * Previous version used block_upper alone, which let
+		 * block_max_skip_advance jump a term past a doc that other
+		 * pivot iterations would later pick up with one term missing
+		 * from its score sum. Manifests at large K (low heap
+		 * threshold) where the looser check fires for blocks whose
+		 * docs are still top-K when non-pivot contributions count.
 		 */
 		block_upper = compute_block_max_at_pivot(terms, pivot_len);
 
-		if (block_upper <= threshold)
 		{
-			block_max_skip_advance(
-					terms, term_count, pivot_len, &active_count, stats);
-			continue;
+			float4 non_pivot_max = 0.0f;
+			int	   np;
+
+			for (np = pivot_len; np < term_count; np++)
+			{
+				TpTermState *ts = terms[np];
+				if (!ts->found || ts->iter.finished)
+					continue;
+				non_pivot_max += ts->max_score;
+			}
+
+			if ((block_upper + non_pivot_max) <= threshold)
+			{
+				block_max_skip_advance(
+						terms, term_count, pivot_len, &active_count, stats);
+				continue;
+			}
 		}
 
 		if (stats)


### PR DESCRIPTION
Fixes #365.

## Bug

`score_segment_multi_term_bmw` decided whether to short-circuit a block via `block_max_skip_advance` using only the pivot terms' block-level upper bound:

```c
block_upper = compute_block_max_at_pivot(terms, pivot_len);
if (block_upper <= threshold) {
    block_max_skip_advance(...);   /* advances one pivot term past current block */
    continue;
}
```

`block_max_skip_advance` then advances one of the pivot terms past its current block. But docs in that block may also appear in *non-pivot* terms' posting lists — when a different pivot iteration later picks those docs up, `score_pivot_document` only iterates `[0..pivot_len)`, so the contribution from the term that was already advanced past is silently missing from the doc's reported score.

The looser the heap threshold (large K), the more frequently the old check fires for blocks whose docs are still top-K candidates once non-pivot contributions are included — exactly the K-dependent score under-reporting seen on the MS MARCO benchmark.

## Fix

Tighten the safe-skip condition to:

```
block_upper(pivot) + sum(max_score(non-pivot)) <= threshold
```

This is a true upper bound on any score we could later compute for a doc in the skipped block, no matter which pivot picks it up.

## Verification

**Local repro on MS MARCO (8.8M docs, pg17, concurrent inserts) — query 1267 doc 3906880**:

| K | Before | After |
|---|--------|-------|
| 10 | -23.0376 ✓ | -23.0376 ✓ |
| 1000 | -20.6486 ✗ (off by 2.39) | -23.0376 ✓ |

**Regression tests**: `bmw`, `bmw_skip_advance`, `wand`, `scoring1..6` all pass.

(`max_shared_memory` fails locally for me both with and without this patch — unrelated, looks like a DSA-state issue on my long-running pg17 cluster; will verify in CI.)

This is the v1.2 blocker called out in #365.