### PR TITLE
chore: bump version to 1.3.0-dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ ranking. (Internal name: Tapir) It implements a memtable-based architecture
 similar to LSM trees, with in-memory structures that spill to disk segments
 for scalability.
 
-**Current Version**: 1.2.0
+**Current Version**: 1.3.0-dev
 
 **Postgres Version Support**: 17, 18 (tested in CI)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXTENSION = pg_textsearch
 EXTVERSION = $(shell awk -F"'" '/default_version/ {print $$2}' pg_textsearch.control)
-DATA = sql/pg_textsearch--1.2.0.sql \
+DATA = sql/pg_textsearch--1.3.0-dev.sql \
        sql/pg_textsearch--0.0.1--0.0.2.sql \
        sql/pg_textsearch--0.0.2--0.0.3.sql \
        sql/pg_textsearch--0.0.3--0.0.4.sql \
@@ -17,7 +17,8 @@ DATA = sql/pg_textsearch--1.2.0.sql \
        sql/pg_textsearch--0.6.0--0.6.1.sql \
        sql/pg_textsearch--0.6.1--1.0.0.sql \
        sql/pg_textsearch--1.0.0--1.1.0.sql \
-       sql/pg_textsearch--1.1.0--1.2.0.sql
+       sql/pg_textsearch--1.1.0--1.2.0.sql \
+       sql/pg_textsearch--1.2.0--1.3.0-dev.sql
 
 # Source files organized by directory
 OBJS = \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Modern ranked text search for Postgres.
 - Supports partitioned tables
 - Best in class performance and scalability
 
-🚀 **Status**: v1.2.0 - Production ready.
+🚀 **Status**: v1.3.0-dev - Production ready.
 
 ![Tapir and Friends](images/tapir_and_friends_v1.2.0.png)
 

--- a/benchmarks/datasets/msmarco-v2/run_v2_benchmark.sh
+++ b/benchmarks/datasets/msmarco-v2/run_v2_benchmark.sh
@@ -63,8 +63,8 @@ check_tapir_version() {
     local ver
     ver=$(psql -t -c "SELECT default_version FROM pg_available_extensions WHERE name = 'pg_textsearch';" 2>/dev/null | tr -d ' ')
     echo "pg_textsearch version: $ver"
-    if [ "$ver" != "1.2.0" ]; then
-        echo "WARNING: Expected 1.2.0, got '$ver'"
+    if [ "$ver" != "1.3.0-dev" ]; then
+        echo "WARNING: Expected 1.3.0-dev, got '$ver'"
     fi
 }
 

--- a/pg_textsearch.control
+++ b/pg_textsearch.control
@@ -1,5 +1,5 @@
 # pg_textsearch extension
 comment = 'Full-text search with BM25 ranking'
-default_version = '1.2.0'
+default_version = '1.3.0-dev'
 module_pathname = '$libdir/pg_textsearch'
 relocatable = false

--- a/sql/pg_textsearch--1.2.0--1.3.0-dev.sql
+++ b/sql/pg_textsearch--1.2.0--1.3.0-dev.sql
@@ -1,0 +1,16 @@
+-- Upgrade from 1.2.0 to 1.3.0-dev
+
+-- Verify the library is loaded. The version-equality check lives in
+-- the main install file (pg_textsearch--<default_version>.sql); upgrade
+-- scripts must accept any loaded version because they may run as
+-- intermediate steps in a chain that ends at default_version, not at
+-- the version named in this filename.
+DO $$
+BEGIN
+    IF pg_catalog.current_setting('pg_textsearch.library_version', true)
+       IS NULL THEN
+        RAISE EXCEPTION
+            'pg_textsearch library not loaded. '
+            'Add pg_textsearch to shared_preload_libraries and restart.';
+    END IF;
+END $$;

--- a/sql/pg_textsearch--1.3.0-dev.sql
+++ b/sql/pg_textsearch--1.3.0-dev.sql
@@ -1,4 +1,4 @@
--- pg_textsearch extension version 1.2.0
+-- pg_textsearch extension version 1.3.0-dev
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_textsearch" to load this file. \quit
@@ -14,11 +14,11 @@ BEGIN
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
     END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '1.2.0' THEN
+    IF lib_ver OPERATOR(pg_catalog.<>) '1.3.0-dev' THEN
         RAISE EXCEPTION
             'pg_textsearch library version mismatch: loaded=%, expected=%. '
             'Restart the server after installing the new binary.',
-            lib_ver, '1.2.0';
+            lib_ver, '1.3.0-dev';
     END IF;
 END $$;
 

--- a/src/mod.c
+++ b/src/mod.c
@@ -33,7 +33,7 @@
 #include "scoring/bm25.h"
 
 #if PG_VERSION_NUM >= 180000
-PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.2.0");
+PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.3.0-dev");
 #else
 PG_MODULE_MAGIC;
 #endif

--- a/test/scripts/memory_accounting.sh
+++ b/test/scripts/memory_accounting.sh
@@ -66,7 +66,7 @@ EOF
     "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" "${TEST_DB}"
     "${PGBINDIR}/psql" -h "${DATA_DIR}" -p "${TEST_PORT}" \
         -d "${TEST_DB}" \
-        -c "CREATE EXTENSION pg_textsearch VERSION '1.2.0';" \
+        -c "CREATE EXTENSION pg_textsearch VERSION '1.3.0-dev';" \
         >/dev/null
 
     # Create a persistent probe table used to force DSA attachment

--- a/test/scripts/multi_index.sh
+++ b/test/scripts/multi_index.sh
@@ -94,7 +94,7 @@ EOF
         "${TEST_DB}"
 
     run_sql_quiet "CREATE EXTENSION pg_textsearch
-                       VERSION '1.2.0';"
+                       VERSION '1.3.0-dev';"
 }
 
 run_sql() {

--- a/test/scripts/segment_wal_recovery.sh
+++ b/test/scripts/segment_wal_recovery.sh
@@ -147,7 +147,7 @@ EOF
 
 "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" \
     "${TEST_DB}"
-run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.2.0';"
+run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.3.0-dev';"
 
 # -------------------------------------------------------
 # Part 1: WAL coverage check


### PR DESCRIPTION
Follow-up to the v1.2.0 release (#358), per the playbook in [RELEASING.md](RELEASING.md). Generated via:

```sh
./scripts/bump-version.sh 1.2.0 1.3.0-dev
```

Renames the main install SQL to `sql/pg_textsearch--1.3.0-dev.sql`, creates the library-version-check stub at `sql/pg_textsearch--1.2.0--1.3.0-dev.sql` (contributors append to this as features land), and bumps the version reference in `pg_textsearch.control`, `Makefile`, `src/mod.c`, `README.md`, `CLAUDE.md`, and the test/benchmark scripts that pin the expected version.

The remaining literal `1.2.0` occurrences flagged by the bump script are intentional historical references (on-disk bm25vector v1→v2 migration notes in `src/types/vector.{c,h}` and `test/sql/vector_v1_rejected.sql`, plus the legacy `1.1.0--1.2.0` upgrade SQL filename in `Makefile` DATA) and are left unchanged.

Verified locally: `make` builds clean against pg17.

Per `RELEASING.md`, this PR should land before the Wikipedia-validation PR (#372) is merged.