### PR TITLE
ci(sanitizer): build pg_walinspect contrib for wal_audit.sh

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yml
+++ b/.github/workflows/sanitizer-build-and-test.yml
@@ -88,11 +88,24 @@ jobs:
         ./configure --prefix=$HOME/$PG_INSTALL_DIR --enable-debug --enable-cassert \
           --with-openssl --without-readline --without-zlib --without-libxml
         make -j$(nproc)
+        # Build the pg_walinspect contrib module under the same
+        # sanitizer flags. wal_audit.sh requires it; without this
+        # CREATE EXTENSION pg_walinspect fails at test setup.
+        make -C contrib/pg_walinspect -j$(nproc)
 
     - name: Install PostgreSQL ${{ matrix.pg }}
       run: |
         cd ~/$PG_SRC_DIR
         make install
+        # On cache hits the build step is skipped, so re-run the
+        # pg_walinspect build here (no-op when already built) and
+        # always install it.
+        make -C contrib/pg_walinspect -j$(nproc)
+        make -C contrib/pg_walinspect install
+        # Fail fast if the contrib install regressed — clearer
+        # error than a CREATE EXTENSION failure 8 minutes into
+        # the test phase.
+        test -f "$HOME/$PG_INSTALL_DIR/share/extension/pg_walinspect.control"
         ~/$PG_INSTALL_DIR/bin/pg_config --version
 
     - name: Verify sanitizers are enabled


### PR DESCRIPTION
Fixes the sanitizer CI workflow, which has failed on every push to `main` since PR #374 (commit 023c3841, 2026-05-15).

## Root cause

`test/scripts/wal_audit.sh` runs `CREATE EXTENSION pg_walinspect` in its `setup_node()`. `pg_walinspect` ships as a PostgreSQL **contrib** module. The sanitizer workflow builds PostgreSQL from source under sanitizer flags but only runs `make` and `make install` on the main tree — contrib is never built or installed. PR #374 added the `wal_audit.sh` and `replication_spill_paths.sh` invocations to the sanitizer workflow without also building contrib.

Latest failure: https://github.com/timescale/pg_textsearch/actions/runs/26535398257 (both PG17.2 and PG18.1 jobs):
```
ERROR:  extension "pg_walinspect" is not available
HINT:  The extension must first be installed on the system where PostgreSQL is running.
##[error]Process completed with exit code 1.
```

## Fix

Build and install `pg_walinspect` under the same sanitizer flags:

1. Cached "Build PostgreSQL" step also runs `make -C contrib/pg_walinspect`.
2. Always-run "Install PostgreSQL" step also runs `make -C contrib/pg_walinspect && make -C contrib/pg_walinspect install` (the build is a no-op on cache hits where the .o files were already produced; the install runs unconditionally).
3. A `test -f .../pg_walinspect.control` guard fails fast if contrib install regresses, instead of waiting 8 minutes for the test phase to discover it.

Scope kept minimal — only `pg_walinspect` is required by any sanitizer-tested script (verified with `grep CREATE EXTENSION test/scripts/`). `ci.yml`'s sanitizer block does not run `wal_audit.sh` and is unaffected.

## Verification

- This branch dispatched against `sanitizer-build-and-test.yml` to confirm green: https://github.com/timescale/pg_textsearch/actions/runs/26540855884
- Cache key includes `hashFiles('.github/**')` so the workflow edit forces a cache miss on the first run with the change, exercising the new contrib build path end-to-end.