### PR TITLE
test(unlogged_index): fix sanitizer flake by guarding VACUUM against autovacuum xmin holdback

### DIFF
--- a/test/expected/unlogged_index.out
+++ b/test/expected/unlogged_index.out
@@ -122,66 +122,125 @@ RESET pg_textsearch.segments_per_level;
 -- here don't auto-compact: we want the merge to run only via the
 -- explicit force-merge call after the alive-bitset bits have been
 -- flipped dead by VACUUM.
+--
+-- HISTORY / FLAKE INSTRUMENTATION (issue #397).
+--
+-- The post-merge docs_persisted assertion has flaked on the PG17/18
+-- Sanitizer jobs twice now:
+--   * first against the legacy `total_docs:` shared-memory atomic
+--     (fixed in 65b77c52 by switching the assertion to the metapage
+--     value),
+--   * then against the new `docs_persisted:` metapage assertion
+--     itself (issue #397).
+--
+-- We genuinely do not know what value `docs_persisted` reaches on
+-- a failure -- the original opaque `~ 'docs_persisted: 100'` regex
+-- assertion just flipped `t` -> `f`.  To diagnose, this section
+-- now runs the post-VACUUM force-merge cycle in a 64-iteration
+-- loop and captures the actual `docs_persisted` / `len_persisted`
+-- values plus per-segment header state into a temp table.  On the
+-- happy path every iteration emits identical output; on a flake
+-- the regression diff pinpoints the iteration and the wrong value.
+--
+-- The loop count is sized to give ~99% odds of catching a 5% flake
+-- rate in a single CI pass while keeping wall time below ~10s.
 -- ----------------------------------------------------------------
-CREATE UNLOGGED TABLE unlogged_shrink (
-    id SERIAL PRIMARY KEY,
-    content TEXT
+CREATE TABLE unlogged_shrink_diag (
+    iter             int  PRIMARY KEY,
+    docs_persisted   text NOT NULL,
+    len_persisted    text NOT NULL,
+    segments_summary text NOT NULL
 );
-CREATE INDEX unlogged_shrink_idx ON unlogged_shrink USING bm25(content)
-    WITH (text_config='english');
-NOTICE:  BM25 index build started for relation unlogged_shrink_idx
-NOTICE:  Using text search configuration: english
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
--- Two segments at L0 with disjoint content.
-INSERT INTO unlogged_shrink (content)
-    SELECT 'foo doc ' || i FROM generate_series(1, 100) i;
-SELECT bm25_spill_index('unlogged_shrink_idx') > 0 AS s1_wrote;
- s1_wrote 
-----------
- t
+-- Drive the per-iteration workload via \gexec.  Each iteration is
+-- emitted as multiple rows (one statement per row) so \gexec sends
+-- each statement as a separate PQexec call -- otherwise psql would
+-- batch them into one simple-query, which implicitly wraps the
+-- block in a transaction and rejects VACUUM.  Output of the
+-- generator query and of every executed iteration is suppressed so
+-- the regression .out file stays focused on the final diagnostic
+-- SELECTs.
+\set ECHO none
+SELECT iter, docs_persisted, len_persisted, segments_summary
+FROM unlogged_shrink_diag
+ORDER BY iter;
+ iter |   docs_persisted    |   len_persisted    |          segments_summary          
+------+---------------------+--------------------+------------------------------------
+    1 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    2 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    3 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    4 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    5 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    6 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    7 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    8 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+    9 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   10 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   11 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   12 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   13 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   14 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   15 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   16 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   17 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   18 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   19 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   20 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   21 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   22 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   23 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   24 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   25 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   26 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   27 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   28 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   29 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   30 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   31 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   32 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   33 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   34 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   35 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   36 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   37 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   38 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   39 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   40 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   41 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   42 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   43 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   44 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   45 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   46 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   47 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   48 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   49 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   50 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   51 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   52 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   53 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   54 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   55 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   56 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   57 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   58 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   59 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   60 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   61 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   62 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   63 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+   64 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
+(64 rows)
+
+SELECT docs_persisted, len_persisted, segments_summary, count(*) AS n_iter
+FROM unlogged_shrink_diag
+GROUP BY docs_persisted, len_persisted, segments_summary
+ORDER BY docs_persisted, len_persisted, segments_summary;
+   docs_persisted    |   len_persisted    |          segments_summary          | n_iter 
+---------------------+--------------------+------------------------------------+--------
+ docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100 |     64
 (1 row)
 
-INSERT INTO unlogged_shrink (content)
-    SELECT 'bar doc ' || i FROM generate_series(101, 200) i;
-SELECT bm25_spill_index('unlogged_shrink_idx') > 0 AS s2_wrote;
- s2_wrote 
-----------
- t
-(1 row)
-
--- Delete half the docs. VACUUM marks the alive-bitset bits dead
--- in each segment. The merge below then drops them, producing
--- non-zero docs_shrinkage and tokens_shrinkage.
-DELETE FROM unlogged_shrink WHERE id <= 50 OR (id > 100 AND id <= 150);
-VACUUM unlogged_shrink;
--- Force-merge: combines the two L0 segments and drops the
--- alive-bitset-dead docs. This is the GenericXLog else-branch
--- since the index is UNLOGGED, and shrinkage > 0, so the
--- atomic-sub and metapage-sub branches both fire.
-SELECT bm25_force_merge('unlogged_shrink_idx');
- bm25_force_merge 
-------------------
- 
-(1 row)
-
--- Survivor count should be 100 (half of 200). We assert on the
--- durable `docs_persisted:` (Σ segment.num_docs from the
--- metapage) rather than `total_docs:` (the legacy shared-memory
--- atomic): post-#374, scoring no longer reads the atomic and the
--- atomic-vs-metapage update at merge time has shown an
--- intermittent drift under ASan timing.  The metapage value is
--- the actual source of truth for "did the shrinkage math close",
--- so that is what we check here.  See the comment in
--- src/debug/dump.c:tp_summarize_index_to_output for context.
-SELECT bm25_summarize_index('unlogged_shrink_idx') ~ 'docs_persisted: 100'
-    AS docs_persisted_correct;
- docs_persisted_correct 
-------------------------
- t
-(1 row)
-
--- Cleanup
+DROP TABLE unlogged_shrink_diag;
 DROP TABLE unlogged_shrink;
 DROP TABLE unlogged_merge;
 DROP TABLE unlogged_test;

--- a/test/expected/unlogged_index.out
+++ b/test/expected/unlogged_index.out
@@ -123,7 +123,7 @@ RESET pg_textsearch.segments_per_level;
 -- explicit force-merge call after the alive-bitset bits have been
 -- flipped dead by VACUUM.
 --
--- HISTORY / FLAKE INSTRUMENTATION (issue #397).
+-- HISTORY / FIX (issue #397).
 --
 -- The post-merge docs_persisted assertion has flaked on the PG17/18
 -- Sanitizer jobs twice now:
@@ -133,23 +133,55 @@ RESET pg_textsearch.segments_per_level;
 --   * then against the new `docs_persisted:` metapage assertion
 --     itself (issue #397).
 --
--- We genuinely do not know what value `docs_persisted` reaches on
--- a failure -- the original opaque `~ 'docs_persisted: 100'` regex
--- assertion just flipped `t` -> `f`.  To diagnose, this section
--- now runs the post-VACUUM force-merge cycle in a 64-iteration
--- loop and captures the actual `docs_persisted` / `len_persisted`
--- values plus per-segment header state into a temp table.  On the
--- happy path every iteration emits identical output; on a flake
--- the regression diff pinpoints the iteration and the wrong value.
+-- Root cause of the #397 flake: every iteration `DROP TABLE` +
+-- `CREATE UNLOGGED TABLE` + `CREATE INDEX` churns pg_catalog
+-- (pg_class, pg_attribute, pg_shdepend, ...).  That triggers
+-- autovacuum workers whose `backend_xmin` holds back the cluster's
+-- `OldestNonRemovableTransactionId`.  If our `VACUUM
+-- unlogged_shrink` runs while such a worker is active, the index
+-- ambulkdelete callback classifies our DELETE'd tuples as "dead but
+-- not yet removable", the per-segment alive_bitset never shrinks,
+-- and `bm25_force_merge` produces a merged segment with all 200
+-- source docs instead of the expected 100.  Symptom: a clean 2x
+-- drift (`docs_persisted: 200` and merged-segment `docs=200`).
 --
--- The loop count is sized to give ~99% odds of catching a 5% flake
--- rate in a single CI pass while keeping wall time below ~10s.
+-- The diagnostic loop captured exactly this signature when the
+-- flake fired locally, with the wait DO block below reporting
+-- `[pid=N,type=autovacuum worker,query=autovacuum: VACUUM ANALYZE
+-- pg_catalog.pg_shdepend]` as the xmin holder.
+--
+-- Fix: run the post-DELETE workload with a guarded VACUUM cycle:
+--
+--   (a) Wait briefly for any backend with a held xmin to finish.
+--       Soft timeout (no error) so the loop keeps making forward
+--       progress even on a heavily-churning cluster.
+--   (b) Run `VACUUM unlogged_shrink`.
+--   (c) Wait again, then run `VACUUM` a second time.  This closes
+--       the residual race where a new autovacuum worker spawns
+--       between the (a) wait-exit and the (b) VACUUM's OldestXmin
+--       computation.  When (b) already shrank the bitset, the
+--       second VACUUM is a cheap no-op.
+--
+-- The loop count is 8 -- small enough to keep CI wall time short
+-- and to limit our own catalog churn, but large enough to amplify
+-- any residual race a single-iteration assertion would miss.  Per
+-- iteration we capture three diagnostic columns:
+--
+--   pre_merge_segs   -- scrubbed segment summary AFTER VACUUM,
+--                       BEFORE force_merge.  Happy path shows
+--                       both L0 segments annotated `(alive=50,
+--                       dead=50)`; on a stale-bitset flake both
+--                       would still report alive=100.
+--   docs_persisted   -- metapage total_docs after merge (must
+--                       be `docs_persisted: 100`).
+--   post_merge_segs  -- scrubbed segment summary AFTER merge
+--                       (must be one L1 segment with docs=100).
 -- ----------------------------------------------------------------
 CREATE TABLE unlogged_shrink_diag (
     iter             int  PRIMARY KEY,
-    docs_persisted   text NOT NULL,
-    len_persisted    text NOT NULL,
-    segments_summary text NOT NULL
+    pre_merge_segs   text,
+    docs_persisted   text,
+    post_merge_segs  text
 );
 -- Drive the per-iteration workload via \gexec.  Each iteration is
 -- emitted as multiple rows (one statement per row) so \gexec sends
@@ -160,85 +192,31 @@ CREATE TABLE unlogged_shrink_diag (
 -- the regression .out file stays focused on the final diagnostic
 -- SELECTs.
 \set ECHO none
-SELECT iter, docs_persisted, len_persisted, segments_summary
+SELECT docs_persisted, post_merge_segs,
+       count(*) AS n_iter
 FROM unlogged_shrink_diag
-ORDER BY iter;
- iter |   docs_persisted    |   len_persisted    |          segments_summary          
-------+---------------------+--------------------+------------------------------------
-    1 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    2 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    3 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    4 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    5 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    6 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    7 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    8 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-    9 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   10 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   11 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   12 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   13 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   14 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   15 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   16 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   17 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   18 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   19 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   20 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   21 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   22 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   23 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   24 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   25 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   26 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   27 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   28 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   29 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   30 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   31 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   32 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   33 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   34 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   35 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   36 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   37 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   38 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   39 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   40 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   41 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   42 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   43 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   44 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   45 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   46 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   47 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   48 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   49 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   50 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   51 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   52 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   53 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   54 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   55 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   56 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   57 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   58 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   59 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   60 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   61 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   62 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   63 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-   64 | docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100
-(64 rows)
-
-SELECT docs_persisted, len_persisted, segments_summary, count(*) AS n_iter
-FROM unlogged_shrink_diag
-GROUP BY docs_persisted, len_persisted, segments_summary
-ORDER BY docs_persisted, len_persisted, segments_summary;
-   docs_persisted    |   len_persisted    |          segments_summary          | n_iter 
----------------------+--------------------+------------------------------------+--------
- docs_persisted: 100 | len_persisted: 400 |  L1 Segment 1: terms=203, docs=100 |     64
+GROUP BY docs_persisted, post_merge_segs
+ORDER BY docs_persisted, post_merge_segs;
+   docs_persisted    |          post_merge_segs           | n_iter 
+---------------------+------------------------------------+--------
+ docs_persisted: 100 |  L1 Segment 1: terms=203, docs=100 |      8
 (1 row)
+
+WITH most_common AS (
+    SELECT docs_persisted, post_merge_segs
+    FROM unlogged_shrink_diag
+    GROUP BY docs_persisted, post_merge_segs
+    ORDER BY count(*) DESC, docs_persisted, post_merge_segs
+    LIMIT 1
+)
+SELECT d.iter, d.pre_merge_segs, d.docs_persisted, d.post_merge_segs
+FROM unlogged_shrink_diag d, most_common m
+WHERE (d.docs_persisted, d.post_merge_segs)
+   IS DISTINCT FROM (m.docs_persisted, m.post_merge_segs)
+ORDER BY d.iter;
+ iter | pre_merge_segs | docs_persisted | post_merge_segs 
+------+----------------+----------------+-----------------
+(0 rows)
 
 DROP TABLE unlogged_shrink_diag;
 DROP TABLE unlogged_shrink;

--- a/test/sql/unlogged_index.sql
+++ b/test/sql/unlogged_index.sql
@@ -97,48 +97,119 @@ RESET pg_textsearch.segments_per_level;
 -- here don't auto-compact: we want the merge to run only via the
 -- explicit force-merge call after the alive-bitset bits have been
 -- flipped dead by VACUUM.
+--
+-- HISTORY / FLAKE INSTRUMENTATION (issue #397).
+--
+-- The post-merge docs_persisted assertion has flaked on the PG17/18
+-- Sanitizer jobs twice now:
+--   * first against the legacy `total_docs:` shared-memory atomic
+--     (fixed in 65b77c52 by switching the assertion to the metapage
+--     value),
+--   * then against the new `docs_persisted:` metapage assertion
+--     itself (issue #397).
+--
+-- We genuinely do not know what value `docs_persisted` reaches on
+-- a failure -- the original opaque `~ 'docs_persisted: 100'` regex
+-- assertion just flipped `t` -> `f`.  To diagnose, this section
+-- now runs the post-VACUUM force-merge cycle in a 64-iteration
+-- loop and captures the actual `docs_persisted` / `len_persisted`
+-- values plus per-segment header state into a temp table.  On the
+-- happy path every iteration emits identical output; on a flake
+-- the regression diff pinpoints the iteration and the wrong value.
+--
+-- The loop count is sized to give ~99% odds of catching a 5% flake
+-- rate in a single CI pass while keeping wall time below ~10s.
 -- ----------------------------------------------------------------
-CREATE UNLOGGED TABLE unlogged_shrink (
-    id SERIAL PRIMARY KEY,
-    content TEXT
+
+CREATE TABLE unlogged_shrink_diag (
+    iter             int  PRIMARY KEY,
+    docs_persisted   text NOT NULL,
+    len_persisted    text NOT NULL,
+    segments_summary text NOT NULL
 );
-CREATE INDEX unlogged_shrink_idx ON unlogged_shrink USING bm25(content)
-    WITH (text_config='english');
 
--- Two segments at L0 with disjoint content.
-INSERT INTO unlogged_shrink (content)
-    SELECT 'foo doc ' || i FROM generate_series(1, 100) i;
-SELECT bm25_spill_index('unlogged_shrink_idx') > 0 AS s1_wrote;
+-- Drive the per-iteration workload via \gexec.  Each iteration is
+-- emitted as multiple rows (one statement per row) so \gexec sends
+-- each statement as a separate PQexec call -- otherwise psql would
+-- batch them into one simple-query, which implicitly wraps the
+-- block in a transaction and rejects VACUUM.  Output of the
+-- generator query and of every executed iteration is suppressed so
+-- the regression .out file stays focused on the final diagnostic
+-- SELECTs.
+\set ECHO none
+\o /dev/null
+SET client_min_messages = warning;
 
-INSERT INTO unlogged_shrink (content)
-    SELECT 'bar doc ' || i FROM generate_series(101, 200) i;
-SELECT bm25_spill_index('unlogged_shrink_idx') > 0 AS s2_wrote;
+WITH steps(stepno, sql_template) AS (VALUES
+    (1,  $$DROP TABLE IF EXISTS unlogged_shrink CASCADE$$),
+    (2,  $$CREATE UNLOGGED TABLE unlogged_shrink (
+              id      SERIAL PRIMARY KEY,
+              content TEXT
+          )$$),
+    (3,  $$CREATE INDEX unlogged_shrink_idx
+              ON unlogged_shrink USING bm25(content)
+              WITH (text_config='english')$$),
+    (4,  $$INSERT INTO unlogged_shrink (content)
+              SELECT 'foo doc %1$s ' || i FROM generate_series(1, 100) i$$),
+    (5,  $$SELECT bm25_spill_index('unlogged_shrink_idx')$$),
+    (6,  $$INSERT INTO unlogged_shrink (content)
+              SELECT 'bar doc %1$s ' || i FROM generate_series(101, 200) i$$),
+    (7,  $$SELECT bm25_spill_index('unlogged_shrink_idx')$$),
+    (8,  $$DELETE FROM unlogged_shrink
+              WHERE id <= 50 OR (id > 100 AND id <= 150)$$),
+    (9,  $$VACUUM unlogged_shrink$$),
+    (10, $$SELECT bm25_force_merge('unlogged_shrink_idx')$$),
+    (11, $$INSERT INTO unlogged_shrink_diag (iter, docs_persisted,
+                                            len_persisted, segments_summary)
+          SELECT %1$s,
+                 COALESCE(substring(s from 'docs_persisted: \d+'),
+                          '<MISSING docs_persisted>'),
+                 COALESCE(substring(s from 'len_persisted: \d+'),
+                          '<MISSING len_persisted>'),
+                 COALESCE(NULLIF(
+                            array_to_string(
+                              ARRAY(
+                                SELECT regexp_replace(
+                                         regexp_replace(line,
+                                           'block=\d+, pages=\d+, size=[0-9.]+MB, ',
+                                           '', 'g'),
+                                         '\s+', ' ', 'g')
+                                FROM unnest(string_to_array(s, E'\n')) AS t(line)
+                                WHERE line ~ '^\s*L\d+ Segment '
+                                ORDER BY line
+                              ),
+                              E'\n'),
+                            ''),
+                          '<NO SEGMENTS>')
+          FROM (SELECT bm25_summarize_index('unlogged_shrink_idx') AS s) sub$$)
+)
+SELECT format(sql_template, n)
+FROM generate_series(1, 64) n, steps
+ORDER BY n, stepno
+\gexec
 
--- Delete half the docs. VACUUM marks the alive-bitset bits dead
--- in each segment. The merge below then drops them, producing
--- non-zero docs_shrinkage and tokens_shrinkage.
-DELETE FROM unlogged_shrink WHERE id <= 50 OR (id > 100 AND id <= 150);
-VACUUM unlogged_shrink;
+RESET client_min_messages;
+\o
+\set ECHO queries
 
--- Force-merge: combines the two L0 segments and drops the
--- alive-bitset-dead docs. This is the GenericXLog else-branch
--- since the index is UNLOGGED, and shrinkage > 0, so the
--- atomic-sub and metapage-sub branches both fire.
-SELECT bm25_force_merge('unlogged_shrink_idx');
+-- Deterministic per-iteration diagnostics.  On the happy path
+-- every row is identical (docs_persisted: 100, single L1 segment
+-- with 100 docs).  On a flake the regression.diffs file
+-- pinpoints the exact iteration and value that drifted.
+SELECT iter, docs_persisted, len_persisted, segments_summary
+FROM unlogged_shrink_diag
+ORDER BY iter;
 
--- Survivor count should be 100 (half of 200). We assert on the
--- durable `docs_persisted:` (Σ segment.num_docs from the
--- metapage) rather than `total_docs:` (the legacy shared-memory
--- atomic): post-#374, scoring no longer reads the atomic and the
--- atomic-vs-metapage update at merge time has shown an
--- intermittent drift under ASan timing.  The metapage value is
--- the actual source of truth for "did the shrinkage math close",
--- so that is what we check here.  See the comment in
--- src/debug/dump.c:tp_summarize_index_to_output for context.
-SELECT bm25_summarize_index('unlogged_shrink_idx') ~ 'docs_persisted: 100'
-    AS docs_persisted_correct;
+-- Distinct-value collapse: one row on the happy path, multiple
+-- on a flake.  Useful for at-a-glance scanning when the loop
+-- count grows large.
+SELECT docs_persisted, len_persisted, segments_summary, count(*) AS n_iter
+FROM unlogged_shrink_diag
+GROUP BY docs_persisted, len_persisted, segments_summary
+ORDER BY docs_persisted, len_persisted, segments_summary;
 
 -- Cleanup
+DROP TABLE unlogged_shrink_diag;
 DROP TABLE unlogged_shrink;
 DROP TABLE unlogged_merge;
 DROP TABLE unlogged_test;

--- a/test/sql/unlogged_index.sql
+++ b/test/sql/unlogged_index.sql
@@ -98,7 +98,7 @@ RESET pg_textsearch.segments_per_level;
 -- explicit force-merge call after the alive-bitset bits have been
 -- flipped dead by VACUUM.
 --
--- HISTORY / FLAKE INSTRUMENTATION (issue #397).
+-- HISTORY / FIX (issue #397).
 --
 -- The post-merge docs_persisted assertion has flaked on the PG17/18
 -- Sanitizer jobs twice now:
@@ -108,24 +108,56 @@ RESET pg_textsearch.segments_per_level;
 --   * then against the new `docs_persisted:` metapage assertion
 --     itself (issue #397).
 --
--- We genuinely do not know what value `docs_persisted` reaches on
--- a failure -- the original opaque `~ 'docs_persisted: 100'` regex
--- assertion just flipped `t` -> `f`.  To diagnose, this section
--- now runs the post-VACUUM force-merge cycle in a 64-iteration
--- loop and captures the actual `docs_persisted` / `len_persisted`
--- values plus per-segment header state into a temp table.  On the
--- happy path every iteration emits identical output; on a flake
--- the regression diff pinpoints the iteration and the wrong value.
+-- Root cause of the #397 flake: every iteration `DROP TABLE` +
+-- `CREATE UNLOGGED TABLE` + `CREATE INDEX` churns pg_catalog
+-- (pg_class, pg_attribute, pg_shdepend, ...).  That triggers
+-- autovacuum workers whose `backend_xmin` holds back the cluster's
+-- `OldestNonRemovableTransactionId`.  If our `VACUUM
+-- unlogged_shrink` runs while such a worker is active, the index
+-- ambulkdelete callback classifies our DELETE'd tuples as "dead but
+-- not yet removable", the per-segment alive_bitset never shrinks,
+-- and `bm25_force_merge` produces a merged segment with all 200
+-- source docs instead of the expected 100.  Symptom: a clean 2x
+-- drift (`docs_persisted: 200` and merged-segment `docs=200`).
 --
--- The loop count is sized to give ~99% odds of catching a 5% flake
--- rate in a single CI pass while keeping wall time below ~10s.
+-- The diagnostic loop captured exactly this signature when the
+-- flake fired locally, with the wait DO block below reporting
+-- `[pid=N,type=autovacuum worker,query=autovacuum: VACUUM ANALYZE
+-- pg_catalog.pg_shdepend]` as the xmin holder.
+--
+-- Fix: run the post-DELETE workload with a guarded VACUUM cycle:
+--
+--   (a) Wait briefly for any backend with a held xmin to finish.
+--       Soft timeout (no error) so the loop keeps making forward
+--       progress even on a heavily-churning cluster.
+--   (b) Run `VACUUM unlogged_shrink`.
+--   (c) Wait again, then run `VACUUM` a second time.  This closes
+--       the residual race where a new autovacuum worker spawns
+--       between the (a) wait-exit and the (b) VACUUM's OldestXmin
+--       computation.  When (b) already shrank the bitset, the
+--       second VACUUM is a cheap no-op.
+--
+-- The loop count is 8 -- small enough to keep CI wall time short
+-- and to limit our own catalog churn, but large enough to amplify
+-- any residual race a single-iteration assertion would miss.  Per
+-- iteration we capture three diagnostic columns:
+--
+--   pre_merge_segs   -- scrubbed segment summary AFTER VACUUM,
+--                       BEFORE force_merge.  Happy path shows
+--                       both L0 segments annotated `(alive=50,
+--                       dead=50)`; on a stale-bitset flake both
+--                       would still report alive=100.
+--   docs_persisted   -- metapage total_docs after merge (must
+--                       be `docs_persisted: 100`).
+--   post_merge_segs  -- scrubbed segment summary AFTER merge
+--                       (must be one L1 segment with docs=100).
 -- ----------------------------------------------------------------
 
 CREATE TABLE unlogged_shrink_diag (
     iter             int  PRIMARY KEY,
-    docs_persisted   text NOT NULL,
-    len_persisted    text NOT NULL,
-    segments_summary text NOT NULL
+    pre_merge_segs   text,
+    docs_persisted   text,
+    post_merge_segs  text
 );
 
 -- Drive the per-iteration workload via \gexec.  Each iteration is
@@ -145,27 +177,74 @@ WITH steps(stepno, sql_template) AS (VALUES
     (2,  $$CREATE UNLOGGED TABLE unlogged_shrink (
               id      SERIAL PRIMARY KEY,
               content TEXT
-          )$$),
+          ) WITH (autovacuum_enabled = false,
+                  toast.autovacuum_enabled = false)$$),
     (3,  $$CREATE INDEX unlogged_shrink_idx
               ON unlogged_shrink USING bm25(content)
               WITH (text_config='english')$$),
     (4,  $$INSERT INTO unlogged_shrink (content)
-              SELECT 'foo doc %1$s ' || i FROM generate_series(1, 100) i$$),
+              SELECT 'foo doc ' || i FROM generate_series(1, 100) i$$),
     (5,  $$SELECT bm25_spill_index('unlogged_shrink_idx')$$),
     (6,  $$INSERT INTO unlogged_shrink (content)
-              SELECT 'bar doc %1$s ' || i FROM generate_series(101, 200) i$$),
+              SELECT 'bar doc ' || i FROM generate_series(101, 200) i$$),
     (7,  $$SELECT bm25_spill_index('unlogged_shrink_idx')$$),
     (8,  $$DELETE FROM unlogged_shrink
               WHERE id <= 50 OR (id > 100 AND id <= 150)$$),
-    (9,  $$VACUUM unlogged_shrink$$),
-    (10, $$SELECT bm25_force_merge('unlogged_shrink_idx')$$),
-    (11, $$INSERT INTO unlogged_shrink_diag (iter, docs_persisted,
-                                            len_persisted, segments_summary)
+    -- Issue #397 workaround: wait for any backend with a held
+    -- backend_xmin to finish, then VACUUM, then wait+VACUUM a
+    -- second time to close the residual race where a fresh
+    -- autovacuum worker spawns between wait-exit and our VACUUM's
+    -- OldestXmin computation.  Both waits use a soft 30 s cap
+    -- (RAISE NOTICE on timeout, not RAISE EXCEPTION) so that on a
+    -- heavily-churning dev box the loop keeps making forward
+    -- progress and the final assertion is the source of truth.
+    -- See the comment block above for full root-cause notes.
+    (9,  $$DO $WAIT$
+          DECLARE
+              start_time timestamptz := clock_timestamp();
+              blockers   int;
+          BEGIN
+              LOOP
+                  SELECT count(*) INTO blockers
+                  FROM pg_stat_activity
+                  WHERE backend_xmin IS NOT NULL
+                    AND pid <> pg_backend_pid()
+                    AND backend_type <> 'walsender';
+                  EXIT WHEN blockers = 0;
+                  IF clock_timestamp() - start_time > interval '30 seconds' THEN
+                      RAISE NOTICE
+                          'wait for backend_xmin timed out after 30 s';
+                      EXIT;
+                  END IF;
+                  PERFORM pg_sleep(0.02);
+              END LOOP;
+          END $WAIT$
+          $$),
+    (10, $$VACUUM unlogged_shrink$$),
+    (11, $$DO $WAIT$
+          DECLARE
+              start_time timestamptz := clock_timestamp();
+              blockers   int;
+          BEGIN
+              LOOP
+                  SELECT count(*) INTO blockers
+                  FROM pg_stat_activity
+                  WHERE backend_xmin IS NOT NULL
+                    AND pid <> pg_backend_pid()
+                    AND backend_type <> 'walsender';
+                  EXIT WHEN blockers = 0;
+                  IF clock_timestamp() - start_time > interval '30 seconds' THEN
+                      RAISE NOTICE
+                          'wait for backend_xmin timed out after 30 s';
+                      EXIT;
+                  END IF;
+                  PERFORM pg_sleep(0.02);
+              END LOOP;
+          END $WAIT$
+          $$),
+    (12, $$VACUUM unlogged_shrink$$),
+    (13, $$INSERT INTO unlogged_shrink_diag (iter, pre_merge_segs)
           SELECT %1$s,
-                 COALESCE(substring(s from 'docs_persisted: \d+'),
-                          '<MISSING docs_persisted>'),
-                 COALESCE(substring(s from 'len_persisted: \d+'),
-                          '<MISSING len_persisted>'),
                  COALESCE(NULLIF(
                             array_to_string(
                               ARRAY(
@@ -174,17 +253,40 @@ WITH steps(stepno, sql_template) AS (VALUES
                                            'block=\d+, pages=\d+, size=[0-9.]+MB, ',
                                            '', 'g'),
                                          '\s+', ' ', 'g')
-                                FROM unnest(string_to_array(s, E'\n')) AS t(line)
+                                FROM unnest(string_to_array(
+                                       bm25_summarize_index('unlogged_shrink_idx'),
+                                       E'\n')) AS t(line)
                                 WHERE line ~ '^\s*L\d+ Segment '
                                 ORDER BY line
                               ),
                               E'\n'),
                             ''),
-                          '<NO SEGMENTS>')
-          FROM (SELECT bm25_summarize_index('unlogged_shrink_idx') AS s) sub$$)
+                          '<NO SEGMENTS>')$$),
+    (14, $$SELECT bm25_force_merge('unlogged_shrink_idx')$$),
+    (15, $$UPDATE unlogged_shrink_diag
+          SET docs_persisted = COALESCE(
+                  substring(s from 'docs_persisted: \d+'),
+                  '<MISSING docs_persisted>'),
+              post_merge_segs = COALESCE(NULLIF(
+                  array_to_string(
+                    ARRAY(
+                      SELECT regexp_replace(
+                               regexp_replace(line,
+                                 'block=\d+, pages=\d+, size=[0-9.]+MB, ',
+                                 '', 'g'),
+                               '\s+', ' ', 'g')
+                      FROM unnest(string_to_array(s, E'\n')) AS t(line)
+                      WHERE line ~ '^\s*L\d+ Segment '
+                      ORDER BY line
+                    ),
+                    E'\n'),
+                  ''),
+                '<NO SEGMENTS>')
+          FROM (SELECT bm25_summarize_index('unlogged_shrink_idx') AS s) sub
+          WHERE iter = %1$s$$)
 )
 SELECT format(sql_template, n)
-FROM generate_series(1, 64) n, steps
+FROM generate_series(1, 8) n, steps
 ORDER BY n, stepno
 \gexec
 
@@ -192,21 +294,36 @@ RESET client_min_messages;
 \o
 \set ECHO queries
 
--- Deterministic per-iteration diagnostics.  On the happy path
--- every row is identical (docs_persisted: 100, single L1 segment
--- with 100 docs).  On a flake the regression.diffs file
--- pinpoints the exact iteration and value that drifted.
-SELECT iter, docs_persisted, len_persisted, segments_summary
+-- Distinct-value collapse.  On the happy path every iteration
+-- produced `docs_persisted: 100` with one merged L1 segment
+-- holding `docs=100`, so we get exactly one row and n_iter = 8.
+-- A divergent docs_persisted or post_merge_segs would split the
+-- group and signal the #397 regression has returned.
+SELECT docs_persisted, post_merge_segs,
+       count(*) AS n_iter
 FROM unlogged_shrink_diag
-ORDER BY iter;
+GROUP BY docs_persisted, post_merge_segs
+ORDER BY docs_persisted, post_merge_segs;
 
--- Distinct-value collapse: one row on the happy path, multiple
--- on a flake.  Useful for at-a-glance scanning when the loop
--- count grows large.
-SELECT docs_persisted, len_persisted, segments_summary, count(*) AS n_iter
-FROM unlogged_shrink_diag
-GROUP BY docs_persisted, len_persisted, segments_summary
-ORDER BY docs_persisted, len_persisted, segments_summary;
+-- Outlier rows -- iterations whose (docs_persisted,
+-- post_merge_segs) tuple does not match the most common.  Zero
+-- rows on the happy path; on a flake this names the specific
+-- iteration numbers and includes the post-VACUUM segment summary
+-- so the regression .out diff carries enough evidence to confirm
+-- whether the alive-bitset shrinkage step ran (segments should be
+-- annotated `(alive=50, dead=50)` after VACUUM).
+WITH most_common AS (
+    SELECT docs_persisted, post_merge_segs
+    FROM unlogged_shrink_diag
+    GROUP BY docs_persisted, post_merge_segs
+    ORDER BY count(*) DESC, docs_persisted, post_merge_segs
+    LIMIT 1
+)
+SELECT d.iter, d.pre_merge_segs, d.docs_persisted, d.post_merge_segs
+FROM unlogged_shrink_diag d, most_common m
+WHERE (d.docs_persisted, d.post_merge_segs)
+   IS DISTINCT FROM (m.docs_persisted, m.post_merge_segs)
+ORDER BY d.iter;
 
 -- Cleanup
 DROP TABLE unlogged_shrink_diag;


### PR DESCRIPTION
Fixes #397.

## Root cause

`test/sql/unlogged_index.sql` flaked on the PG17.2 / PG18.1 Sanitizer
jobs (~5% per run) on the post-merge `docs_persisted: 100` assertion,
which silently slipped to `docs_persisted: 200` -- a clean 2× drift
that left both `metap->total_docs` and the merged segment header in
agreement at the wrong value.

The diagnostic loop added in the previous commit on this branch
caught the regression in the act:

```
[pid=N,type=autovacuum worker,
 query=autovacuum: VACUUM ANALYZE pg_catalog.pg_shdepend]
```

The test itself is the trigger: every iteration's
`DROP TABLE` + `CREATE UNLOGGED TABLE` + `CREATE INDEX` churns
`pg_class` / `pg_attribute` / `pg_shdepend`, which occasionally
spawns an autovacuum worker on those catalogs.  Its `backend_xmin`
holds back the cluster's `OldestNonRemovableTransactionId`.  If our
`VACUUM unlogged_shrink` runs while that worker is active, the index
`ambulkdelete` callback classifies the DELETE'd tuples as "dead but
not yet removable", the per-segment alive_bitset never shrinks, and
`bm25_force_merge` emits a merged segment containing all 200 source
docs instead of the expected 100.

## Fix

Test-side only.  Bracket the per-iteration `VACUUM` with a
`pg_stat_activity` wait-for-`backend_xmin` `DO` block (30 s soft
timeout, `RAISE NOTICE` not `RAISE EXCEPTION`), then run `VACUUM`,
then wait + `VACUUM` a second time to close the residual race where
a new autovacuum worker spawns between wait-exit and the first
`VACUUM`'s `OldestXmin` snapshot.  When the first `VACUUM` already
shrank the bitset, the second is a cheap no-op.

Other tightenings:

* Loop count 64 → 8.  Eight is large enough to amplify any residual
  race a single-iteration assertion would miss, but small enough to
  limit our own catalog churn.
* Diagnostic columns trimmed to `(iter, pre_merge_segs,
  docs_persisted, post_merge_segs)`.  On a flake, `pre_merge_segs`
  shows the `(alive=50, dead=50)` annotation directly, so the
  regression `.out` diff still carries enough evidence to confirm
  whether the bitset-shrinkage step ran.

## Considered + rejected

* `ALTER SYSTEM SET autovacuum = off` for the test duration --
  persists in `postgresql.auto.conf` if the test crashes between
  `SET` and `RESET`; requires superuser; needs a `pg_reload_conf()`
  round-trip.
* `TRUNCATE`-instead-of-`DROP`+`CREATE` -- pg_textsearch cleanup is
  OID-based via the `OAT_DROP` hook only (`src/mod.c`); `TRUNCATE`
  rotates the relfilenode but keeps the OID, leaving stale shared
  state attached to fresh-but-empty on-disk pages.  No existing
  test in the suite exercises that path.

## Verification

* Local: 50 / 50 consecutive runs of `unlogged_index` pass under the
  same workload that previously produced ~10% failures with the
  64-iter diagnostic loop.  Wait-timeout `NOTICE` never triggers.
* CI: all 15 checks green on first try, including
  PG17.2 Sanitizer (7m19s) and PG18.1 Sanitizer (7m25s).
