### PR TITLE
feat(memtable): test + benchmark scaffolding for in-memory memtable cache

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -69,6 +69,17 @@
  */
 #define TP_MIN_SPILL_PAGES 2
 
+/*
+ * Default for pg_textsearch.memory_limit (in kilobytes).  Matches the
+ * v1 in-memory memtable's 2 GiB ceiling.  Used as both the GUC default
+ * and the initial value of the backing variable so the two cannot
+ * drift.  A value of 0 means "no limit" (cache grows until backend
+ * memory is exhausted); the cache implementation will treat any
+ * non-zero value as a three-tier budget (per-index soft = limit/8,
+ * global soft = limit/2, global hard = limit).
+ */
+#define TP_DEFAULT_MEMORY_LIMIT_KB (2 * 1024 * 1024)
+
 /* Hash table sizes */
 #define TP_STRING_INTERNING_HASH_SIZE	  1024
 #define TP_POSTING_LIST_HASH_INITIAL_SIZE 32

--- a/src/mod.c
+++ b/src/mod.c
@@ -67,6 +67,15 @@ int tp_segments_per_level = TP_DEFAULT_SEGMENTS_PER_LEVEL;
  */
 bool tp_compress_segments = true;
 
+/*
+ * Memtable shared-memory cache enable flag.  Scaffolding only:
+ * this variable is registered as a GUC but not read anywhere in
+ * this build.  A subsequent change will wire it to gate the
+ * in-memory cache lookup path that sits in front of the on-disk
+ * memtable chain.
+ */
+bool tp_memtable_cache_enabled = false;
+
 /* Previous object access hook */
 static object_access_hook_type prev_object_access_hook = NULL;
 
@@ -244,6 +253,21 @@ _PG_init(void)
 			&tp_compress_segments,
 			true,		 /* default on - benchmarks show net benefit */
 			PGC_USERSET, /* Can be changed per session */
+			0,
+			NULL,
+			NULL,
+			NULL);
+
+	DefineCustomBoolVariable(
+			"pg_textsearch.memtable_cache_enabled",
+			"Enable the in-memory memtable cache for queries.",
+			"When enabled (default once the cache is implemented), "
+			"queries read from a derived shared-memory cache rather "
+			"than walking the on-disk memtable chain. The chain "
+			"remains the source of truth. No-op in this build.",
+			&tp_memtable_cache_enabled,
+			false, /* default off until cache implementation lands */
+			PGC_USERSET,
 			0,
 			NULL,
 			NULL,

--- a/src/mod.c
+++ b/src/mod.c
@@ -13,6 +13,7 @@
 #include <catalog/objectaccess.h>
 #include <catalog/pg_class_d.h>
 #include <fmgr.h>
+#include <limits.h>
 #include <miscadmin.h>
 #include <nodes/parsenodes.h>
 #include <pg_config.h>
@@ -75,6 +76,15 @@ bool tp_compress_segments = true;
  * memtable chain.
  */
 bool tp_memtable_cache_enabled = false;
+
+/*
+ * Soft+hard memory budget for the in-memory memtable cache, in
+ * kilobytes.  Restored from v1; scaffolding only in this build —
+ * no consumer reads this yet.  Default and bounds live in
+ * constants.h (TP_DEFAULT_MEMORY_LIMIT_KB) so the GUC registration
+ * and the backing-variable initializer cannot drift.
+ */
+int tp_memory_limit_kb = TP_DEFAULT_MEMORY_LIMIT_KB;
 
 /* Previous object access hook */
 static object_access_hook_type prev_object_access_hook = NULL;
@@ -273,12 +283,30 @@ _PG_init(void)
 			NULL,
 			NULL);
 
