### PR TITLE
Make PG_CONFIG overridable via the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ PG_CPPFLAGS += -Wno-unknown-warning-option -Wno-clobbered -Wno-packed-not-aligne
 REGRESS = abort aerodocs basic binary_io bmw bmw_skip_advance bulk_load cache_apply cache_memory_cap cache_source cache_spill catalog_stats chain_source compression concurrent_build coverage deletion vacuum vacuum_bitmap vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index force_merge implicit index inheritance large_documents limits lock manyterms memory memtable_append memtable_page memtable_spill memtable_spill_dead memtable_reclaim merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security segment segment_integrity strings temp_table text_array text_config unsupported updates vector vector_v1_rejected unlogged_index wand
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 


### PR DESCRIPTION
## Summary

Change `PG_CONFIG = pg_config` to `PG_CONFIG ?= pg_config` in the Makefile so the target `pg_config` can be selected via an **environment variable**, in addition to the existing command-line override (`make PG_CONFIG=...`) and PATH-based selection.

## Motivation

With a plain `=` assignment, make precedence means an environment `PG_CONFIG` is **ignored** (only a command-line override or PATH selection takes effect). Using `?=` (conditional assignment) lets the environment variable work too, which is convenient when building against a specific PostgreSQL major version without prepending its bin directory to PATH:

```sh
PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config make
```

## Behavior

- Default unchanged: when `PG_CONFIG` is set neither in the environment nor on the command line, it still resolves to `pg_config`.
- Command-line override (`make PG_CONFIG=...`) continues to win, as before.
- Environment variable is now also honored.

Verified all three selection paths resolve as expected and a clean build succeeds.