### PR TITLE
chore: bump version to 1.4.0-dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ ranking. (Internal name: Tapir) It implements a memtable-based architecture
 similar to LSM trees, with in-memory structures that spill to disk segments
 for scalability.
 
-**Current Version**: 1.3.0
+**Current Version**: 1.4.0-dev
 
 **Postgres Version Support**: 17, 18 (tested in CI)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXTENSION = pg_textsearch
 EXTVERSION = $(shell awk -F"'" '/default_version/ {print $$2}' pg_textsearch.control)
-DATA = sql/pg_textsearch--1.3.0.sql \
+DATA = sql/pg_textsearch--1.4.0-dev.sql \
        sql/pg_textsearch--0.0.1--0.0.2.sql \
        sql/pg_textsearch--0.0.2--0.0.3.sql \
        sql/pg_textsearch--0.0.3--0.0.4.sql \
@@ -18,7 +18,8 @@ DATA = sql/pg_textsearch--1.3.0.sql \
        sql/pg_textsearch--0.6.1--1.0.0.sql \
        sql/pg_textsearch--1.0.0--1.1.0.sql \
        sql/pg_textsearch--1.1.0--1.2.0.sql \
-       sql/pg_textsearch--1.2.0--1.3.0.sql
+       sql/pg_textsearch--1.2.0--1.3.0.sql \
+       sql/pg_textsearch--1.3.0--1.4.0-dev.sql
 
 # Source files organized by directory
 OBJS = \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Modern ranked text search for Postgres.
 - Supports partitioned tables
 - Best in class performance and scalability
 
-🚀 **Status**: v1.3.0 - Production ready.
+🚀 **Status**: v1.4.0-dev - Production ready.
 
 ![Tapir and Friends](images/tapir_and_friends_v1.3.0.png)
 

--- a/benchmarks/datasets/msmarco-v2/run_v2_benchmark.sh
+++ b/benchmarks/datasets/msmarco-v2/run_v2_benchmark.sh
@@ -63,8 +63,8 @@ check_tapir_version() {
     local ver
     ver=$(psql -t -c "SELECT default_version FROM pg_available_extensions WHERE name = 'pg_textsearch';" 2>/dev/null | tr -d ' ')
     echo "pg_textsearch version: $ver"
-    if [ "$ver" != "1.3.0" ]; then
-        echo "WARNING: Expected 1.3.0, got '$ver'"
+    if [ "$ver" != "1.4.0-dev" ]; then
+        echo "WARNING: Expected 1.4.0-dev, got '$ver'"
     fi
 }
 

--- a/pg_textsearch.control
+++ b/pg_textsearch.control
@@ -1,5 +1,5 @@
 # pg_textsearch extension
 comment = 'Full-text search with BM25 ranking'
-default_version = '1.3.0'
+default_version = '1.4.0-dev'
 module_pathname = '$libdir/pg_textsearch'
 relocatable = false

--- a/sql/pg_textsearch--1.3.0--1.4.0-dev.sql
+++ b/sql/pg_textsearch--1.3.0--1.4.0-dev.sql
@@ -1,0 +1,16 @@
+-- Upgrade from 1.3.0 to 1.4.0-dev
+
+-- Verify the library is loaded. The version-equality check lives in
+-- the main install file (pg_textsearch--<default_version>.sql); upgrade
+-- scripts must accept any loaded version because they may run as
+-- intermediate steps in a chain that ends at default_version, not at
+-- the version named in this filename.
+DO $$
+BEGIN
+    IF pg_catalog.current_setting('pg_textsearch.library_version', true)
+       IS NULL THEN
+        RAISE EXCEPTION
+            'pg_textsearch library not loaded. '
+            'Add pg_textsearch to shared_preload_libraries and restart.';
+    END IF;
+END $$;

--- a/sql/pg_textsearch--1.4.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0-dev.sql
@@ -1,4 +1,4 @@
--- pg_textsearch extension version 1.3.0
+-- pg_textsearch extension version 1.4.0-dev
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pg_textsearch" to load this file. \quit
@@ -14,11 +14,11 @@ BEGIN
             'pg_textsearch library not loaded. '
             'Add pg_textsearch to shared_preload_libraries and restart.';
     END IF;
-    IF lib_ver OPERATOR(pg_catalog.<>) '1.3.0' THEN
+    IF lib_ver OPERATOR(pg_catalog.<>) '1.4.0-dev' THEN
         RAISE EXCEPTION
             'pg_textsearch library version mismatch: loaded=%, expected=%. '
             'Restart the server after installing the new binary.',
-            lib_ver, '1.3.0';
+            lib_ver, '1.4.0-dev';
     END IF;
 END $$;
 

--- a/src/mod.c
+++ b/src/mod.c
@@ -31,7 +31,7 @@
 #include "scoring/bm25.h"
 
 #if PG_VERSION_NUM >= 180000
-PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.3.0");
+PG_MODULE_MAGIC_EXT(.name = "pg_textsearch", .version = "1.4.0-dev");
 #else
 PG_MODULE_MAGIC;
 #endif

--- a/test/scripts/multi_index.sh
+++ b/test/scripts/multi_index.sh
@@ -93,7 +93,7 @@ EOF
         "${TEST_DB}"
 
     run_sql_quiet "CREATE EXTENSION pg_textsearch
-                       VERSION '1.3.0';"
+                       VERSION '1.4.0-dev';"
 }
 
 run_sql() {

--- a/test/scripts/segment_wal_recovery.sh
+++ b/test/scripts/segment_wal_recovery.sh
@@ -146,7 +146,7 @@ EOF
 
 "${PGBINDIR}/createdb" -h "${DATA_DIR}" -p "${TEST_PORT}" \
     "${TEST_DB}"
-run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.3.0';"
+run_sql_quiet "CREATE EXTENSION pg_textsearch VERSION '1.4.0-dev';"
 
 # -------------------------------------------------------
 # Part 1: WAL coverage check


### PR DESCRIPTION
Bumps the extension version from `1.3.0` to `1.4.0-dev`, opening the
1.4.0 development cycle. Follows the "Bumping to the Next Dev Version"
procedure in `RELEASING.md`.

## Changes (via `scripts/bump-version.sh 1.3.0 1.4.0-dev`)
- Renamed main install file `sql/pg_textsearch--1.3.0.sql` →
  `sql/pg_textsearch--1.4.0-dev.sql` and bumped its version-equality check.
- Added upgrade stub `sql/pg_textsearch--1.3.0--1.4.0-dev.sql`
  (library-loaded check only; contributors append feature DDL as work lands).
- Updated `Makefile` DATA list, `pg_textsearch.control` default_version,
  `src/mod.c` module version, `README.md`/`CLAUDE.md` status, and the
  affected test/benchmark scripts.

## Manual fixes beyond the script
The blanket substitution rewrote two *historical* references that must
stay `1.3.0`; reverted by hand:
- `src/mod.c` comment about the SRF removed in **1.3.0** and DROPped by
  `pg_textsearch--1.2.0--1.3.0.sql`.
- `README.md` "Starting in **1.3.0**, the L0 memtable lives in the index
  relation" (on-disk memtable shipped in 1.3.0, #374).

The remaining `1.3.0` stragglers the script flagged (`ci.yml` comments,
the `1.2.0--1.3.0.sql` Makefile chain entry, `multi_backend_reindex.sh`
historical note) are all correct as-is.

## Verification
- `make` builds cleanly.

The README banner image ref intentionally stays at `v1.3.0.png` (dev
cycles don't ship a new banner).