+	DefineCustomIntVariable(
+			"pg_textsearch.memory_limit",
+			"Maximum shared memory used by the in-memory memtable cache.",
+			"This setting has no effect in this build; it is "
+			"scaffolding for an upcoming change.  Once the cache "
+			"is wired up, this value will be applied as a "
+			"three-tier budget: per-index soft (limit/8) triggers "
+			"spill of that index; global soft (limit/2) evicts "
+			"the largest cache; global hard (limit) refuses new "
+			"inserts.  A value of 0 means no limit.",
+			&tp_memory_limit_kb,
+			TP_DEFAULT_MEMORY_LIMIT_KB,
+			0,
+			INT_MAX,
+			PGC_SIGHUP,
+			GUC_UNIT_KB,
+			NULL,
+			NULL,
+			NULL);
+
 	/*
-	 * Reserve the pg_textsearch.* GUC prefix.  Without this,
-	 * postgresql.conf entries for GUCs we removed in earlier
-	 * releases (e.g. pg_textsearch.memory_limit, deleted in
-	 * 1.3.0's Phase 7B) are silently ignored after upgrade
-	 * instead of producing a warning at server start.
+	 * Reserve the pg_textsearch.* GUC prefix so unknown settings
+	 * (typos, or GUCs removed in a future release) produce a
+	 * warning at server start rather than being silently ignored.
 	 */
 	MarkGUCPrefixReserved("pg_textsearch");
 

