### PR TITLE
feat(metapage): backward-compatible v6 read + lazy v6→v7 upgrade (closes #383)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,7 +661,7 @@ jobs:
         pg_ctl stop -D tmp_hypertable_test/data || true
         rm -rf tmp_hypertable_test
 
-    - name: Run upgrade compat test (v6 metapage → REINDEX path)
+    - name: Run upgrade compat test (v6 metapage → in-place upgrade path)
       timeout-minutes: 5
       run: |
         export PATH="/usr/lib/postgresql/17/bin:$PATH"
@@ -671,7 +671,8 @@ jobs:
         # Download and build v1.0.0 (V4 segment + v6 metapage) WITHOUT
         # coverage flags.  Used to seed an index whose on-disk format is
         # the pre-1.3.0 layout; we then upgrade the binary and exercise
-        # the v6-metapage rejection + REINDEX-from-heap recovery path.
+        # the v6→v7 metapage in-place upgrade path plus REINDEX-from-
+        # heap as a fallback.
         curl -fsSL -o /tmp/old.tar.gz \
           "https://github.com/timescale/pg_textsearch/releases/download/v1.0.0/pg_textsearch-1.0.0.tar.gz"
         tar -xzf /tmp/old.tar.gz -C /tmp
@@ -717,40 +718,57 @@ jobs:
 
         pg_ctl start -D tmp_upgrade_cov/data -l tmp_upgrade_cov/data/logfile -w
 
-        # Exercise v6-metapage rejection + REINDEX-from-heap path.
-        # The 1.3.0 binary refuses to read v6 metapages (data-safety
-        # guarantee: pre-1.3.0 indexes may contain on-disk docid-page
-        # docs that the new binary cannot replay).  Operators must
-        # REINDEX before queries work.  This gives us coverage of
-        # both the metapage-version error path AND the
-        # build-from-heap codepath on a legacy heap.
+        # Exercise v6-metapage in-place upgrade + REINDEX path.
+        # Issue #383: the 1.3.0 binary now reads v6 metapages in place
+        # (byte-identical prefix), normalizes the new chain head/tail
+        # fields, and lazily upgrades to v7 on the first metapage
+        # write.  This step exercises the read path, the
+        # ALTER EXTENSION UPDATE, an INSERT that triggers the in-place
+        # v6→v7 upgrade via memtable_bootstrap_and_append, and finally
+        # a REINDEX (still supported as the fallback recovery path)
+        # plus VACUUM and force_merge.
         psql -h $PWD/tmp_upgrade_cov -p 55435 -d upgrade_cov << 'SQL'
         \set ON_ERROR_STOP on
 
-        -- Pre-ALTER: queries against v6 index should ERROR with
-        -- REINDEX hint (errcode 0A000 / feature_not_supported).
-        -- Capture this in a savepoint so the next statement still
-        -- runs.
-        BEGIN;
-        SAVEPOINT s;
+        -- Pre-ALTER: queries against the v6 index should succeed
+        -- (in-place compat read; no REINDEX required).
         DO $$
+        DECLARE n bigint;
         BEGIN
-          PERFORM count(*) FROM (
+          SELECT count(*) INTO n FROM (
             SELECT 1 FROM docs
             ORDER BY content <@> to_bm25query('database', 'idx')
             LIMIT 10) sub;
-          RAISE EXCEPTION 'expected v6 metapage ERROR did not fire';
-        EXCEPTION
-          WHEN feature_not_supported THEN
-            RAISE NOTICE 'PASS: v6 metapage rejected pre-REINDEX';
+          IF n = 0 THEN
+            RAISE EXCEPTION 'FAIL: pre-ALTER v6 query returned 0 rows';
+          END IF;
+          RAISE NOTICE 'PASS: pre-ALTER v6 index queryable, n=%', n;
         END $$;
-        ROLLBACK TO SAVEPOINT s;
-        COMMIT;
 
         ALTER EXTENSION pg_textsearch UPDATE;
 
-        -- REINDEX rebuilds the index from heap; new index uses
-        -- the v7 metapage and current segment format.
+        -- INSERT triggers memtable_bootstrap_and_append, which
+        -- runs tp_metapage_upgrade_to_current() inside its
+        -- GenericXLog record.  Validates that the v6→v7 in-place
+        -- upgrade landed on disk.
+        INSERT INTO docs (content) VALUES
+          ('compat upgrade insert one'),
+          ('compat upgrade insert two');
+
+        DO $$
+        DECLARE dump_text text;
+        BEGIN
+          dump_text := bm25_dump_index('idx');
+          IF dump_text NOT LIKE '%version: 7' || E'\n' || '%' THEN
+            RAISE EXCEPTION
+              'FAIL: metapage not upgraded to v7 after INSERT; '
+              'dump excerpt: %', substr(dump_text, 1, 400);
+          END IF;
+          RAISE NOTICE 'PASS: in-place v6→v7 upgrade after first write';
+        END $$;
+
+        -- REINDEX is still supported as the operator fallback;
+        -- exercise the build-from-heap codepath for coverage.
         REINDEX INDEX idx;
 
         -- V7/V5 reading post-REINDEX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,13 +159,6 @@ jobs:
           echo "✗ Multi-index tests failed"
           exit 1
         fi
-        echo "Running multi-backend reindex tests (issue #390)..."
-        if (cd test/scripts && ./multi_backend_reindex.sh); then
-          echo "✓ Multi-backend reindex tests passed"
-        else
-          echo "✗ Multi-backend reindex tests failed"
-          exit 1
-        fi
         echo "Running replication tests..."
         if (cd test/scripts && ./replication.sh); then
           echo "✓ Replication tests passed"
@@ -750,6 +743,24 @@ jobs:
             RAISE EXCEPTION 'FAIL: pre-ALTER v6 query returned 0 rows';
           END IF;
           RAISE NOTICE 'PASS: pre-ALTER v6 index queryable, n=%', n;
+        END $$;
+
+        -- Read-only queries MUST NOT upgrade the on-disk metapage
+        -- (issue #383 contract: tp_get_metapage normalizes a v6
+        -- page in its palloc'd copy but does not mutate the
+        -- buffer).  Regression here would mean the read path
+        -- accidentally emits a write.
+        DO $$
+        DECLARE dump_text text;
+        BEGIN
+          dump_text := bm25_dump_index('idx');
+          IF dump_text NOT LIKE '%version: 6' || E'\n' || '%' THEN
+            RAISE EXCEPTION
+              'FAIL: metapage upgraded by read-only queries; '
+              'expected version: 6, dump excerpt: %',
+              substr(dump_text, 1, 400);
+          END IF;
+          RAISE NOTICE 'PASS: read-only queries left v6 metapage intact';
         END $$;
 
         ALTER EXTENSION pg_textsearch UPDATE;

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -115,8 +115,12 @@ jobs:
           USING bm25 (content) WITH (text_config = 'english');
         SQL
 
-        # Compat tier (>= 0.5.1): add batch 2, spill, capture baselines
-        if false; then  # all pre-1.3.0 versions have v6 metapage → REINDEX required (Batch 1)
+        # Compat tier (>= 0.5.1): v6 metapage is read-compatible with
+        # the new binary (issue #383); ALTER EXTENSION UPDATE alone is
+        # enough — no REINDEX needed.  Add batch 2, spill, capture
+        # baselines.  Pre-v0.5.1 versions have a v5 metapage which is
+        # still REINDEX-only (legacy tier below).
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then
           psql -h /tmp -d upgrade_test << 'SQL'
           \set ON_ERROR_STOP on
 
@@ -246,7 +250,7 @@ jobs:
       run: |
         export PATH=/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH
 
-        if false; then  # all pre-1.3.0 versions have v6 metapage → REINDEX required (Batch 1)
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
           echo "=== Testing new binary reads old segments (pre-ALTER EXTENSION) ==="
           psql -h /tmp -d upgrade_test << 'SQL'
           \set ON_ERROR_STOP on
@@ -299,6 +303,32 @@ jobs:
             RAISE NOTICE 'PASS: pre-alter baselines captured (% results)', cnt;
           END $$;
 
+          -- Verify the new binary actually uses the BM25 index scan on
+          -- the v6-format index (issue #383).  A sequential scan that
+          -- fell back to standalone scoring would silently pass the
+          -- result-count / score-sign checks above, hiding a broken
+          -- v6 read path.  Grep the EXPLAIN plan for the index name.
+          DO $$
+          DECLARE
+            rec record;
+            plan_txt text := '';
+          BEGIN
+            SET LOCAL enable_seqscan = off;
+            FOR rec IN EXECUTE
+              'EXPLAIN SELECT id FROM upgrade_docs '
+              'ORDER BY content <@> to_bm25query(''database'', '
+              '''idx_upgrade_bm25'') LIMIT 5'
+            LOOP
+              plan_txt := plan_txt || rec."QUERY PLAN" || E'\n';
+            END LOOP;
+            IF plan_txt NOT LIKE '%idx_upgrade_bm25%' THEN
+              RAISE EXCEPTION
+                'FAIL: pre-ALTER plan did not use bm25 index; got: %',
+                plan_txt;
+            END IF;
+            RAISE NOTICE 'PASS: pre-ALTER plan uses BM25 index scan';
+          END $$;
+
           SELECT 'baseline_q1' AS query, * FROM baseline_q1;
           SELECT 'baseline_q2' AS query, * FROM baseline_q2;
           SELECT 'baseline_q3' AS query, * FROM baseline_q3;
@@ -311,7 +341,7 @@ jobs:
       run: |
         export PATH=/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH
 
-        if false; then  # all pre-1.3.0 versions have v6 metapage → REINDEX required (Batch 1)
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
           echo "=== Compat tier: ALTER EXTENSION UPDATE (no REINDEX) ==="
           psql -h /tmp -d upgrade_test << 'SQL'
           \set ON_ERROR_STOP on
@@ -336,7 +366,7 @@ jobs:
         EXPECTED_VERSION=$(awk -F"'" '/^[\t ]*default_version/ {print $2}' \
           pg_textsearch.control | cut -d. -f1,2)
 
-        if false; then  # all pre-1.3.0 versions have v6 metapage → REINDEX required (Batch 1)
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
           echo "=== Compat tier: multi-phase segment validation ==="
           psql -h /tmp -d upgrade_test \
             -v expected_version="$EXPECTED_VERSION" << 'SQL'
@@ -378,6 +408,138 @@ jobs:
               RAISE EXCEPTION 'FAIL: new data not searchable after merge';
             END IF;
             RAISE NOTICE 'PASS: new data searchable, id=%', rec.id;
+          END $$;
+
+          -- Phase 4a: Assert the metapage was lazily upgraded v6 -> v7
+          -- on the first write (issue #383).  The INSERTs above trigger
+          -- memtable_bootstrap_and_append (or the fragment-publish
+          -- branch), which calls tp_metapage_upgrade_to_current()
+          -- inside its GenericXLog record.  We deliberately do this
+          -- check AFTER an INSERT rather than after VACUUM because
+          -- VACUUM in v1.3 uses per-segment alive bitsets and only
+          -- writes the metapage when an actual segment merge changes
+          -- num_docs — on a fresh test fixture there may be no such
+          -- shrinkage, so VACUUM alone is not a reliable trigger.
+          DO $$
+          DECLARE dump_text text;
+          BEGIN
+            dump_text := bm25_dump_index('idx_upgrade_bm25');
+            IF dump_text NOT LIKE '%version: 7' || E'\n' || '%' THEN
+              RAISE EXCEPTION
+                'FAIL: metapage not upgraded to v7 after first write; '
+                'dump excerpt: %', substr(dump_text, 1, 400);
+            END IF;
+            RAISE NOTICE 'PASS: metapage lazily upgraded v6 -> v7 on '
+                         'first write';
+          END $$;
+
+          -- Phase 4b: UPDATE rows that came from the v6-format segment
+          -- chain.  In Postgres, UPDATE on a non-HOT-able index (bm25
+          -- never HOT-updates) is delete-old-tuple + insert-new-tuple;
+          -- the bm25 index sees both versions until VACUUM cleans up
+          -- the dead ones.  This proves that:
+          --   1. INSERTs land in the upgraded chain (issue #383).
+          --   2. MVCC visibility correctly hides the pre-UPDATE
+          --      content from queries that target the new content.
+          --   3. The post-UPDATE VACUUM marks the dead ctids in the
+          --      v6-built segments via the alive bitset and the
+          --      new content stays queryable through the update.
+          --
+          -- Pick rows from batch 1 (ids 41-120, post-DELETE) whose
+          -- original content matched 'database'.  After UPDATE their
+          -- content is 'mongodb sentinel <id>' — a deliberately unique
+          -- term so the post-UPDATE query is unambiguous.
+          UPDATE upgrade_docs
+          SET content = 'mongodb sentinel update ' || id
+          WHERE id BETWEEN 41 AND 120
+            AND content LIKE '%database%';
+
+          DO $$
+          DECLARE
+            updated_count int;
+            topk_match int;
+            top_score float8;
+          BEGIN
+            SELECT count(*) INTO updated_count FROM upgrade_docs
+            WHERE content LIKE 'mongodb sentinel update %';
+            IF updated_count = 0 THEN
+              RAISE EXCEPTION 'FAIL: UPDATE affected no rows';
+            END IF;
+
+            -- Query for the sentinel term: top-(updated_count) results
+            -- must all be the UPDATEd rows.  Pre-UPDATE content did
+            -- not contain 'sentinel' anywhere in the corpus, so any
+            -- match comes from the post-UPDATE ctid.
+            SET LOCAL enable_seqscan = off;
+            SELECT count(*) INTO topk_match FROM (
+              SELECT id, content FROM upgrade_docs
+              ORDER BY content <@>
+                to_bm25query('sentinel', 'idx_upgrade_bm25')
+              LIMIT updated_count
+            ) s WHERE s.content LIKE 'mongodb sentinel update %';
+
+            IF topk_match <> updated_count THEN
+              RAISE EXCEPTION
+                'FAIL: post-UPDATE top-% sentinel hits contained '
+                'only % UPDATEd rows (expected all %); MVCC or '
+                'index out of sync',
+                updated_count, topk_match, updated_count;
+            END IF;
+
+            -- Top score must be a real BM25 hit (strictly negative).
+            SELECT content <@>
+              to_bm25query('sentinel', 'idx_upgrade_bm25')
+            INTO top_score FROM upgrade_docs
+            ORDER BY content <@>
+              to_bm25query('sentinel', 'idx_upgrade_bm25')
+            LIMIT 1;
+            IF top_score IS NULL OR top_score >= 0 THEN
+              RAISE EXCEPTION
+                'FAIL: post-UPDATE sentinel top score not negative: %',
+                top_score;
+            END IF;
+
+            RAISE NOTICE
+              'PASS: UPDATE on v6-built segment indexed correctly '
+              '(% rows, all in top-% sentinel results, top score %)',
+              updated_count, updated_count, top_score;
+          END $$;
+
+          -- VACUUM after UPDATE: the alive bitset must mark the
+          -- pre-UPDATE ctids dead in the v6-built segments.  The
+          -- sentinel query keeps working (post-UPDATE ctids are in
+          -- a newer segment / the memtable chain, unaffected by the
+          -- bitset flip), and the original content of those rows is
+          -- gone (no row both contains 'mongodb sentinel update'
+          -- AND any of the original batch-1 terms).
+          VACUUM upgrade_docs;
+          DO $$
+          DECLARE
+            updated_count int;
+            topk_match int;
+          BEGIN
+            SELECT count(*) INTO updated_count FROM upgrade_docs
+            WHERE content LIKE 'mongodb sentinel update %';
+            SET LOCAL enable_seqscan = off;
+            SELECT count(*) INTO topk_match FROM (
+              SELECT id FROM upgrade_docs
+              ORDER BY content <@>
+                to_bm25query('sentinel', 'idx_upgrade_bm25')
+              LIMIT updated_count
+            ) s WHERE s.id IN (
+              SELECT id FROM upgrade_docs
+              WHERE content LIKE 'mongodb sentinel update %'
+            );
+            IF topk_match <> updated_count THEN
+              RAISE EXCEPTION
+                'FAIL: post-VACUUM sentinel hits = %, expected % '
+                '(alive bitset interaction broke UPDATE-inserted '
+                'ctids)', topk_match, updated_count;
+            END IF;
+            RAISE NOTICE
+              'PASS: post-VACUUM, UPDATE-inserted ctids still '
+              'queryable through the upgraded chain (% rows)',
+              updated_count;
           END $$;
 
           -- Phase 5: Version check

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -115,12 +115,19 @@ jobs:
           USING bm25 (content) WITH (text_config = 'english');
         SQL
 
-        # Compat tier (>= 0.5.1): v6 metapage is read-compatible with
-        # the new binary (issue #383); ALTER EXTENSION UPDATE alone is
+        # Compat tier (v6 metapage, read-compatible with the new
+        # binary per issue #383): ALTER EXTENSION UPDATE alone is
         # enough — no REINDEX needed.  Add batch 2, spill, capture
-        # baselines.  Pre-v0.5.1 versions have a v5 metapage which is
-        # still REINDEX-only (legacy tier below).
-        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then
+        # baselines.  Pre-v0.5.1 versions have a v5 metapage which
+        # is still REINDEX-only (legacy tier below).
+        #
+        # The regex bounds the upper end at 1.2.x deliberately:
+        # v1.3.0 is the first release that writes v7 metapages
+        # natively, so newer versions belong in their own tier
+        # (when added to the matrix they should NOT be classified
+        # as v6 compat — the in-place upgrade is a no-op and the
+        # Phase 1a "still v6" assertion would fail).
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-2]\.[0-9]+)$ ]]; then
           psql -h /tmp -d upgrade_test << 'SQL'
           \set ON_ERROR_STOP on
 
@@ -250,7 +257,7 @@ jobs:
       run: |
         export PATH=/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH
 
-        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-2]\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
           echo "=== Testing new binary reads old segments (pre-ALTER EXTENSION) ==="
           psql -h /tmp -d upgrade_test << 'SQL'
           \set ON_ERROR_STOP on
@@ -341,7 +348,7 @@ jobs:
       run: |
         export PATH=/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH
 
-        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-2]\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
           echo "=== Compat tier: ALTER EXTENSION UPDATE (no REINDEX) ==="
           psql -h /tmp -d upgrade_test << 'SQL'
           \set ON_ERROR_STOP on
@@ -366,7 +373,7 @@ jobs:
         EXPECTED_VERSION=$(awk -F"'" '/^[\t ]*default_version/ {print $2}' \
           pg_textsearch.control | cut -d. -f1,2)
 
-        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-9]+\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
+        if [[ "${{ matrix.old_version }}" =~ ^(0\.5\.1|0\.6\.[01]|1\.[0-2]\.[0-9]+)$ ]]; then  # v0.5.1+ uses metapage v6 (read-compatible via #383)
           echo "=== Compat tier: multi-phase segment validation ==="
           psql -h /tmp -d upgrade_test \
             -v expected_version="$EXPECTED_VERSION" << 'SQL'
@@ -376,6 +383,51 @@ jobs:
           SELECT validate_baseline('database',       'baseline_q1', 'post-alter q1');
           SELECT validate_baseline('search ranking', 'baseline_q2', 'post-alter q2');
           SELECT validate_baseline('optimization',   'baseline_q3', 'post-alter q3');
+
+          -- Phase 1a: After read-only queries the on-disk metapage
+          -- MUST still be v6 (issue #383 contract: tp_get_metapage
+          -- normalizes a v6 page in its palloc'd copy but does NOT
+          -- mutate the buffer).  This phase catches a regression
+          -- where the read path accidentally emits a write.
+          DO $$
+          DECLARE dump_text text;
+          BEGIN
+            dump_text := bm25_dump_index('idx_upgrade_bm25');
+            IF dump_text NOT LIKE '%version: 6' || E'\n' || '%' THEN
+              RAISE EXCEPTION
+                'FAIL: metapage upgraded after read-only queries; '
+                'expected version: 6, dump excerpt: %',
+                substr(dump_text, 1, 400);
+            END IF;
+            RAISE NOTICE 'PASS: read-only queries did not upgrade '
+                         'the v6 metapage';
+          END $$;
+
+          -- Phase 1b: A single INSERT MUST trigger the lazy v6 -> v7
+          -- upgrade via memtable_bootstrap_and_append's GenericXLog
+          -- record (src/memtable/log.c calls
+          -- tp_metapage_upgrade_to_current).  We assert here, BEFORE
+          -- Phase 2's VACUUM and Phase 3's force_merge — both of
+          -- which also independently call the upgrade helper — so
+          -- that this phase isolates the INSERT path.  A regression
+          -- that removes only the INSERT-path call would still be
+          -- caught here even if VACUUM / force_merge still upgrade.
+          INSERT INTO upgrade_docs (content)
+            VALUES ('first post-upgrade write to trigger v6 -> v7');
+
+          DO $$
+          DECLARE dump_text text;
+          BEGIN
+            dump_text := bm25_dump_index('idx_upgrade_bm25');
+            IF dump_text NOT LIKE '%version: 7' || E'\n' || '%' THEN
+              RAISE EXCEPTION
+                'FAIL: metapage not upgraded to v7 after first '
+                'INSERT (issue #383); dump excerpt: %',
+                substr(dump_text, 1, 400);
+            END IF;
+            RAISE NOTICE 'PASS: single INSERT triggered v6 -> v7 '
+                         'lazy upgrade';
+          END $$;
 
           -- Phase 2: DELETE + VACUUM — alive bitset on old-format segments
           -- Delete ~20% of rows (40 of 200, 5 per topic cluster in batch 1)
@@ -410,28 +462,11 @@ jobs:
             RAISE NOTICE 'PASS: new data searchable, id=%', rec.id;
           END $$;
 
-          -- Phase 4a: Assert the metapage was lazily upgraded v6 -> v7
-          -- on the first write (issue #383).  The INSERTs above trigger
-          -- memtable_bootstrap_and_append (or the fragment-publish
-          -- branch), which calls tp_metapage_upgrade_to_current()
-          -- inside its GenericXLog record.  We deliberately do this
-          -- check AFTER an INSERT rather than after VACUUM because
-          -- VACUUM in v1.3 uses per-segment alive bitsets and only
-          -- writes the metapage when an actual segment merge changes
-          -- num_docs — on a fresh test fixture there may be no such
-          -- shrinkage, so VACUUM alone is not a reliable trigger.
-          DO $$
-          DECLARE dump_text text;
-          BEGIN
-            dump_text := bm25_dump_index('idx_upgrade_bm25');
-            IF dump_text NOT LIKE '%version: 7' || E'\n' || '%' THEN
-              RAISE EXCEPTION
-                'FAIL: metapage not upgraded to v7 after first write; '
-                'dump excerpt: %', substr(dump_text, 1, 400);
-            END IF;
-            RAISE NOTICE 'PASS: metapage lazily upgraded v6 -> v7 on '
-                         'first write';
-          END $$;
+          -- Note: The v6 -> v7 upgrade is asserted in Phase 1b above
+          -- (in isolation from VACUUM / force_merge / additional
+          -- INSERTs).  We rely on that assertion rather than
+          -- re-checking here so that the test pinpoints the
+          -- regression (INSERT path vs. VACUUM path vs. merge path).
 
           -- Phase 4b: UPDATE rows that came from the v6-format segment
           -- chain.  In Postgres, UPDATE on a non-HOT-able index (bm25

--- a/docs/memtable_v2.md
+++ b/docs/memtable_v2.md
@@ -361,9 +361,67 @@ btree scan tolerates concurrent writers.
 
 ## Upgrade
 
-`TP_METAPAGE_VERSION` was bumped 6 → 7. v6 metapages from
-1.2.x and earlier fail at open with a clear error pointing to
-REINDEX. There is no dual-format support.
+`TP_METAPAGE_VERSION` was bumped 6 → 7 to record the on-disk
+memtable chain head/tail.  As of issue #383, v6 metapages from
+1.2.x and earlier are read in place (no REINDEX required):
+
+- `tp_get_metapage` accepts version 6 OR 7.  When the on-disk
+  metapage is v6 it normalizes `memtable_head_blkno` and
+  `memtable_tail_blkno` to `InvalidBlockNumber` in the returned
+  palloc'd copy (the v7-only bytes are zero on a v6 page, which
+  is block 0 — the metapage itself — NOT `InvalidBlockNumber`,
+  so naive direct reads would be catastrophic).
+- Direct-buffer readers in `src/memtable/log.c` and
+  `src/memtable/chain_source.c` use the version-tolerant helpers
+  `tp_metapage_read_memtable_head` / `_tail` instead of touching
+  the raw struct fields.
+- The first write to a v6 metapage (any GenericXLog mutation
+  reaching it — insert, spill finalize, vacuum stats update,
+  merge linkage) calls `tp_metapage_upgrade_to_current` on the
+  page returned by `GenericXLogRegisterBuffer`.  That helper
+  initializes the new chain fields to `InvalidBlockNumber`, bumps
+  `pd_lower` so the new 8 bytes land in the WAL image, and stamps
+  `version = TP_METAPAGE_VERSION`.  The upgrade piggybacks on the
+  surrounding WAL record — no extra WAL traffic.
+
+The v1.2.x layout kept a docid-chain head in `first_docid_page`
+(same offset as v7's `_unused_docid_page`).  v1.1.0+ drained that
+chain on clean shutdown via a `before_shmem_exit` callback;
+v0.5.1–v1.0.0 did not.  Real upgrade workflows call
+`bm25_spill_index()` before the binary swap (the documented
+procedure), which moves every memtable record into segments but,
+in the older releases, leaves the `first_docid_page` pointer
+non-Invalid because the helper never cleared it — the on-disk
+bytes survive into the v6 metapage that v1.3 inherits.
+
+`tp_get_metapage` accepts a v6 metapage with a non-Invalid
+`_unused_docid_page` and emits a one-time LOG-level message
+recording the orphaned pointer for forensics.
+`tp_metapage_upgrade_to_current` clears the field on the first
+metapage mutation, so the message fires at most once per index
+lifetime.
+
+If an operator suspects in-flight documents were lost (e.g. a
+SIGKILL'd cluster from a release without shutdown spill, with
+no prior `bm25_spill_index()` call), the LOG hint recommends
+`REINDEX INDEX <name>` to rebuild from heap.
+
+Pre-v6 metapages (v5, from v0.5.0 and earlier) still REINDEX —
+those releases predate the BMW correctness fix and we don't
+maintain a multi-version read path past one major.
+
+Validation lives in `.github/workflows/upgrade-tests.yml`.  The
+compat-tier matrix downloads every v0.5.1–v1.2.0 release tarball,
+builds and runs each release on a real cluster, ingests data,
+swaps to the current binary, runs `ALTER EXTENSION UPDATE` *without*
+`REINDEX`, and asserts (a) pre-upgrade query results match
+post-upgrade results, (b) VACUUM + alive-bitset work on old-format
+segments, (c) `bm25_force_merge` rewrites them, (d) new inserts
+land in the upgraded chain, (e) the on-disk metapage version is 7
+after the first write.  That's the source of truth for the
+contract documented above — the synthetic regression test that
+mutated a v7 metapage back to v6 in process was removed in favor
+of testing against real v1.2.x bytes.
 
 ## Removed in 1.3.0
 

--- a/docs/memtable_v2.md
+++ b/docs/memtable_v2.md
@@ -395,16 +395,32 @@ non-Invalid because the helper never cleared it — the on-disk
 bytes survive into the v6 metapage that v1.3 inherits.
 
 `tp_get_metapage` accepts a v6 metapage with a non-Invalid
-`_unused_docid_page` and emits a one-time LOG-level message
-recording the orphaned pointer for forensics.
-`tp_metapage_upgrade_to_current` clears the field on the first
-metapage mutation, so the message fires at most once per index
-lifetime.
+`_unused_docid_page` and proceeds without complaint — the read
+path stays silent.  `tp_metapage_upgrade_to_current` is where
+the policy is enforced: on the first metapage mutation, if the
+orphan pointer is set, it emits a one-time LOG-level forensic
+message ("upgrading index … orphaning a non-empty docid chain
+pointer") and clears the field as part of the same WAL record
+that bumps the version to 7.  Because the upgrade fires at most
+once per index lifetime on the primary, the LOG fires at most
+once per upgraded index too — even on read-heavy workloads and
+on hot standbys (the standby never reaches the upgrade helper;
+it merely replays the WAL record the primary emitted).
 
 If an operator suspects in-flight documents were lost (e.g. a
 SIGKILL'd cluster from a release without shutdown spill, with
-no prior `bm25_spill_index()` call), the LOG hint recommends
-`REINDEX INDEX <name>` to rebuild from heap.
+no prior `bm25_spill_index()` call), the LOG `errhint`
+recommends `REINDEX INDEX <name>` to rebuild from heap.  Indexes
+that never get a metapage mutation (a read-only-since-upgrade
+index on the primary, or any index on a never-written standby)
+stay v6 indefinitely; this is by design — the read path tolerates
+either layout, so the lazy strategy is safe at rest.
+
+To confirm an in-place upgrade has landed, call
+`bm25_dump_index('<name>')` and inspect the `Metapage Info`
+block: a post-upgrade, pre-insert resting state shows
+`version: 7` with `memtable_head_blkno: 4294967295` and
+`memtable_tail_blkno: 4294967295` (= `InvalidBlockNumber`).
 
 Pre-v6 metapages (v5, from v0.5.0 and earlier) still REINDEX —
 those releases predate the BMW correctness fix and we don't
@@ -415,13 +431,16 @@ compat-tier matrix downloads every v0.5.1–v1.2.0 release tarball,
 builds and runs each release on a real cluster, ingests data,
 swaps to the current binary, runs `ALTER EXTENSION UPDATE` *without*
 `REINDEX`, and asserts (a) pre-upgrade query results match
-post-upgrade results, (b) VACUUM + alive-bitset work on old-format
-segments, (c) `bm25_force_merge` rewrites them, (d) new inserts
-land in the upgraded chain, (e) the on-disk metapage version is 7
-after the first write.  That's the source of truth for the
-contract documented above — the synthetic regression test that
-mutated a v7 metapage back to v6 in process was removed in favor
-of testing against real v1.2.x bytes.
+post-upgrade results, (b) read-only queries leave the metapage
+at v6 (the read path is non-mutating), (c) a single INSERT
+triggers v6 → v7 in isolation (before any VACUUM / merge /
+additional inserts), (d) VACUUM + alive-bitset work on old-format
+segments, (e) `bm25_force_merge` rewrites them, (f) post-upgrade
+UPDATE + sentinel-term query proves new content lands in the
+upgraded chain and MVCC stays consistent.  That's the source of
+truth for the contract documented above — the synthetic
+regression test that mutated a v7 metapage back to v6 in process
+was removed in favor of testing against real v1.2.x bytes.
 
 ## Removed in 1.3.0
 

--- a/src/access/build.c
+++ b/src/access/build.c
@@ -417,8 +417,14 @@ tp_truncate_dead_pages(Relation index)
 	 * never truncated.  Each link is read under SHARED buffer
 	 * lock; the per-index LWLock held by the caller (EXCLUSIVE)
 	 * ensures no concurrent extension races us.
+	 *
+	 * Use tp_metapage_read_memtable_head() (not a direct struct
+	 * read) so a v6 metapage left over from a v1.2.x upgrade
+	 * (issue #383) returns InvalidBlockNumber instead of the
+	 * raw zero bytes at that offset — block 0 is the metapage
+	 * itself, and walking it would fail the magic check below.
 	 */
-	chain_blk = metap->memtable_head_blkno;
+	chain_blk = tp_metapage_read_memtable_head(metapage);
 	while (chain_blk != InvalidBlockNumber)
 	{
 		Buffer				  cbuf;

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -267,7 +267,9 @@ tp_apply_vacuum_shrinkage(
 
 	xlog_state = GenericXLogStart(index);
 	mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);
-	mp		   = (TpIndexMetaPage)PageGetContents(mpage);
+	/* v6 -> v7 in-place upgrade (issue #383). */
+	tp_metapage_upgrade_to_current(mpage);
+	mp = (TpIndexMetaPage)PageGetContents(mpage);
 
 	mp->total_docs = (mp->total_docs >= docs_shrinkage)
 						   ? mp->total_docs - docs_shrinkage
@@ -653,7 +655,9 @@ tp_vacuum_replace_segment(
 
 		xlog_state = GenericXLogStart(index);
 		meta_copy  = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
-		meta_ptr   = (TpIndexMetaPage)PageGetContents(meta_copy);
+		/* v6 -> v7 in-place upgrade (issue #383). */
+		tp_metapage_upgrade_to_current(meta_copy);
+		meta_ptr = (TpIndexMetaPage)PageGetContents(meta_copy);
 
 		/* Set new segment's next_segment and level */
 		if (new_root != InvalidBlockNumber)

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -268,7 +268,7 @@ tp_apply_vacuum_shrinkage(
 	xlog_state = GenericXLogStart(index);
 	mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);
 	/* v6 -> v7 in-place upgrade (issue #383). */
-	tp_metapage_upgrade_to_current(mpage);
+	tp_metapage_upgrade_to_current(index, mpage);
 	mp = (TpIndexMetaPage)PageGetContents(mpage);
 
 	mp->total_docs = (mp->total_docs >= docs_shrinkage)
@@ -656,7 +656,7 @@ tp_vacuum_replace_segment(
 		xlog_state = GenericXLogStart(index);
 		meta_copy  = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
 		/* v6 -> v7 in-place upgrade (issue #383). */
-		tp_metapage_upgrade_to_current(meta_copy);
+		tp_metapage_upgrade_to_current(index, meta_copy);
 		meta_ptr = (TpIndexMetaPage)PageGetContents(meta_copy);
 
 		/* Set new segment's next_segment and level */

--- a/src/constants.h
+++ b/src/constants.h
@@ -22,15 +22,36 @@
  * Each page type has its own version for independent evolution.
  */
 /*
- * v7: on-disk memtable redesign (issue #374).  Adds
+ * v7: on-disk memtable redesign (issue #374).  Appends
  * memtable_head_blkno and memtable_tail_blkno at the end of
- * TpIndexMetaPageData and removes the docid recovery pages.
- * v6 indexes may contain unspilled documents in the now-deleted
- * docid pages, so we reject v6 at metapage open with a REINDEX
- * hint instead of upgrading lazily and risking silent data loss.
+ * TpIndexMetaPageData and retires the docid recovery pages.
+ *
+ * v6 is read-compatible (issue #383): tp_get_metapage accepts a
+ * v6 layout in place and normalizes the missing chain head/tail
+ * to InvalidBlockNumber.  The first metapage mutation upgrades
+ * the on-disk page to v7 atomically inside the surrounding
+ * GenericXLog record (no extra WAL).
+ *
+ * A v6 index's only source of pending (unspilled) data is the
+ * retired docid recovery chain anchored by
+ * (now-renamed) _unused_docid_page: a v1.2.x clean shutdown
+ * always spilled and cleared this pointer, but a SIGKILL'd
+ * v1.2.x cluster could leave a non-Invalid pointer to ctids
+ * that the v7 binary cannot re-tokenize.  tp_get_metapage
+ * refuses to open such an index with a hint to either re-run
+ * the v1.2.x binary to finish its recovery + spill, or to
+ * REINDEX.  Indexes from a clean v1.2.x shutdown have
+ * _unused_docid_page == InvalidBlockNumber and upgrade with
+ * no operator intervention.
+ *
+ * v5 and below are not read-compatible.  v5 -> v6 changed BMW
+ * scoring semantics with no on-disk-struct change, but
+ * pre-v0.5.0 indexes carry an older segment format the v7
+ * binary cannot read; those continue to require REINDEX.
  */
-#define TP_METAPAGE_VERSION	  7
-#define TP_PAGE_INDEX_VERSION 1 /* Page index format version */
+#define TP_METAPAGE_VERSION	   7
+#define TP_METAPAGE_VERSION_V6 6 /* read-compatible (issue #383) */
+#define TP_PAGE_INDEX_VERSION  1 /* Page index format version */
 /* Initial version (introduced with the on-disk memtable design) */
 #define TP_MEMTABLE_PAGE_VERSION 1
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -37,12 +37,14 @@
  * (now-renamed) _unused_docid_page: a v1.2.x clean shutdown
  * always spilled and cleared this pointer, but a SIGKILL'd
  * v1.2.x cluster could leave a non-Invalid pointer to ctids
- * that the v7 binary cannot re-tokenize.  tp_get_metapage
- * refuses to open such an index with a hint to either re-run
- * the v1.2.x binary to finish its recovery + spill, or to
- * REINDEX.  Indexes from a clean v1.2.x shutdown have
- * _unused_docid_page == InvalidBlockNumber and upgrade with
- * no operator intervention.
+ * that the v7 binary cannot re-tokenize.  Such an index opens
+ * fine; the first metapage mutation (via
+ * tp_metapage_upgrade_to_current) emits a LOG-level forensic
+ * message recording the orphaned pointer and then clears it.
+ * Operators who suspect lost in-flight documents from a SIGKILL
+ * should REINDEX.  Indexes from a clean v1.2.x shutdown have
+ * _unused_docid_page == InvalidBlockNumber and upgrade silently
+ * with no operator intervention.
  *
  * v5 and below are not read-compatible.  v5 -> v6 changed BMW
  * scoring semantics with no on-disk-struct change, but

--- a/src/index/metapage.c
+++ b/src/index/metapage.c
@@ -9,6 +9,7 @@
  */
 #include <postgres.h>
 
+#include <miscadmin.h>
 #include <storage/bufmgr.h>
 #include <storage/bufpage.h>
 #include <utils/rel.h>
@@ -123,13 +124,16 @@ tp_get_metapage(Relation index)
 	 * the surrounding GenericXLog record.
 	 *
 	 * v6 with a non-Invalid _unused_docid_page (formerly
-	 * first_docid_page) is the one shape we cannot silently
-	 * upgrade: it indicates a v1.2.x cluster that didn't get a
-	 * chance to spill before binary swap (e.g. SIGKILL'd, then
-	 * the operator replaced the binaries without restarting
-	 * v1.2.x to drain the docid chain).  The v7 binary has no
-	 * docid-replay path, so accepting the index would silently
-	 * lose those pending documents.  Refuse with a clear hint.
+	 * first_docid_page) is also accepted here.  It indicates
+	 * either (a) the operator called bm25_spill_index() before
+	 * the binary swap and the pointer is stale bookkeeping
+	 * safe to orphan, or (b) v1.2.x was SIGKILL'd with
+	 * in-flight documents in the chain and those documents
+	 * are now lost.  We cannot distinguish those cases from
+	 * the on-disk bytes alone, so we log a LOG-level forensic
+	 * message from the upgrade helper (which fires once, on
+	 * first write) and proceed.  Operators who suspect lost
+	 * documents should REINDEX.
 	 *
 	 * v5 and earlier are not read-compatible and require
 	 * REINDEX as before.
@@ -153,55 +157,15 @@ tp_get_metapage(Relation index)
 						 RelationGetRelationName(index))));
 	}
 
-	if (metap->version == TP_METAPAGE_VERSION_V6 &&
-		BlockNumberIsValid(metap->_unused_docid_page))
-	{
-		/*
-		 * v1.2.x and earlier maintained a "docid chain" of
-		 * pages anchored by first_docid_page.  Inserts wrote
-		 * ctids there before the in-memory memtable; on a clean
-		 * restart the chain was replayed to re-tokenize pending
-		 * documents from the heap.  v1.3 (issue #374) replaced
-		 * the docid chain with an on-disk memtable, so the
-		 * pointer's target is now meaningless.
-		 *
-		 * If the pointer is non-Invalid, the operator either
-		 *   - called bm25_spill_index() before the binary swap
-		 *     (data is in segments; the chain is stale
-		 *     bookkeeping safe to orphan), or
-		 *   - did not give v1.2.x a chance to drain (in-flight
-		 *     documents in the chain are lost — they were
-		 *     scheduled for re-tokenization that v1.3 cannot
-		 *     perform).
-		 *
-		 * We cannot distinguish those cases from the on-disk
-		 * bytes alone.  Log a one-time LOG-level message
-		 * recording the orphaned pointer for forensics and
-		 * proceed; the upgrade helper clears the pointer on
-		 * the first metapage mutation so this fires at most
-		 * once per index lifetime.  Operators who suspect lost
-		 * documents should REINDEX.
-		 */
-		ereport(LOG,
-				(errmsg("pg_textsearch: index \"%s\" was upgraded "
-						"from a pre-v1.3 metapage (v6) with a "
-						"non-empty docid chain pointer "
-						"(first_docid_page = %u); orphaning the "
-						"chain",
-						RelationGetRelationName(index),
-						metap->_unused_docid_page),
-				 errdetail(
-						 "The docid chain was a v1.2.x mechanism for "
-						 "replaying in-flight documents from heap on "
-						 "restart.  v1.3 has no equivalent.  If you "
-						 "did not call bm25_spill_index() on this "
-						 "index before swapping binaries, some "
-						 "recently-inserted documents may be missing "
-						 "from query results."),
-				 errhint("If query results look incomplete, "
-						 "REINDEX INDEX %s to rebuild from heap.",
-						 RelationGetRelationName(index))));
-	}
+	/*
+	 * Note: a v6 metapage with a non-Invalid _unused_docid_page
+	 * is accepted here as well — the operator-visible LOG fires
+	 * once, from tp_metapage_upgrade_to_current() on the first
+	 * write, at the point we actually orphan the pointer.  See
+	 * the rationale block in that function.  Emitting the LOG
+	 * here would spam (this function is on the hot path; the
+	 * upgrade fires at most once per index lifetime).
+	 */
 
 	/*
 	 * Copy metapage data to avoid buffer issues.  On v6 we only
@@ -262,11 +226,12 @@ tp_metapage_read_memtable_tail(Page page)
  * caller contract.  No-op when the page is already v7.
  */
 void
-tp_metapage_upgrade_to_current(Page page)
+tp_metapage_upgrade_to_current(Relation index, Page page)
 {
 	TpIndexMetaPage metap;
 	PageHeader		phdr;
 	Size			v7_pd_lower;
+	BlockNumber		orphan_docid_page;
 
 	metap = (TpIndexMetaPage)PageGetContents(page);
 
@@ -276,9 +241,8 @@ tp_metapage_upgrade_to_current(Page page)
 	/*
 	 * tp_get_metapage() is the only legitimate way to first
 	 * observe the on-disk version, and it has already filtered
-	 * out anything besides v6/v7 and refused v6 indexes with
-	 * unspilled docid pages.  Reaching this function with any
-	 * other version means a caller mutated the metapage
+	 * out anything besides v6/v7.  Reaching this function with
+	 * any other version means a caller mutated the metapage
 	 * without going through the open path — refuse to stamp
 	 * an unknown layout as v7, which would silently corrupt
 	 * the page (the new chain head/tail fields may land on
@@ -294,17 +258,65 @@ tp_metapage_upgrade_to_current(Page page)
 						 "via tp_get_metapage() before calling "
 						 "tp_metapage_upgrade_to_current().")));
 
+	orphan_docid_page = metap->_unused_docid_page;
+
 	metap->memtable_head_blkno = InvalidBlockNumber;
 	metap->memtable_tail_blkno = InvalidBlockNumber;
+
 	/*
-	 * Orphan any stale v1.2.x docid-chain pointer.  See the
-	 * matching ereport(LOG, ...) in tp_get_metapage() for why
-	 * this field can be non-Invalid on an upgraded v6 page.
-	 * Clearing it here ensures the LOG message fires at most
-	 * once per index lifetime (after the first metapage
-	 * mutation), instead of once per backend that opens the
-	 * index.
+	 * Orphan any stale v1.2.x docid-chain pointer.
+	 *
+	 * v1.2.x and earlier maintained a "docid chain" of pages
+	 * anchored by first_docid_page (now renamed
+	 * _unused_docid_page).  Inserts wrote ctids there before
+	 * the in-memory memtable; on a clean restart the chain was
+	 * replayed to re-tokenize pending documents from heap.
+	 * v1.3 (issue #374) replaced the docid chain with an
+	 * on-disk memtable, so the pointer's target is meaningless
+	 * to the v1.3+ binary.
+	 *
+	 * If the pointer is non-Invalid at upgrade time, the
+	 * operator either:
+	 *   - called bm25_spill_index() before the binary swap
+	 *     (data is in segments; the chain is stale bookkeeping
+	 *     safe to orphan), or
+	 *   - did not give v1.2.x a chance to drain (in-flight
+	 *     documents in the chain are lost — they were
+	 *     scheduled for re-tokenization that v1.3 cannot do).
+	 *
+	 * We cannot distinguish those cases from the on-disk bytes
+	 * alone.  Log a one-time LOG-level message recording the
+	 * orphaned pointer for forensics and proceed; the upgrade
+	 * fires at most once per index lifetime so this LOG fires
+	 * at most once per upgraded index (vs the previous design
+	 * which logged from tp_get_metapage and so fired once per
+	 * backend per opened-but-not-yet-written v6 index).
+	 *
+	 * RecoveryInProgress() suppresses the LOG on a hot standby
+	 * — standbys never reach this function (it runs only on
+	 * the primary, inside a writer's GenericXLog scope), but
+	 * the guard documents that intent.
 	 */
+	if (BlockNumberIsValid(orphan_docid_page) && !RecoveryInProgress())
+		ereport(LOG,
+				(errmsg("pg_textsearch: upgrading index \"%s\" "
+						"from a pre-v1.3 metapage (v6) and "
+						"orphaning a non-empty docid chain "
+						"pointer (first_docid_page = %u)",
+						RelationGetRelationName(index),
+						orphan_docid_page),
+				 errdetail(
+						 "The docid chain was a v1.2.x mechanism for "
+						 "replaying in-flight documents from heap on "
+						 "restart.  v1.3 has no equivalent.  If you "
+						 "did not call bm25_spill_index() on this "
+						 "index before swapping binaries, some "
+						 "recently-inserted documents may be missing "
+						 "from query results."),
+				 errhint("If query results look incomplete, "
+						 "REINDEX INDEX %s to rebuild from heap.",
+						 RelationGetRelationName(index))));
+
 	metap->_unused_docid_page = InvalidBlockNumber;
 	metap->version			  = TP_METAPAGE_VERSION;
 

--- a/src/index/metapage.c
+++ b/src/index/metapage.c
@@ -110,15 +110,32 @@ tp_get_metapage(Relation index)
 	}
 
 	/*
-	 * Check version compatibility.  v6 was the last
-	 * shared-memory-memtable release; v7 (this version) replaces
-	 * that with an on-disk paged chain and drops the docid
-	 * recovery pages.  A v6 index may have unspilled documents
-	 * in docid pages (since removed) that the new code cannot
-	 * read, so we reject v6 with an explicit REINDEX hint rather
-	 * than silently truncating the corpus.
+	 * Check version compatibility.
+	 *
+	 * v7 (current) is the on-disk memtable redesign (issue
+	 * #374).  v6 is read-compatible (issue #383): the layout is
+	 * byte-identical up through level_counts[]; v7 only appends
+	 * memtable_head_blkno and memtable_tail_blkno.  We accept
+	 * v6 here and normalize the missing fields to
+	 * InvalidBlockNumber in the returned copy.  The first
+	 * metapage mutation upgrades the on-disk page to v7
+	 * atomically via tp_metapage_upgrade_to_current() inside
+	 * the surrounding GenericXLog record.
+	 *
+	 * v6 with a non-Invalid _unused_docid_page (formerly
+	 * first_docid_page) is the one shape we cannot silently
+	 * upgrade: it indicates a v1.2.x cluster that didn't get a
+	 * chance to spill before binary swap (e.g. SIGKILL'd, then
+	 * the operator replaced the binaries without restarting
+	 * v1.2.x to drain the docid chain).  The v7 binary has no
+	 * docid-replay path, so accepting the index would silently
+	 * lose those pending documents.  Refuse with a clear hint.
+	 *
+	 * v5 and earlier are not read-compatible and require
+	 * REINDEX as before.
 	 */
-	if (metap->version != TP_METAPAGE_VERSION)
+	if (metap->version != TP_METAPAGE_VERSION &&
+		metap->version != TP_METAPAGE_VERSION_V6)
 	{
 		uint32 found_version = metap->version;
 
@@ -136,10 +153,173 @@ tp_get_metapage(Relation index)
 						 RelationGetRelationName(index))));
 	}
 
-	/* Copy metapage data to avoid buffer issues */
+	if (metap->version == TP_METAPAGE_VERSION_V6 &&
+		BlockNumberIsValid(metap->_unused_docid_page))
+	{
+		/*
+		 * v1.2.x and earlier maintained a "docid chain" of
+		 * pages anchored by first_docid_page.  Inserts wrote
+		 * ctids there before the in-memory memtable; on a clean
+		 * restart the chain was replayed to re-tokenize pending
+		 * documents from the heap.  v1.3 (issue #374) replaced
+		 * the docid chain with an on-disk memtable, so the
+		 * pointer's target is now meaningless.
+		 *
+		 * If the pointer is non-Invalid, the operator either
+		 *   - called bm25_spill_index() before the binary swap
+		 *     (data is in segments; the chain is stale
+		 *     bookkeeping safe to orphan), or
+		 *   - did not give v1.2.x a chance to drain (in-flight
+		 *     documents in the chain are lost — they were
+		 *     scheduled for re-tokenization that v1.3 cannot
+		 *     perform).
+		 *
+		 * We cannot distinguish those cases from the on-disk
+		 * bytes alone.  Log a one-time LOG-level message
+		 * recording the orphaned pointer for forensics and
+		 * proceed; the upgrade helper clears the pointer on
+		 * the first metapage mutation so this fires at most
+		 * once per index lifetime.  Operators who suspect lost
+		 * documents should REINDEX.
+		 */
+		ereport(LOG,
+				(errmsg("pg_textsearch: index \"%s\" was upgraded "
+						"from a pre-v1.3 metapage (v6) with a "
+						"non-empty docid chain pointer "
+						"(first_docid_page = %u); orphaning the "
+						"chain",
+						RelationGetRelationName(index),
+						metap->_unused_docid_page),
+				 errdetail(
+						 "The docid chain was a v1.2.x mechanism for "
+						 "replaying in-flight documents from heap on "
+						 "restart.  v1.3 has no equivalent.  If you "
+						 "did not call bm25_spill_index() on this "
+						 "index before swapping binaries, some "
+						 "recently-inserted documents may be missing "
+						 "from query results."),
+				 errhint("If query results look incomplete, "
+						 "REINDEX INDEX %s to rebuild from heap.",
+						 RelationGetRelationName(index))));
+	}
+
+	/*
+	 * Copy metapage data to avoid buffer issues.  On v6 we only
+	 * copy the v6-sized prefix and then explicitly initialize
+	 * the v7-new fields, since the on-disk bytes at those
+	 * offsets are unrelated (PageInit zero-fill, NOT
+	 * InvalidBlockNumber = 0xFFFFFFFF).
+	 */
 	result = (TpIndexMetaPage)palloc(sizeof(TpIndexMetaPageData));
-	memcpy(result, metap, sizeof(TpIndexMetaPageData));
+	if (metap->version == TP_METAPAGE_VERSION)
+	{
+		memcpy(result, metap, sizeof(TpIndexMetaPageData));
+	}
+	else
+	{
+		Assert(metap->version == TP_METAPAGE_VERSION_V6);
+		memcpy(result, metap, TP_INDEX_METAPAGE_DATA_SIZE_V6);
+		result->memtable_head_blkno = InvalidBlockNumber;
+		result->memtable_tail_blkno = InvalidBlockNumber;
+	}
 
 	UnlockReleaseBuffer(buf);
 	return result;
+}
+
+/*
+ * Read memtable_head_blkno from a metapage buffer page in a
+ * version-tolerant way (issue #383).  See header for contract.
+ */
+BlockNumber
+tp_metapage_read_memtable_head(Page page)
+{
+	TpIndexMetaPage metap = (TpIndexMetaPage)PageGetContents(page);
+
+	if (metap->version == TP_METAPAGE_VERSION_V6)
+		return InvalidBlockNumber;
+
+	return metap->memtable_head_blkno;
+}
+
+/*
+ * Read memtable_tail_blkno from a metapage buffer page in a
+ * version-tolerant way (issue #383).  See header for contract.
+ */
+BlockNumber
+tp_metapage_read_memtable_tail(Page page)
+{
+	TpIndexMetaPage metap = (TpIndexMetaPage)PageGetContents(page);
+
+	if (metap->version == TP_METAPAGE_VERSION_V6)
+		return InvalidBlockNumber;
+
+	return metap->memtable_tail_blkno;
+}
+
+/*
+ * In-place v6 -> v7 upgrade (issue #383).  See header for
+ * caller contract.  No-op when the page is already v7.
+ */
+void
+tp_metapage_upgrade_to_current(Page page)
+{
+	TpIndexMetaPage metap;
+	PageHeader		phdr;
+	Size			v7_pd_lower;
+
+	metap = (TpIndexMetaPage)PageGetContents(page);
+
+	if (metap->version == TP_METAPAGE_VERSION)
+		return;
+
+	/*
+	 * tp_get_metapage() is the only legitimate way to first
+	 * observe the on-disk version, and it has already filtered
+	 * out anything besides v6/v7 and refused v6 indexes with
+	 * unspilled docid pages.  Reaching this function with any
+	 * other version means a caller mutated the metapage
+	 * without going through the open path — refuse to stamp
+	 * an unknown layout as v7, which would silently corrupt
+	 * the page (the new chain head/tail fields may land on
+	 * top of meaningful bytes in a future format).
+	 */
+	if (metap->version != TP_METAPAGE_VERSION_V6)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pg_textsearch: cannot upgrade metapage "
+						"with unknown version %u",
+						metap->version),
+				 errhint("Caller must validate the metapage version "
+						 "via tp_get_metapage() before calling "
+						 "tp_metapage_upgrade_to_current().")));
+
+	metap->memtable_head_blkno = InvalidBlockNumber;
+	metap->memtable_tail_blkno = InvalidBlockNumber;
+	/*
+	 * Orphan any stale v1.2.x docid-chain pointer.  See the
+	 * matching ereport(LOG, ...) in tp_get_metapage() for why
+	 * this field can be non-Invalid on an upgraded v6 page.
+	 * Clearing it here ensures the LOG message fires at most
+	 * once per index lifetime (after the first metapage
+	 * mutation), instead of once per backend that opens the
+	 * index.
+	 */
+	metap->_unused_docid_page = InvalidBlockNumber;
+	metap->version			  = TP_METAPAGE_VERSION;
+
+	/*
+	 * Bump pd_lower so the two newly-included BlockNumber
+	 * fields are inside the "used" area of the page.
+	 * GenericXLog computes the page hole as
+	 * [pd_lower, pd_upper) and skips that region in the
+	 * recorded image — if we didn't bump pd_lower, the new
+	 * fields would land in the hole and replay would zero
+	 * them, leaving a v7 page with chain head/tail == 0 (i.e.
+	 * pointing at the metapage block itself).
+	 */
+	v7_pd_lower = SizeOfPageHeaderData + sizeof(TpIndexMetaPageData);
+	phdr		= (PageHeader)page;
+	if (phdr->pd_lower < v7_pd_lower)
+		phdr->pd_lower = v7_pd_lower;
 }

--- a/src/index/metapage.h
+++ b/src/index/metapage.h
@@ -150,6 +150,9 @@ extern BlockNumber tp_metapage_read_memtable_tail(Page page);
  * helper:
  *   - initializes memtable_head_blkno = memtable_tail_blkno =
  *     InvalidBlockNumber,
+ *   - clears any stale _unused_docid_page pointer (and emits a
+ *     LOG-level forensic message if it was non-Invalid; see the
+ *     rationale block in tp_metapage_upgrade_to_current()),
  *   - bumps the version field to TP_METAPAGE_VERSION,
  *   - bumps pd_lower to cover the new fields so GenericXLog
  *     records them in the page image.
@@ -158,5 +161,9 @@ extern BlockNumber tp_metapage_read_memtable_tail(Page page);
  * there is no extra WAL traffic.  Concurrent writers cannot race
  * the upgrade — the EXCLUSIVE buffer lock serializes them, and a
  * later writer simply observes v7 and the helper is a no-op.
+ *
+ * The Relation is only used to format the orphan-pointer LOG
+ * message with the index name; the function does not otherwise
+ * touch it.
  */
-extern void tp_metapage_upgrade_to_current(Page page);
+extern void tp_metapage_upgrade_to_current(Relation index, Page page);

--- a/src/index/metapage.h
+++ b/src/index/metapage.h
@@ -97,7 +97,66 @@ typedef struct TpIndexMetaPageData
 typedef TpIndexMetaPageData *TpIndexMetaPage;
 
 /*
+ * V6 metapage size (bytes), used by:
+ *   - tp_metapage_upgrade_to_current() when bumping pd_lower on
+ *     in-place upgrade.
+ *   - Tests / debug code that downgrades a v7 page to v6 for
+ *     compat-path exercise.
+ *
+ * v6 had no memtable_head_blkno / memtable_tail_blkno fields;
+ * everything else is byte-identical.  Use offsetof() so we never
+ * drift from the real prefix layout of the live struct.
+ */
+#define TP_INDEX_METAPAGE_DATA_SIZE_V6 \
+	offsetof(TpIndexMetaPageData, memtable_head_blkno)
+
+/*
+ * Pin the historical v6 prefix size at 108 bytes.  v6 was frozen
+ * by the v1.2.x releases; any future struct edit that changes the
+ * layout of bytes [0, 108) would silently break v6 read compat
+ * (issue #383).  v7 only appends new fields after this prefix.
+ */
+StaticAssertDecl(
+		TP_INDEX_METAPAGE_DATA_SIZE_V6 == 108,
+		"v6 metapage prefix layout changed - "
+		"backward-compat is broken");
+
+/*
  * Metapage operations
  */
 extern void			   tp_init_metapage(Page page, Oid text_config_oid);
 extern TpIndexMetaPage tp_get_metapage(Relation index);
+
+/*
+ * Read the on-disk memtable chain head/tail from a buffer page,
+ * tolerating v6 metapages (where the fields do not exist on disk
+ * and the underlying bytes are zero — which would otherwise be
+ * misinterpreted as block 0, i.e. the metapage itself, rather
+ * than InvalidBlockNumber).
+ *
+ * Caller must hold at least BUFFER_LOCK_SHARE on the metapage
+ * buffer.  These helpers are for direct-buffer reader sites that
+ * bypass tp_get_metapage() (which already normalizes its palloc'd
+ * copy).  See src/memtable/log.c and src/memtable/chain_source.c.
+ */
+extern BlockNumber tp_metapage_read_memtable_head(Page page);
+extern BlockNumber tp_metapage_read_memtable_tail(Page page);
+
+/*
+ * In-place v6 -> v7 metapage upgrade (issue #383).  Must be
+ * called on a GenericXLogRegisterBuffer-returned page copy under
+ * BUFFER_LOCK_EXCLUSIVE, BEFORE setting any v7-specific field on
+ * the page.  On a v7 page this is a no-op.  On a v6 page the
+ * helper:
+ *   - initializes memtable_head_blkno = memtable_tail_blkno =
+ *     InvalidBlockNumber,
+ *   - bumps the version field to TP_METAPAGE_VERSION,
+ *   - bumps pd_lower to cover the new fields so GenericXLog
+ *     records them in the page image.
+ *
+ * The upgrade piggybacks on the surrounding GenericXLog record;
+ * there is no extra WAL traffic.  Concurrent writers cannot race
+ * the upgrade — the EXCLUSIVE buffer lock serializes them, and a
+ * later writer simply observes v7 and the helper is a no-op.
+ */
+extern void tp_metapage_upgrade_to_current(Page page);

--- a/src/memtable/chain_source.c
+++ b/src/memtable/chain_source.c
@@ -508,14 +508,19 @@ tp_memtable_chain_source_create(
 	 * of returning NULL for an empty memtable.
 	 */
 	{
-		Buffer			metabuf;
-		TpIndexMetaPage metap;
-		bool			empty;
+		Buffer metabuf;
+		bool   empty;
 
 		metabuf = ReadBuffer(rel, TP_METAPAGE_BLKNO);
 		LockBuffer(metabuf, BUFFER_LOCK_SHARE);
-		metap = (TpIndexMetaPage)PageGetContents(BufferGetPage(metabuf));
-		empty = (metap->memtable_head_blkno == InvalidBlockNumber);
+		/*
+		 * Use the version-tolerant helper (issue #383): on a v6
+		 * page the on-disk field bytes are zero (= block 0,
+		 * the metapage itself), not InvalidBlockNumber.
+		 */
+		empty =
+				(tp_metapage_read_memtable_head(BufferGetPage(metabuf)) ==
+				 InvalidBlockNumber);
 		UnlockReleaseBuffer(metabuf);
 		if (empty)
 		{

--- a/src/memtable/log.c
+++ b/src/memtable/log.c
@@ -61,16 +61,12 @@
 static BlockNumber
 memtable_read_tail_blkno(Relation rel)
 {
-	Buffer			buf;
-	Page			page;
-	TpIndexMetaPage metap;
-	BlockNumber		tail;
+	Buffer		buf;
+	BlockNumber tail;
 
 	buf = ReadBuffer(rel, TP_METAPAGE_BLKNO);
 	LockBuffer(buf, BUFFER_LOCK_SHARE);
-	page  = BufferGetPage(buf);
-	metap = (TpIndexMetaPage)PageGetContents(page);
-	tail  = metap->memtable_tail_blkno;
+	tail = tp_metapage_read_memtable_tail(BufferGetPage(buf));
 	UnlockReleaseBuffer(buf);
 
 	return tail;
@@ -138,17 +134,12 @@ memtable_bootstrap_and_append(
 	metabuf = ReadBuffer(rel, TP_METAPAGE_BLKNO);
 	LockBuffer(metabuf, BUFFER_LOCK_EXCLUSIVE);
 
+	if (tp_metapage_read_memtable_tail(BufferGetPage(metabuf)) !=
+		InvalidBlockNumber)
 	{
-		Page			cur_meta_page = BufferGetPage(metabuf);
-		TpIndexMetaPage cur_metap	  = (TpIndexMetaPage)PageGetContents(
-				cur_meta_page);
-
-		if (cur_metap->memtable_tail_blkno != InvalidBlockNumber)
-		{
-			/* Lost the race: another backend bootstrapped first. */
-			UnlockReleaseBuffer(metabuf);
-			return InvalidBlockNumber;
-		}
+		/* Lost the race: another backend bootstrapped first. */
+		UnlockReleaseBuffer(metabuf);
+		return InvalidBlockNumber;
 	}
 
 	newbuf = tp_memtable_alloc_page(rel);
@@ -162,6 +153,13 @@ memtable_bootstrap_and_append(
 	tp_memtable_page_init(newpage_local);
 	tp_memtable_page_append(
 			newpage_local, ctid, doc_length, vector_bytes, vector_len);
+
+	/*
+	 * v6 -> v7 in-place upgrade (issue #383): no-op on v7 pages;
+	 * on v6 pages flips version + initializes new chain fields
+	 * before we overwrite them below, all within this GenericXLog.
+	 */
+	tp_metapage_upgrade_to_current(metapage_local);
 
 	metap = (TpIndexMetaPage)PageGetContents(metapage_local);
 	metap->memtable_head_blkno = newblk;
@@ -230,6 +228,9 @@ memtable_extend_and_append(
 			newpage_local, ctid, doc_length, vector_bytes, vector_len);
 
 	tp_memtable_page_set_next(tailpage_local, newblk);
+
+	/* v6 -> v7 in-place upgrade (issue #383); see bootstrap path. */
+	tp_metapage_upgrade_to_current(metapage_local);
 
 	metap = (TpIndexMetaPage)PageGetContents(metapage_local);
 	metap->memtable_tail_blkno = newblk;
@@ -403,10 +404,8 @@ memtable_append_fragment(
 
 	if (bootstrap)
 	{
-		Page			cur_mp	  = BufferGetPage(metabuf);
-		TpIndexMetaPage cur_metap = (TpIndexMetaPage)PageGetContents(cur_mp);
-
-		if (cur_metap->memtable_tail_blkno != InvalidBlockNumber)
+		if (tp_metapage_read_memtable_tail(BufferGetPage(metabuf)) !=
+			InvalidBlockNumber)
 		{
 			/*
 			 * Lost bootstrap race: another backend populated the
@@ -426,7 +425,9 @@ memtable_append_fragment(
 
 			xlog_state = GenericXLogStart(rel);
 			meta_local = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
-			metap	   = (TpIndexMetaPage)PageGetContents(meta_local);
+			/* v6 -> v7 in-place upgrade (issue #383). */
+			tp_metapage_upgrade_to_current(meta_local);
+			metap = (TpIndexMetaPage)PageGetContents(meta_local);
 			metap->memtable_head_blkno = thead_blkno;
 			metap->memtable_tail_blkno = tnew_blkno;
 			GenericXLogFinish(xlog_state);
@@ -449,6 +450,8 @@ memtable_append_fragment(
 		meta_local	   = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
 
 		tp_memtable_page_set_next(old_tail_local, thead_blkno);
+		/* v6 -> v7 in-place upgrade (issue #383). */
+		tp_metapage_upgrade_to_current(meta_local);
 		metap = (TpIndexMetaPage)PageGetContents(meta_local);
 		metap->memtable_tail_blkno = tnew_blkno;
 
@@ -736,7 +739,17 @@ tp_spill_finalize(
 
 	state	 = GenericXLogStart(rel);
 	metapage = GenericXLogRegisterBuffer(state, metabuf, 0);
-	metap	 = (TpIndexMetaPage)PageGetContents(metapage);
+	/*
+	 * v6 -> v7 in-place upgrade (issue #383).  Must run before
+	 * we touch any v7-only field below.  On a v6 page this
+	 * piggybacks on the spill's GenericXLog record; on v7 it's
+	 * a no-op.  Note: spill cannot be entered on a v6 index
+	 * with unspilled chain data (v6 had no chain pages), so the
+	 * helper only ever flips version + zero-inits the new
+	 * fields here.
+	 */
+	tp_metapage_upgrade_to_current(metapage);
+	metap = (TpIndexMetaPage)PageGetContents(metapage);
 
 	old_l0_head = metap->level_heads[0];
 

--- a/src/memtable/log.c
+++ b/src/memtable/log.c
@@ -159,7 +159,7 @@ memtable_bootstrap_and_append(
 	 * on v6 pages flips version + initializes new chain fields
 	 * before we overwrite them below, all within this GenericXLog.
 	 */
-	tp_metapage_upgrade_to_current(metapage_local);
+	tp_metapage_upgrade_to_current(rel, metapage_local);
 
 	metap = (TpIndexMetaPage)PageGetContents(metapage_local);
 	metap->memtable_head_blkno = newblk;
@@ -230,7 +230,7 @@ memtable_extend_and_append(
 	tp_memtable_page_set_next(tailpage_local, newblk);
 
 	/* v6 -> v7 in-place upgrade (issue #383); see bootstrap path. */
-	tp_metapage_upgrade_to_current(metapage_local);
+	tp_metapage_upgrade_to_current(rel, metapage_local);
 
 	metap = (TpIndexMetaPage)PageGetContents(metapage_local);
 	metap->memtable_tail_blkno = newblk;
@@ -426,7 +426,7 @@ memtable_append_fragment(
 			xlog_state = GenericXLogStart(rel);
 			meta_local = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
 			/* v6 -> v7 in-place upgrade (issue #383). */
-			tp_metapage_upgrade_to_current(meta_local);
+			tp_metapage_upgrade_to_current(rel, meta_local);
 			metap = (TpIndexMetaPage)PageGetContents(meta_local);
 			metap->memtable_head_blkno = thead_blkno;
 			metap->memtable_tail_blkno = tnew_blkno;
@@ -451,7 +451,7 @@ memtable_append_fragment(
 
 		tp_memtable_page_set_next(old_tail_local, thead_blkno);
 		/* v6 -> v7 in-place upgrade (issue #383). */
-		tp_metapage_upgrade_to_current(meta_local);
+		tp_metapage_upgrade_to_current(rel, meta_local);
 		metap = (TpIndexMetaPage)PageGetContents(meta_local);
 		metap->memtable_tail_blkno = tnew_blkno;
 
@@ -748,7 +748,7 @@ tp_spill_finalize(
 	 * helper only ever flips version + zero-inits the new
 	 * fields here.
 	 */
-	tp_metapage_upgrade_to_current(metapage);
+	tp_metapage_upgrade_to_current(rel, metapage);
 	metap = (TpIndexMetaPage)PageGetContents(metapage);
 
 	old_l0_head = metap->level_heads[0];

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -1760,7 +1760,8 @@ tp_merge_level_segments(Relation index, uint32 level, uint32 max_merge)
 
 			xlog_state = GenericXLogStart(index);
 			meta_copy  = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
-			meta_ptr   = (TpIndexMetaPage)PageGetContents(meta_copy);
+			tp_metapage_upgrade_to_current(meta_copy);
+			meta_ptr = (TpIndexMetaPage)PageGetContents(meta_copy);
 
 			meta_ptr->level_heads[level]  = remainder_head;
 			meta_ptr->level_counts[level] = total_at_level - segment_count;

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -1760,7 +1760,7 @@ tp_merge_level_segments(Relation index, uint32 level, uint32 max_merge)
 
 			xlog_state = GenericXLogStart(index);
 			meta_copy  = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
-			tp_metapage_upgrade_to_current(meta_copy);
+			tp_metapage_upgrade_to_current(index, meta_copy);
 			meta_ptr = (TpIndexMetaPage)PageGetContents(meta_copy);
 
 			meta_ptr->level_heads[level]  = remainder_head;


### PR DESCRIPTION
## Summary

PR #375 (memtable v2, issue #374) bumped `TP_METAPAGE_VERSION` from 6 to 7
to record the on-disk memtable chain head/tail. Until now, opening any v6
metapage from a v1.2.x cluster errored with a "REINDEX INDEX" hint —
breaking the standard ALTER EXTENSION UPDATE path for operators upgrading
from v1.2.x to v1.3+.

This PR re-establishes v6 backward compatibility (Closes #383):

- **Read path:** `tp_get_metapage()` accepts version 6 *or* 7. On v6 it
  memcpy's the byte-identical prefix and normalizes the new chain
  head/tail fields to `InvalidBlockNumber` in the returned palloc'd
  copy. Two version-tolerant helpers
  (`tp_metapage_read_memtable_head/tail`) replace direct struct-field
  reads in `log.c` / `chain_source.c` so the bootstrap,
  fragment-publish, spill, and early-empty paths work against a v6
  page unchanged.
- **Lazy in-place upgrade:** `tp_metapage_upgrade_to_current(index,
  page)` does an in-place v6 → v7 upgrade on the page returned by
  `GenericXLogRegisterBuffer`, inside the surrounding critical section
  (no extra WAL traffic). It bumps `pd_lower` so the new 8 bytes land
  in the WAL image (GenericXLog skips the `[pd_lower, pd_upper)`
  hole). Called from every post-build metapage writer site (5 in
  `memtable/log.c`, 2 in `access/vacuum.c`, 1 in `segment/merge.c`).
  Unknown versions (not v6, not v7) are refused with
  `ERRCODE_DATA_CORRUPTED` instead of being defensively stamped.
- **Stale docid-chain handling (no refusal — LOG and orphan):**
  v1.2.x stored unspilled docids in a chain anchored by
  `first_docid_page` (renamed `_unused_docid_page` at the same offset
  in v7). A clean shutdown drained it via a `before_shmem_exit`
  callback, but releases v0.5.1–v1.0.0 left it non-Invalid even after
  a clean drain, and a SIGKILL'd v1.1.0+ cluster also leaves it
  non-Invalid (with in-flight documents the v1.3 binary cannot
  re-tokenize). Because the on-disk bytes can't distinguish those two
  cases, refusing the index would brick legitimate v0.5.1–v1.0.0
  upgrades — so the read path **accepts** the v6 page, and the lazy
  upgrade helper emits a one-shot `LOG`-level forensic message
  recording the orphaned pointer (`first_docid_page = N`) before
  clearing it. The `LOG` includes an operator hint to `REINDEX INDEX`
  if recent INSERTs look missing from query results. Standbys never
  reach the upgrade helper (it runs only on the primary, inside a
  writer's `GenericXLog` scope); a `RecoveryInProgress()` guard
  documents that intent.

## Why "v6" is special

| Version | Releases | v1.3 handling |
|---|---|---|
| v5 | v0.2.0–v0.5.0 | Still REINDEX (legacy tier in upgrade-tests) |
| v6 | v0.5.1–v1.2.0 | Read in place + lazy upgrade (this PR) |
| v7 | v1.3.0+ | Native |

v6 only differs from v7 by the two appended `BlockNumber` fields. On a
v6 page the bytes at those offsets are zero (PageInit), which is block
0 = the metapage itself, NOT `InvalidBlockNumber` (`0xFFFFFFFF`) — so
naive direct reads would be catastrophic. Hence the version-tolerant
helpers.

## Testing

The hard part of testing v6 → v7 lazy upgrade is that nothing in this
branch can *write* a v6 metapage — the writer always stamps the
current version. We therefore test against real v6 indexes produced
by legitimate older binaries inside `upgrade-tests.yml`, where the
matrix already installs every prior release into PostgreSQL and runs
`ALTER EXTENSION pg_textsearch UPDATE` against an index whose
metapage bytes were written by that older binary.

- `.github/workflows/upgrade-tests.yml` (compat tier, v0.5.1–v1.2.0):
  - **Phase 1**: install old binary, build a real on-disk index,
    install new binary, `ALTER EXTENSION UPDATE`, query — proves the
    read path tolerates v6.
  - **Phase 1a**: after the read-only query workload, assert
    `metapage_version = 6` is *still* on disk — proves the read path
    is non-mutating (no accidental upgrade on a pure-read workload).
  - **Phase 1b**: an isolated `INSERT` of a single row, then assert
    `metapage_version = 7` — proves the first metapage mutation
    triggers the lazy upgrade. This isolation matters because the
    later Phase 3 force-merge would *also* upgrade the metapage; we
    needed a small isolated write to attribute the upgrade to first
    write rather than to force-merge.
  - **Phases 2–4** (unchanged): DELETE + VACUUM, force-merge,
    post-upgrade writes/queries — exercise the upgraded v7 page
    across the full lifecycle.
  - A separate "ALTER bin → query before any write" assertion
    confirms that an index can be opened, queried, and closed by the
    new binary with the metapage staying on v6.
- Matrix regex tightened from `1\.[0-9]+\.[0-9]+` to
  `1\.[0-2]\.[0-9]+` so future v1.3.x+ releases (which write v7
  natively) are not silently classified as v6-compat-tier.
- `StaticAssertDecl` pins `TP_INDEX_METAPAGE_DATA_SIZE_V6` to 108
  bytes so any future struct edit before `memtable_head_blkno` fails
  the build instead of silently breaking v6 compat.
- `make installcheck`: all 70 tests pass on PG17/18.
- `make format-check` clean (clang-format 21.1.8).
- All sanitizer jobs pass (PG17.2 + PG18.1, first try).

## CI changes

- Lifts the `if false;` gates in `.github/workflows/upgrade-tests.yml`
  so v0.5.1+ (v6 metapage) → 1.3.0-dev runs the compat tier (ALTER
  EXTENSION UPDATE without REINDEX) end-to-end. Pre-v6 versions
  (v0.2.0–v0.5.0, metapage v5) stay on the legacy REINDEX tier via a
  regex partition.
- `.github/workflows/ci.yml` coverage step now asserts the
  before/after metapage version around `ALTER EXTENSION UPDATE` to
  catch eager-upgrade regressions on every PR.

## Files changed

- `src/constants.h` — adds `TP_METAPAGE_VERSION_V6 = 6`, rewrites
  version comment to document the read-compat + accept-and-LOG
  contract.
- `src/index/metapage.{h,c}` — accepts v6, implements
  `tp_metapage_upgrade_to_current(Relation, Page)` and the two
  version-tolerant readers, adds `StaticAssertDecl`. The upgrade
  helper takes `Relation index` so the one-shot `LOG` can name the
  index.
- `src/memtable/log.c`, `src/memtable/chain_source.c`,
  `src/access/vacuum.c`, `src/segment/merge.c` — call sites for read
  helpers and upgrade helper.
- `.github/workflows/upgrade-tests.yml` — lift `if false;` gates,
  tighten matrix regex, add Phase 1a/1b version assertions.
- `.github/workflows/ci.yml` — coverage-step metapage-version
  assertions around `ALTER EXTENSION UPDATE`.
- `docs/memtable_v2.md` — rewritten `## Upgrade` section documenting
  LOG location, read-only/standby semantics, and a
  `bm25_dump_index` recipe for operators to inspect upgrade state.

## Out of scope

- v5 (and earlier) read compat. Pre-v0.5.1 releases predate the BMW
  correctness fix and we don't maintain a multi-version read path
  past one major.
- Reclaiming orphaned v6 docid-chain pages. The chain pages are
  no longer reachable from any walker after the upgrade; they'll
  eventually be reclaimed by truncation. Tracking separately if it
  proves to matter in practice.
- An eager `ALTER EXTENSION UPDATE`-time upgrade. The lazy on-first-write
  design preserves backward compatibility for read-only standbys and
  for indexes that are queried but never written between binary swap
  and the next `REINDEX` — they stay on v6 forever, which is the
  documented contract.
- A SQL-level `bm25_metapage_version()` helper. Operators inspect
  upgrade state via `bm25_dump_index()` (see `docs/memtable_v2.md`).