--- a/test/expected/scoring1.out
+++ b/test/expected/scoring1.out
@@ -39,7 +39,6 @@ SELECT validate_bm25_scoring('scoring1_bulk', 'content', 'scoring1_bulk_idx', 'h
 
 -- Validate index scan vs standalone scoring match for 'hello'
 SELECT validate_index_vs_standalone('scoring1_bulk', 'content', 'scoring1_bulk_idx', 'hello') as hello_modes_match;
-NOTICE:  BM25 index scan: tid=(0,1), BM25_score=-0.7549
  hello_modes_match 
 -------------------
  t
@@ -64,7 +63,6 @@ SELECT validate_bm25_scoring('scoring1_bulk', 'content', 'scoring1_bulk_idx', 'c
 
 -- Validate index scan vs standalone scoring match for 'cruel'
 SELECT validate_index_vs_standalone('scoring1_bulk', 'content', 'scoring1_bulk_idx', 'cruel') as cruel_modes_match;
-NOTICE:  BM25 index scan: tid=(0,2), BM25_score=-0.6407
  cruel_modes_match 
 -------------------
  t
@@ -104,7 +102,6 @@ SELECT validate_bm25_scoring('scoring1_incr', 'content', 'scoring1_incr_idx', 'h
 
 -- Validate index scan vs standalone scoring match for 'hello' (incremental)
 SELECT validate_index_vs_standalone('scoring1_incr', 'content', 'scoring1_incr_idx', 'hello') as hello_incr_modes_match;
-NOTICE:  BM25 index scan: tid=(0,1), BM25_score=-0.7549
  hello_incr_modes_match 
 ------------------------
  t
@@ -129,7 +126,6 @@ SELECT validate_bm25_scoring('scoring1_incr', 'content', 'scoring1_incr_idx', 'c
 
 -- Validate index scan vs standalone scoring match for 'cruel' (incremental)
 SELECT validate_index_vs_standalone('scoring1_incr', 'content', 'scoring1_incr_idx', 'cruel') as cruel_incr_modes_match;
-NOTICE:  BM25 index scan: tid=(0,2), BM25_score=-0.6407
  cruel_incr_modes_match 
 ------------------------
  t

--- a/test/sql/validation.sql
+++ b/test/sql/validation.sql
@@ -82,8 +82,19 @@ DECLARE
     v_total_docs integer;
     v_avg_doc_length float8;
     v_all_match boolean;
+    v_idx_match_10 boolean;
+    v_idx_match_100 boolean;
     v_sql text;
+    v_idx_sql text;
+    v_saved_log_scores text;
 BEGIN
+    -- Suppress per-row BM25 NOTICEs from this helper's internal index
+    -- queries so output stays stable regardless of caller's log_scores
+    -- setting, and so the cold+warm doubled execution does not duplicate
+    -- NOTICE lines.
+    v_saved_log_scores := current_setting('pg_textsearch.log_scores', true);
+    PERFORM set_config('pg_textsearch.log_scores', 'off', true);
+
     -- Step 1: Tokenize documents with proper term frequency counting
     EXECUTE format($sql$
         CREATE TEMP TABLE temp_docs ON COMMIT DROP AS
@@ -162,7 +173,8 @@ BEGIN
     $sql$, p_text_column, p_query, p_index_name, p_table_name, p_text_column);
     EXECUTE v_sql;
 
-    -- Step 7: Compute BM25 scores and compare to 4 decimal places
+    -- Step 7: Materialize SQL ground-truth scores and compare to standalone
+    CREATE TEMP TABLE temp_sql_scores ON COMMIT DROP AS
     WITH sql_scores AS (
         SELECT
             d.doc_id,
@@ -180,12 +192,84 @@ BEGIN
         LEFT JOIN temp_df df ON df.term = q.term
         GROUP BY d.doc_id, d.content
     )
+    SELECT doc_id, content, bm25_score FROM sql_scores;
+
     SELECT bool_and(
         -- Compare to 4 decimal places
         ROUND(s.bm25_score::numeric, 4) = ROUND((-t.score)::numeric, 4)
     ) INTO v_all_match
-    FROM sql_scores s
+    FROM temp_sql_scores s
     JOIN temp_tapir_scores t ON s.doc_id = t.doc_id;
+
+    -- Step 8: Exercise the index-scan path (top-k ORDER BY + LIMIT) twice
+    -- for each of two cap sizes. With memtable_cache_enabled=on, the first
+    -- run exercises the cold/lazy-build path and the second the warm cache;
+    -- both runs must match the SQL ground-truth scores from Step 7.  With
+    -- the cache disabled the two runs are trivially identical so existing
+    -- behavior is unchanged.
+    v_idx_sql := format($sql$
+        SELECT
+            %I as content,
+            (%I <@> to_bm25query(%L, %L))::float8 as score
+        FROM %I
+        WHERE %I IS NOT NULL
+        ORDER BY %I <@> to_bm25query(%L, %L)
+        LIMIT %s
+    $sql$, p_text_column, p_text_column, p_query, p_index_name,
+          p_table_name, p_text_column,
+          p_text_column, p_query, p_index_name, 10);
+
+    EXECUTE format(
+        'CREATE TEMP TABLE temp_idx_cold_10 ON COMMIT DROP AS %s', v_idx_sql);
+    EXECUTE format(
+        'CREATE TEMP TABLE temp_idx_warm_10 ON COMMIT DROP AS %s', v_idx_sql);
+
+    SELECT bool_and(
+        -- Both runs must match each other AND the ground-truth score for
+        -- the same content.
+        ROUND(c.score::numeric, 4) = ROUND(w.score::numeric, 4)
+        AND EXISTS (
+            SELECT 1 FROM temp_sql_scores s
+            WHERE s.content = c.content
+              AND ROUND(s.bm25_score::numeric, 4)
+                  = ROUND((-c.score)::numeric, 4)
+        )
+    ) INTO v_idx_match_10
+    FROM (SELECT row_number() OVER () AS rn, content, score
+          FROM temp_idx_cold_10) c
+    FULL OUTER JOIN (SELECT row_number() OVER () AS rn, content, score
+                     FROM temp_idx_warm_10) w USING (rn);
+
+    v_idx_sql := format($sql$
+        SELECT
+            %I as content,
+            (%I <@> to_bm25query(%L, %L))::float8 as score
+        FROM %I
+        WHERE %I IS NOT NULL
+        ORDER BY %I <@> to_bm25query(%L, %L)
+        LIMIT %s
+    $sql$, p_text_column, p_text_column, p_query, p_index_name,
+          p_table_name, p_text_column,
+          p_text_column, p_query, p_index_name, 100);
+
+    EXECUTE format(
+        'CREATE TEMP TABLE temp_idx_cold_100 ON COMMIT DROP AS %s', v_idx_sql);
+    EXECUTE format(
+        'CREATE TEMP TABLE temp_idx_warm_100 ON COMMIT DROP AS %s', v_idx_sql);
+
+    SELECT bool_and(
+        ROUND(c.score::numeric, 4) = ROUND(w.score::numeric, 4)
+        AND EXISTS (
+            SELECT 1 FROM temp_sql_scores s
+            WHERE s.content = c.content
+              AND ROUND(s.bm25_score::numeric, 4)
+                  = ROUND((-c.score)::numeric, 4)
+        )
+    ) INTO v_idx_match_100
+    FROM (SELECT row_number() OVER () AS rn, content, score
+          FROM temp_idx_cold_100) c
+    FULL OUTER JOIN (SELECT row_number() OVER () AS rn, content, score
+                     FROM temp_idx_warm_100) w USING (rn);
 
     -- Clean up
     DROP TABLE IF EXISTS temp_docs;
@@ -193,8 +277,19 @@ BEGIN
     DROP TABLE IF EXISTS temp_df;
     DROP TABLE IF EXISTS temp_query;
     DROP TABLE IF EXISTS temp_tapir_scores;
+    DROP TABLE IF EXISTS temp_sql_scores;
+    DROP TABLE IF EXISTS temp_idx_cold_10;
+    DROP TABLE IF EXISTS temp_idx_warm_10;
+    DROP TABLE IF EXISTS temp_idx_cold_100;
+    DROP TABLE IF EXISTS temp_idx_warm_100;
 
-    RETURN COALESCE(v_all_match, false);
+    -- Restore caller's log_scores setting
+    PERFORM set_config('pg_textsearch.log_scores',
+                      COALESCE(v_saved_log_scores, 'off'), true);
+
+    RETURN COALESCE(v_all_match, false)
+        AND COALESCE(v_idx_match_10, true)
+        AND COALESCE(v_idx_match_100, true);
 END;
 $$ LANGUAGE plpgsql;
 
@@ -336,8 +431,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Validate that index scan and standalone scoring produce identical results
--- Index scan is triggered by ORDER BY score LIMIT; standalone runs on all rows
+-- Validate that index scan and standalone scoring produce identical results.
+-- Index scan is triggered by ORDER BY score LIMIT; standalone runs on all
+-- rows.  The index query is executed TWICE so that, when the memtable cache
+-- is enabled, the first run exercises the cold/lazy-build path and the
+-- second run exercises the warm path; both runs must agree with standalone
+-- scoring and with each other.
 CREATE OR REPLACE FUNCTION validate_index_vs_standalone(
     p_table_name text,
     p_text_column text,
@@ -346,12 +445,21 @@ CREATE OR REPLACE FUNCTION validate_index_vs_standalone(
     p_limit integer DEFAULT 100
 ) RETURNS boolean AS $$
 DECLARE
-    v_all_match boolean;
+    v_cold_match boolean;
+    v_warm_match boolean;
+    v_cold_eq_warm boolean;
+    v_idx_sql text;
     v_sql text;
+    v_saved_log_scores text;
 BEGIN
-    -- Get scores via index scan mode (ORDER BY score triggers index use)
-    v_sql := format($sql$
-        CREATE TEMP TABLE idx_scan_scores ON COMMIT DROP AS
+    -- Suppress per-row BM25 NOTICEs from the helper's internal queries so
+    -- output stays stable whether the caller has set log_scores or not, and
+    -- so the cold+warm doubled execution does not duplicate NOTICE lines.
+    v_saved_log_scores := current_setting('pg_textsearch.log_scores', true);
+    PERFORM set_config('pg_textsearch.log_scores', 'off', true);
+
+    -- Index scan query reused for cold and warm runs
+    v_idx_sql := format($sql$
         SELECT
             %I as content,
             (%I <@> to_bm25query(%L, %L))::float8 as score
@@ -362,7 +470,16 @@ BEGIN
     $sql$, p_text_column, p_text_column, p_query, p_index_name,
           p_table_name, p_text_column,
           p_text_column, p_query, p_index_name, p_limit);
-    EXECUTE v_sql;
+
+    -- Cold run (first touch of the index after any prior state)
+    EXECUTE format(
+        'CREATE TEMP TABLE idx_scan_scores_cold ON COMMIT DROP AS %s',
+        v_idx_sql);
+
+    -- Warm run (re-execute identical query; exercises warm cache when enabled)
+    EXECUTE format(
+        'CREATE TEMP TABLE idx_scan_scores_warm ON COMMIT DROP AS %s',
+        v_idx_sql);
 
     -- Get scores via standalone scoring mode (no ORDER BY score)
     v_sql := format($sql$
@@ -378,21 +495,48 @@ BEGIN
           p_text_column, p_query, p_index_name);
     EXECUTE v_sql;
 
-    -- Verify all index scan results exist in standalone with matching scores
+    -- Verify cold run matches standalone
     SELECT bool_and(
         EXISTS (
             SELECT 1 FROM standalone_scores s
             WHERE s.content = i.content
               AND ROUND(s.score::numeric, 6) = ROUND(i.score::numeric, 6)
         )
-    ) INTO v_all_match
-    FROM idx_scan_scores i;
+    ) INTO v_cold_match
+    FROM idx_scan_scores_cold i;
+
+    -- Verify warm run matches standalone
+    SELECT bool_and(
+        EXISTS (
+            SELECT 1 FROM standalone_scores s
+            WHERE s.content = i.content
+              AND ROUND(s.score::numeric, 6) = ROUND(i.score::numeric, 6)
+        )
+    ) INTO v_warm_match
+    FROM idx_scan_scores_warm i;
+
+    -- Verify cold and warm produce identical ranked results
+    SELECT bool_and(
+        c.content IS NOT DISTINCT FROM w.content
+        AND ROUND(c.score::numeric, 6) = ROUND(w.score::numeric, 6)
+    ) INTO v_cold_eq_warm
+    FROM (SELECT row_number() OVER () AS rn, content, score
+          FROM idx_scan_scores_cold) c
+    FULL OUTER JOIN (SELECT row_number() OVER () AS rn, content, score
+                     FROM idx_scan_scores_warm) w USING (rn);
 
     -- Cleanup
-    DROP TABLE IF EXISTS idx_scan_scores;
+    DROP TABLE IF EXISTS idx_scan_scores_cold;
+    DROP TABLE IF EXISTS idx_scan_scores_warm;
     DROP TABLE IF EXISTS standalone_scores;
 
-    RETURN COALESCE(v_all_match, true);
+    -- Restore caller's log_scores setting
+    PERFORM set_config('pg_textsearch.log_scores',
+                      COALESCE(v_saved_log_scores, 'off'), true);
+
+    RETURN COALESCE(v_cold_match, true)
+        AND COALESCE(v_warm_match, true)
+        AND COALESCE(v_cold_eq_warm, true);
 END;
 $$ LANGUAGE plpgsql;
 

--- a/test/sql/validation.sql
+++ b/test/sql/validation.sql
@@ -91,9 +91,19 @@ BEGIN
     -- Suppress per-row BM25 NOTICEs from this helper's internal index
     -- queries so output stays stable regardless of caller's log_scores
     -- setting, and so the cold+warm doubled execution does not duplicate
-    -- NOTICE lines.
+    -- NOTICE lines.  log_scores is registered PGC_SUSET; non-superuser
+    -- callers cannot change it, so skip the set_config when it's already
+    -- off and tolerate insufficient_privilege errors otherwise.
     v_saved_log_scores := current_setting('pg_textsearch.log_scores', true);
-    PERFORM set_config('pg_textsearch.log_scores', 'off', true);
+    IF v_saved_log_scores IS DISTINCT FROM 'off' THEN
+        BEGIN
+            PERFORM set_config('pg_textsearch.log_scores', 'off', true);
+        EXCEPTION WHEN insufficient_privilege THEN
+            -- Caller lacks privilege to mutate the GUC; leave it as-is.
+            -- Restore step will also be skipped (v_saved_log_scores -> NULL).
+            v_saved_log_scores := NULL;
+        END;
+    END IF;
 
     -- Step 1: Tokenize documents with proper term frequency counting
     EXECUTE format($sql$
@@ -225,9 +235,14 @@ BEGIN
         'CREATE TEMP TABLE temp_idx_warm_10 ON COMMIT DROP AS %s', v_idx_sql);
 
     SELECT bool_and(
-        -- Both runs must match each other AND the ground-truth score for
-        -- the same content.
-        ROUND(c.score::numeric, 4) = ROUND(w.score::numeric, 4)
+        -- Cold and warm must produce the same ranked content+score; both
+        -- must match the SQL ground-truth score for that content.  Use
+        -- IS NOT DISTINCT FROM so one-sided rows (NULL from FULL OUTER
+        -- JOIN) are detected instead of being silently masked by NULL
+        -- propagation through `=`.
+        c.content IS NOT DISTINCT FROM w.content
+        AND ROUND(c.score::numeric, 4)
+            IS NOT DISTINCT FROM ROUND(w.score::numeric, 4)
         AND EXISTS (
             SELECT 1 FROM temp_sql_scores s
             WHERE s.content = c.content
@@ -235,9 +250,11 @@ BEGIN
                   = ROUND((-c.score)::numeric, 4)
         )
     ) INTO v_idx_match_10
-    FROM (SELECT row_number() OVER () AS rn, content, score
+    FROM (SELECT row_number() OVER (ORDER BY score, content) AS rn,
+                 content, score
           FROM temp_idx_cold_10) c
-    FULL OUTER JOIN (SELECT row_number() OVER () AS rn, content, score
+    FULL OUTER JOIN (SELECT row_number() OVER (ORDER BY score, content) AS rn,
+                            content, score
                      FROM temp_idx_warm_10) w USING (rn);
 
     v_idx_sql := format($sql$
@@ -258,7 +275,9 @@ BEGIN
         'CREATE TEMP TABLE temp_idx_warm_100 ON COMMIT DROP AS %s', v_idx_sql);
 
     SELECT bool_and(
-        ROUND(c.score::numeric, 4) = ROUND(w.score::numeric, 4)
+        c.content IS NOT DISTINCT FROM w.content
+        AND ROUND(c.score::numeric, 4)
+            IS NOT DISTINCT FROM ROUND(w.score::numeric, 4)
         AND EXISTS (
             SELECT 1 FROM temp_sql_scores s
             WHERE s.content = c.content
@@ -266,9 +285,11 @@ BEGIN
                   = ROUND((-c.score)::numeric, 4)
         )
     ) INTO v_idx_match_100
-    FROM (SELECT row_number() OVER () AS rn, content, score
+    FROM (SELECT row_number() OVER (ORDER BY score, content) AS rn,
+                 content, score
           FROM temp_idx_cold_100) c
-    FULL OUTER JOIN (SELECT row_number() OVER () AS rn, content, score
+    FULL OUTER JOIN (SELECT row_number() OVER (ORDER BY score, content) AS rn,
+                            content, score
                      FROM temp_idx_warm_100) w USING (rn);
 
     -- Clean up
@@ -283,9 +304,18 @@ BEGIN
     DROP TABLE IF EXISTS temp_idx_cold_100;
     DROP TABLE IF EXISTS temp_idx_warm_100;
 
-    -- Restore caller's log_scores setting
-    PERFORM set_config('pg_textsearch.log_scores',
-                      COALESCE(v_saved_log_scores, 'off'), true);
+    -- Restore caller's log_scores setting.  Skipped when v_saved_log_scores
+    -- is NULL, which means we either didn't change the GUC (already 'off')
+    -- or couldn't (non-superuser caller).
+    IF v_saved_log_scores IS NOT NULL THEN
+        BEGIN
+            PERFORM set_config('pg_textsearch.log_scores',
+                              v_saved_log_scores, true);
+        EXCEPTION WHEN insufficient_privilege THEN
+            -- Best-effort: caller lost privilege mid-call (unlikely)
+            NULL;
+        END;
+    END IF;
 
     RETURN COALESCE(v_all_match, false)
         AND COALESCE(v_idx_match_10, true)
@@ -455,8 +485,16 @@ BEGIN
     -- Suppress per-row BM25 NOTICEs from the helper's internal queries so
     -- output stays stable whether the caller has set log_scores or not, and
     -- so the cold+warm doubled execution does not duplicate NOTICE lines.
+    -- log_scores is PGC_SUSET; skip the set_config when it's already off
+    -- and tolerate insufficient_privilege for non-superuser callers.
     v_saved_log_scores := current_setting('pg_textsearch.log_scores', true);
-    PERFORM set_config('pg_textsearch.log_scores', 'off', true);
+    IF v_saved_log_scores IS DISTINCT FROM 'off' THEN
+        BEGIN
+            PERFORM set_config('pg_textsearch.log_scores', 'off', true);
+        EXCEPTION WHEN insufficient_privilege THEN
+            v_saved_log_scores := NULL;
+        END;
+    END IF;
 
     -- Index scan query reused for cold and warm runs
     v_idx_sql := format($sql$
@@ -515,14 +553,21 @@ BEGIN
     ) INTO v_warm_match
     FROM idx_scan_scores_warm i;
 
-    -- Verify cold and warm produce identical ranked results
+    -- Verify cold and warm produce identical ranked results.  Use
+    -- IS NOT DISTINCT FROM so one-sided rows from FULL OUTER JOIN fail
+    -- the comparison instead of being masked by NULL propagation, and
+    -- give row_number() a deterministic ordering so tied scores rank
+    -- the same in both subqueries.
     SELECT bool_and(
         c.content IS NOT DISTINCT FROM w.content
-        AND ROUND(c.score::numeric, 6) = ROUND(w.score::numeric, 6)
+        AND ROUND(c.score::numeric, 6)
+            IS NOT DISTINCT FROM ROUND(w.score::numeric, 6)
     ) INTO v_cold_eq_warm
-    FROM (SELECT row_number() OVER () AS rn, content, score
+    FROM (SELECT row_number() OVER (ORDER BY score, content) AS rn,
+                 content, score
           FROM idx_scan_scores_cold) c
-    FULL OUTER JOIN (SELECT row_number() OVER () AS rn, content, score
+    FULL OUTER JOIN (SELECT row_number() OVER (ORDER BY score, content) AS rn,
+                            content, score
                      FROM idx_scan_scores_warm) w USING (rn);
 
     -- Cleanup
@@ -530,9 +575,16 @@ BEGIN
     DROP TABLE IF EXISTS idx_scan_scores_warm;
     DROP TABLE IF EXISTS standalone_scores;
 
-    -- Restore caller's log_scores setting
-    PERFORM set_config('pg_textsearch.log_scores',
-                      COALESCE(v_saved_log_scores, 'off'), true);
+    -- Restore caller's log_scores setting.  Skipped when v_saved_log_scores
+    -- is NULL (we didn't change it, or couldn't as a non-superuser).
+    IF v_saved_log_scores IS NOT NULL THEN
+        BEGIN
+            PERFORM set_config('pg_textsearch.log_scores',
+                              v_saved_log_scores, true);
+        EXCEPTION WHEN insufficient_privilege THEN
+            NULL;
+        END;
+    END IF;
 
     RETURN COALESCE(v_cold_match, true)
         AND COALESCE(v_warm_match, true)


### PR DESCRIPTION
## Summary

Scaffolding-only PR. Lands the **tests, benchmarks, and GUC stubs** that the upcoming memtable shared-memory cache will be developed against. **No cache code lives in this PR** — the cache implementation will land as a follow-up that flips the no-op GUC on and wires consumers to the registered settings.

## Motivation

The v1 → v2 transition (#374, #375) moved the L0 memtable from shared memory to an on-disk paged chain. Durability and replication improved, but query latency on memtable-resident corpora regressed substantially (~15 ms vs ~2 ms on a 10k-doc memtable). The plan to recover that performance is to keep the v2 chain as the durable record and maintain a derived shared-memory cache (per-term posting lists + doc-length HTAB) that is lazily/incrementally rebuilt from the chain.

This PR's job is to make that follow-up work test-driven: every behavior the cache must preserve gets a regression test or benchmark added here first, while the no-op GUCs reserve the configuration surface.

## What's in this PR

So far (more tasks pending):

- `pg_textsearch.memtable_cache_enabled` (bool, default off, PGC_USERSET) — master switch for the cache lookup path.
- `pg_textsearch.memory_limit` (int KB, default 2 GiB, PGC_SIGHUP) — restored from v1; will gate the cache's three-tier memory budget (per-index soft = limit/8, global soft = limit/2, global hard = limit).
- `MarkGUCPrefixReserved` comment cleanup to drop the obsolete reference to the deleted-then-restored `memory_limit`.
- `TP_DEFAULT_MEMORY_LIMIT_KB` macro in `constants.h` so the GUC default and backing-variable initializer cannot drift.

Both GUCs are pure storage variables in this PR; nothing reads them.

## Still to land in this PR (TODO)

- `validate_index_vs_cache` SQL helper (mirrors existing `validate_index_vs_standalone`).
- `test/sql/cache_basic.sql` regression test.
- `test/sql/cache_spill.sql` regression test.
- `test/scripts/replication_cache.sh` standby behavior test.
- `benchmarks/sql/memtable_resident.sql` + driver script.
- CI wiring for the new shell test and benchmark.

## Out of scope

- The cache implementation itself.
- Backward compatibility with versions older than 1.3.0-dev.
