### PR TITLE
Fix invalid segment header in standalone scoring during concurrent spill/merge (#404)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ clean-test-dirs:
 test-concurrency:
 	@echo "Running concurrency tests..."
 	@cd test/scripts && ./concurrency.sh
+	@cd test/scripts && ./partial_concurrent_read.sh
 
 test-recovery:
 	@echo "Running crash recovery tests..."

--- a/src/debug/dump.c
+++ b/src/debug/dump.c
@@ -165,6 +165,7 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 	uint32			   segment_terms  = 0;
 	uint32			   segment_docs	  = 0;
 	uint32			   segment_alive  = 0;
+	bool			   acquired_lock  = false;
 
 	dump_printf(out, "Index: %s\n", index_name);
 
@@ -196,6 +197,30 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 		return;
 	}
 
+	/*
+	 * Issue #404: the segment walks below open pages by block number from
+	 * metap->level_heads[].  A concurrent spill/merge (per-index LWLock
+	 * LW_EXCLUSIVE) frees old segment pages and the memtable recycles
+	 * those blocks, so an unlocked reader can hit "invalid segment
+	 * header".  Hold the per-index lock in SHARED mode across the reads
+	 * and re-read the metapage under it (the snapshot above was taken
+	 * without the lock).  Ownership-aware: if a live source already holds
+	 * the lock we neither re-acquire nor release it here.  On error the
+	 * end-of-xact LWLockReleaseAll plus state cleanup reset the lock.
+	 */
+	if (index_state != NULL && !index_state->lock_held)
+	{
+		tp_acquire_index_lock(index_state, LW_SHARED);
+		acquired_lock = true;
+	}
+	if (index_state != NULL)
+	{
+		TpIndexMetaPage fresh = tp_get_metapage(index_rel);
+
+		if (metap)
+			pfree(metap);
+		metap = fresh;
+	}
 	/*
 	 * Corpus statistics.
 	 *
@@ -419,6 +444,8 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 			(unsigned long)RelationGetNumberOfBlocks(index_rel) * BLCKSZ);
 
 	/* Cleanup */
+	if (acquired_lock)
+		tp_release_index_lock(index_state);
 	if (metap)
 		pfree(metap);
 	if (index_rel)
@@ -435,6 +462,7 @@ tp_dump_index_to_output(const char *index_name, DumpOutput *out)
 	Relation		   index_rel = NULL;
 	TpIndexMetaPage	   metap	 = NULL;
 	TpLocalIndexState *index_state;
+	bool			   acquired_lock = false;
 
 	dump_printf(out, "Tapir Index Debug: %s\n", index_name);
 
@@ -464,6 +492,25 @@ tp_dump_index_to_output(const char *index_name, DumpOutput *out)
 		if (index_rel)
 			index_close(index_rel, AccessShareLock);
 		return;
+	}
+
+	/*
+	 * Issue #404: hold the per-index lock (SHARED) and re-read the
+	 * metapage under it before walking segments below; see the matching
+	 * comment in tp_summarize_index_to_output.
+	 */
+	if (index_state != NULL && !index_state->lock_held)
+	{
+		tp_acquire_index_lock(index_state, LW_SHARED);
+		acquired_lock = true;
+	}
+	if (index_state != NULL)
+	{
+		TpIndexMetaPage fresh = tp_get_metapage(index_rel);
+
+		if (metap)
+			pfree(metap);
+		metap = fresh;
 	}
 
 	/*
@@ -636,6 +683,8 @@ tp_dump_index_to_output(const char *index_name, DumpOutput *out)
 	}
 
 	/* Cleanup */
+	if (acquired_lock)
+		tp_release_index_lock(index_state);
 	if (metap)
 		pfree(metap);
 	if (index_rel)

--- a/src/debug/dump.c
+++ b/src/debug/dump.c
@@ -199,13 +199,9 @@ tp_summarize_index_to_output(const char *index_name, DumpOutput *out)
 
 	/*
 	 * Issue #404: the segment walks below open pages by block number from
-	 * metap->level_heads[].  A concurrent spill/merge (per-index LWLock
-	 * LW_EXCLUSIVE) frees old segment pages and the memtable recycles
-	 * those blocks, so an unlocked reader can hit "invalid segment
-	 * header".  Hold the per-index lock in SHARED mode across the reads
-	 * and re-read the metapage under it (the snapshot above was taken
-	 * without the lock).  Ownership-aware: if a live source already holds
-	 * the lock we neither re-acquire nor release it here.  On error the
+	 * metap->level_heads[], which races a concurrent spill/merge that
+	 * frees and recycles those blocks ("invalid segment header"). Hold the
+	 * per-index lock SHARED and re-read the metapage under it. On error the
 	 * end-of-xact LWLockReleaseAll plus state cleanup reset the lock.
 	 */
 	if (index_state != NULL && !index_state->lock_held)

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -862,12 +862,10 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 		}
 
 		/*
-		 * Issue #404: the per-index lock + level_heads re-read needed to
-		 * safely open segment pages is taken lazily in the IDF-cache-miss
-		 * branch below (the only place segments are read), so cache-hit
-		 * rows pay no lock or metapage cost.  total_docs / total_len /
-		 * first_segment used for scoring are scalar stats, not block
-		 * numbers, so the pre-lock snapshot above is fine for them.
+		 * Issue #404: the lock + level_heads re-read that protect the
+		 * segment reads are taken lazily in the cache-miss branch below.
+		 * total_docs / total_len / first_segment are scalar stats (not
+		 * block numbers), so the unlocked snapshot above is fine here.
 		 */
 
 		/*
@@ -1012,26 +1010,14 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 					}
 
 					/*
-					 * Issue #404: the segment reads below open pages by
-					 * block number from level_heads[].  A concurrent spill
-					 * / merge (per-index LWLock LW_EXCLUSIVE) frees old
-					 * segment pages and the memtable recycles those blocks,
-					 * so an unlocked reader can read a recycled page where a
-					 * segment header is expected ("invalid segment header").
-					 *
-					 * Take the per-index lock in SHARED mode and re-read
-					 * level_heads under it before the reads, exactly as the
-					 * index-scan path (access/scan.c) does.  The level_heads
-					 * snapshot taken earlier without the lock may already
-					 * name a freed/recycled block, hence the re-read.
-					 *
-					 * Done lazily on the first cache miss so cache-hit rows
-					 * pay no lock or metapage cost.  The chain source uses
-					 * the same ownership convention: if it already holds the
-					 * lock (non-empty chain) we neither re-acquire nor
-					 * release it here; it releases its own acquisition on
-					 * close.  Either way the lock must be held before the
-					 * reads, so we still re-read level_heads under it.
+					 * Issue #404: opening segment pages by block number
+					 * races a concurrent spill/merge that frees and
+					 * recycles those blocks ("invalid segment header").
+					 * Hold the per-index lock SHARED and re-read
+					 * level_heads under it, like the index-scan path. Done
+					 * lazily on first cache miss so cache-hit rows pay
+					 * nothing; the chain source may already hold the lock
+					 * (ownership-aware).
 					 */
 					if (!segments_locked)
 					{
@@ -1102,10 +1088,7 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 			tp_source_close(memtable_src);
 			memtable_src = NULL;
 		}
-		/*
-		 * Release the per-index lock only if we acquired it (issue #404),
-		 * after the term loop's segment reads above have completed.
-		 */
+		/* Release the per-index lock only if we acquired it (issue #404). */
 		if (acquired_lock)
 		{
 			tp_release_index_lock(locked_state);

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -695,6 +695,8 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 	BlockNumber		   level_heads[TP_MAX_LEVELS];
 	bool			   is_partitioned;
 	char			  *indexed_colname = NULL;
+	bool			   acquired_lock   = false;
+	TpLocalIndexState *locked_state	   = NULL;
 
 	/* Get index OID from query */
 	index_oid = get_tpquery_index_oid(query);
@@ -856,6 +858,44 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 					}
 				}
 			}
+		}
+
+		/*
+		 * Issue #404: the per-term IDF cache misses below open segment
+		 * pages by block number from level_heads[].  A concurrent spill /
+		 * merge (which holds the per-index LWLock LW_EXCLUSIVE) frees old
+		 * segment pages and lets the memtable recycle those blocks, so an
+		 * unlocked reader can read a recycled memtable page where a
+		 * segment header is expected ("invalid segment header").  Hold the
+		 * per-index lock in SHARED mode across the segment reads, exactly
+		 * as the index-scan path (access/scan.c) does.
+		 *
+		 * The level_heads snapshot above was read without the lock and
+		 * may already name a freed/recycled block, so re-read the
+		 * metapage under the lock before using it.
+		 *
+		 * The chain source uses the same lock-ownership convention: if it
+		 * already acquired the lock (non-empty chain), index_state->
+		 * lock_held is true and we must neither re-acquire nor release it
+		 * here; the source releases its own acquisition on close.
+		 */
+		if (index_state != NULL && !index_state->lock_held)
+		{
+			tp_acquire_index_lock(index_state, LW_SHARED);
+			acquired_lock = true;
+			locked_state  = index_state;
+		}
+
+		{
+			TpIndexMetaPage fresh = tp_get_metapage(index_rel);
+
+			pfree(metap);
+			metap		  = fresh;
+			first_segment = metap->level_heads[0];
+			for (int i = 0; i < TP_MAX_LEVELS; i++)
+				level_heads[i] = metap->level_heads[i];
+			total_docs = metap->total_docs;
+			total_len  = metap->total_len;
 		}
 
 		/*
@@ -1047,6 +1087,15 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 			tp_source_close(memtable_src);
 			memtable_src = NULL;
 		}
+		/*
+		 * Release the per-index lock only if we acquired it (issue #404).
+		 * Done after the chain source close so its reads stayed protected.
+		 */
+		if (acquired_lock)
+		{
+			tp_release_index_lock(locked_state);
+			acquired_lock = false;
+		}
 		pfree(metap);
 		metap = NULL;
 		index_close(index_rel, AccessShareLock);
@@ -1056,6 +1105,8 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 	{
 		if (memtable_src)
 			tp_source_close(memtable_src);
+		if (acquired_lock)
+			tp_release_index_lock(locked_state);
 		if (metap)
 			pfree(metap);
 		if (index_rel)

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -696,6 +696,7 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 	bool			   is_partitioned;
 	char			  *indexed_colname = NULL;
 	bool			   acquired_lock   = false;
+	bool			   segments_locked = false;
 	TpLocalIndexState *locked_state	   = NULL;
 
 	/* Get index OID from query */
@@ -861,51 +862,13 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 		}
 
 		/*
-		 * Issue #404: the per-term IDF cache misses below open segment
-		 * pages by block number from level_heads[].  A concurrent spill /
-		 * merge (which holds the per-index LWLock LW_EXCLUSIVE) frees old
-		 * segment pages and lets the memtable recycle those blocks, so an
-		 * unlocked reader can read a recycled memtable page where a
-		 * segment header is expected ("invalid segment header").  Hold the
-		 * per-index lock in SHARED mode across the segment reads, exactly
-		 * as the index-scan path (access/scan.c) does.
-		 *
-		 * The level_heads snapshot above was read without the lock and
-		 * may already name a freed/recycled block, so re-read the
-		 * metapage under the lock before using it.
-		 *
-		 * The chain source uses the same lock-ownership convention: if it
-		 * already acquired the lock (non-empty chain), index_state->
-		 * lock_held is true and we must neither re-acquire nor release it
-		 * here; the source releases its own acquisition on close.
+		 * Issue #404: the per-index lock + level_heads re-read needed to
+		 * safely open segment pages is taken lazily in the IDF-cache-miss
+		 * branch below (the only place segments are read), so cache-hit
+		 * rows pay no lock or metapage cost.  total_docs / total_len /
+		 * first_segment used for scoring are scalar stats, not block
+		 * numbers, so the pre-lock snapshot above is fine for them.
 		 */
-		if (index_state != NULL && !index_state->lock_held)
-		{
-			tp_acquire_index_lock(index_state, LW_SHARED);
-			acquired_lock = true;
-			locked_state  = index_state;
-		}
-
-		/*
-		 * Whoever acquired it, the per-index lock must be held before the
-		 * segment reads below (either we took it, or the live chain source
-		 * did).  Enforce that invariant so a future change that returns a
-		 * source without holding the lock fails loudly instead of silently
-		 * reintroducing issue #404.
-		 */
-		Assert(index_state == NULL || index_state->lock_held);
-
-		{
-			TpIndexMetaPage fresh = tp_get_metapage(index_rel);
-
-			pfree(metap);
-			metap		  = fresh;
-			first_segment = metap->level_heads[0];
-			for (int i = 0; i < TP_MAX_LEVELS; i++)
-				level_heads[i] = metap->level_heads[i];
-			total_docs = metap->total_docs;
-			total_len  = metap->total_len;
-		}
 
 		/*
 		 * Phase 4 of issue #374: add the active memtable's contribution
@@ -1048,6 +1011,49 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 						}
 					}
 
+					/*
+					 * Issue #404: the segment reads below open pages by
+					 * block number from level_heads[].  A concurrent spill
+					 * / merge (per-index LWLock LW_EXCLUSIVE) frees old
+					 * segment pages and the memtable recycles those blocks,
+					 * so an unlocked reader can read a recycled page where a
+					 * segment header is expected ("invalid segment header").
+					 *
+					 * Take the per-index lock in SHARED mode and re-read
+					 * level_heads under it before the reads, exactly as the
+					 * index-scan path (access/scan.c) does.  The level_heads
+					 * snapshot taken earlier without the lock may already
+					 * name a freed/recycled block, hence the re-read.
+					 *
+					 * Done lazily on the first cache miss so cache-hit rows
+					 * pay no lock or metapage cost.  The chain source uses
+					 * the same ownership convention: if it already holds the
+					 * lock (non-empty chain) we neither re-acquire nor
+					 * release it here; it releases its own acquisition on
+					 * close.  Either way the lock must be held before the
+					 * reads, so we still re-read level_heads under it.
+					 */
+					if (!segments_locked)
+					{
+						if (index_state != NULL && !index_state->lock_held)
+						{
+							tp_acquire_index_lock(index_state, LW_SHARED);
+							acquired_lock = true;
+							locked_state  = index_state;
+						}
+						Assert(index_state == NULL || index_state->lock_held);
+
+						if (index_state != NULL)
+						{
+							TpIndexMetaPage fresh = tp_get_metapage(index_rel);
+
+							for (int i = 0; i < TP_MAX_LEVELS; i++)
+								level_heads[i] = fresh->level_heads[i];
+							pfree(fresh);
+						}
+						segments_locked = true;
+					}
+
 					/* Get doc_freq from all segment levels */
 					for (int level = 0; level < TP_MAX_LEVELS; level++)
 					{
@@ -1097,8 +1103,8 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 			memtable_src = NULL;
 		}
 		/*
-		 * Release the per-index lock only if we acquired it (issue #404).
-		 * Done after the chain source close so its reads stayed protected.
+		 * Release the per-index lock only if we acquired it (issue #404),
+		 * after the term loop's segment reads above have completed.
 		 */
 		if (acquired_lock)
 		{

--- a/src/types/query.c
+++ b/src/types/query.c
@@ -886,6 +886,15 @@ bm25_text_bm25query_score(PG_FUNCTION_ARGS)
 			locked_state  = index_state;
 		}
 
+		/*
+		 * Whoever acquired it, the per-index lock must be held before the
+		 * segment reads below (either we took it, or the live chain source
+		 * did).  Enforce that invariant so a future change that returns a
+		 * source without holding the lock fails loudly instead of silently
+		 * reintroducing issue #404.
+		 */
+		Assert(index_state == NULL || index_state->lock_held);
+
 		{
 			TpIndexMetaPage fresh = tp_get_metapage(index_rel);
 

--- a/test/scripts/partial_concurrent_read.sh
+++ b/test/scripts/partial_concurrent_read.sh
@@ -95,11 +95,28 @@ FROM generate_series(1, 4000) gs;
 SELECT bm25_spill_index('docs_de_bm25');
 SELECT bm25_force_merge('docs_de_bm25');
 SQL
+
+    # Guard against silent planner drift: the regression only exercises the
+    # buggy code path if the reader query runs as a Seq Scan (standalone
+    # <@> scoring). Fail loudly if a future planner change picks an index
+    # scan instead, which would make this test silently stop covering #404.
+    local plan
+    plan=$($PSQL -c "SET enable_indexscan=off; SET enable_bitmapscan=off;
+        EXPLAIN (COSTS off)
+        SELECT id FROM docs WHERE lang='de'
+        ORDER BY content <@> to_bm25query('postgres bm25', 'docs_de_bm25')
+        LIMIT 20")
+    if ! echo "$plan" | grep -qi "Seq Scan"; then
+        warn "Reader plan was not a Seq Scan:"
+        echo "$plan"
+        error "TEST SETUP FAILED: reader no longer exercises the standalone path"
+    fi
 }
 
 writer() {
     for i in $(seq 1 120); do
-        $PSQL -c "INSERT INTO docs (content, lang)
+        $PSQL -c "SET statement_timeout='60s'; SET lock_timeout='30s';
+          INSERT INTO docs (content, lang)
           SELECT 'writer postgres bm25 ' || gs, 'de'
           FROM generate_series(1, 30) gs" \
           >>"${ERR_DIR}/writer.log" 2>&1 || return 10
@@ -114,11 +131,15 @@ merger() {
     done
 }
 
-# Forces the standalone (<@> operator) scoring path via enable_indexscan=off.
+# "Partial" is incidental here: the trigger is the standalone <@> scoring
+# path, which the planner uses for a sequential scan (enable_indexscan=off
+# below). A partial index just makes that plan more likely; there is no
+# distinct partial-index code path involved.
 reader() {
     local tag=$1
     for i in $(seq 1 300); do
         $PSQL -c "SET enable_indexscan=off; SET enable_bitmapscan=off;
+          SET statement_timeout='60s'; SET lock_timeout='30s';
           SELECT count(*) FROM (
             SELECT id FROM docs WHERE lang='de'
             ORDER BY content <@> to_bm25query('postgres bm25', 'docs_de_bm25')

--- a/test/scripts/partial_concurrent_read.sh
+++ b/test/scripts/partial_concurrent_read.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+#
+# Regression test for issue #404:
+#   "Partial BM25 reads can fail with invalid segment header during
+#    concurrent matching writes and spill/merge"
+#
+# The standalone <@> scoring operator (used when the planner picks a
+# sequential scan instead of an index scan) opened segment pages by block
+# number WITHOUT holding the per-index LWLock. A concurrent spill/merge
+# (LW_EXCLUSIVE) frees old segment pages and the memtable recycles those
+# blocks, so the unlocked reader could read a recycled memtable page where
+# a segment header was expected:
+#
+#   ERROR: invalid segment header at block N
+#   DETAIL: magic=0x5450544D, expected 0x54505347
+#
+# The reader below forces the standalone path (enable_indexscan=off) on a
+# selective partial index while writers and spill/merge run concurrently.
+# Before the fix this fails within a few seconds; after the fix it must
+# complete cleanly.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PORT=55441
+TEST_DB=partial_concurrent_read_test
+DATA_DIR="${SCRIPT_DIR}/../tmp_partial_concurrent_read"
+LOGFILE="${DATA_DIR}/postgres.log"
+ERR_DIR="${DATA_DIR}/client_logs"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"; }
+warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARNING: $1${NC}"; }
+error() { echo -e "${RED}[$(date '+%H:%M:%S')] ERROR: $1${NC}"; exit 1; }
+
+cleanup() {
+    local exit_code=$?
+    log "Cleaning up (exit code: $exit_code)..."
+    jobs -p | xargs -r kill 2>/dev/null || true
+    if [ -f "${DATA_DIR}/postmaster.pid" ]; then
+        pg_ctl stop -D "${DATA_DIR}" -m immediate &>/dev/null || true
+    fi
+    rm -rf "${DATA_DIR}"
+    exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+setup_test_db() {
+    log "Setting up PostgreSQL instance..."
+    rm -rf "${DATA_DIR}"
+    mkdir -p "${DATA_DIR}"
+
+    initdb -D "${DATA_DIR}" --auth-local=trust --auth-host=trust >/dev/null 2>&1
+    mkdir -p "${ERR_DIR}"
+
+    cat >> "${DATA_DIR}/postgresql.conf" << EOF
+port = ${TEST_PORT}
+unix_socket_directories = '${DATA_DIR}'
+listen_addresses = 'localhost'
+shared_preload_libraries = 'pg_textsearch'
+logging_collector = on
+log_directory = '.'
+log_filename = 'postgres.log'
+autovacuum = on
+EOF
+
+    pg_ctl start -D "${DATA_DIR}" -l "${LOGFILE}" -w -o "-p ${TEST_PORT}" || \
+        error "Failed to start PostgreSQL"
+
+    createdb -h "${DATA_DIR}" -p ${TEST_PORT} ${TEST_DB}
+    psql -h "${DATA_DIR}" -p ${TEST_PORT} -d ${TEST_DB} \
+        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+    log "Test database ready"
+}
+
+PSQL="psql -h ${DATA_DIR} -p ${TEST_PORT} -d ${TEST_DB} -qAt -v ON_ERROR_STOP=1"
+
+seed_data() {
+    log "Creating selective partial index and seeding data..."
+    $PSQL <<'SQL' >/dev/null
+SET client_min_messages=warning;
+CREATE TABLE docs (id bigserial PRIMARY KEY, content text NOT NULL, lang text NOT NULL);
+CREATE INDEX docs_de_bm25 ON docs USING bm25(content)
+    WITH (text_config='german') WHERE lang = 'de';
+INSERT INTO docs (content, lang)
+SELECT repeat('postgres bm25 search ', 50) || gs,
+       CASE WHEN gs % 2 = 0 THEN 'de' ELSE 'en' END
+FROM generate_series(1, 4000) gs;
+SELECT bm25_spill_index('docs_de_bm25');
+SELECT bm25_force_merge('docs_de_bm25');
+SQL
+}
+
+writer() {
+    for i in $(seq 1 120); do
+        $PSQL -c "INSERT INTO docs (content, lang)
+          SELECT 'writer postgres bm25 ' || gs, 'de'
+          FROM generate_series(1, 30) gs" \
+          >>"${ERR_DIR}/writer.log" 2>&1 || return 10
+    done
+}
+
+merger() {
+    for i in $(seq 1 200); do
+        $PSQL -c "SELECT bm25_spill_index('docs_de_bm25');
+                  SELECT bm25_force_merge('docs_de_bm25')" \
+          >>"${ERR_DIR}/merger.log" 2>&1 || return 30
+    done
+}
+
+# Forces the standalone (<@> operator) scoring path via enable_indexscan=off.
+reader() {
+    local tag=$1
+    for i in $(seq 1 300); do
+        $PSQL -c "SET enable_indexscan=off; SET enable_bitmapscan=off;
+          SELECT count(*) FROM (
+            SELECT id FROM docs WHERE lang='de'
+            ORDER BY content <@> to_bm25query('postgres bm25', 'docs_de_bm25')
+            LIMIT 20
+          ) s" >>"${ERR_DIR}/reader_${tag}.log" 2>&1 || return 40
+    done
+}
+
+run_test() {
+    log "Running concurrent writer + merger + readers (standalone path)..."
+
+    writer & w_pid=$!
+    merger & m_pid=$!
+    reader a & ra_pid=$!
+    reader b & rb_pid=$!
+
+    local failed=0
+    wait $w_pid || { warn "writer failed"; failed=1; }
+    wait $m_pid || { warn "merger failed"; failed=1; }
+    wait $ra_pid || { warn "reader a failed"; failed=1; }
+    wait $rb_pid || { warn "reader b failed"; failed=1; }
+
+    # Surface the actual error for diagnosis.
+    if grep -RIl "invalid segment header" "${ERR_DIR}" >/dev/null 2>&1; then
+        warn "Found 'invalid segment header' in client logs:"
+        grep -RIn "invalid segment header" "${ERR_DIR}" | head -5
+        error "TEST FAILED: issue #404 reproduced (invalid segment header)"
+    fi
+
+    if [ "$failed" -ne 0 ]; then
+        warn "Client logs:"
+        tail -n 20 "${ERR_DIR}"/*.log 2>/dev/null || true
+        error "TEST FAILED: a concurrent client exited with an error"
+    fi
+
+    log "TEST PASSED: partial-index standalone reads survived concurrent spill/merge"
+}
+
+# Main
+setup_test_db
+seed_data
+run_test
+
+log "All tests passed!"
+exit 0

--- a/test/scripts/partial_concurrent_read.sh
+++ b/test/scripts/partial_concurrent_read.sh
@@ -1,23 +1,13 @@
 #!/bin/bash
 #
-# Regression test for issue #404:
-#   "Partial BM25 reads can fail with invalid segment header during
-#    concurrent matching writes and spill/merge"
+# Regression test for issue #404: the standalone <@> scoring operator
+# (used on a seqscan) opened segment pages without the per-index LWLock,
+# so a concurrent spill/merge could free and recycle those blocks under
+# the reader, yielding "invalid segment header".
 #
-# The standalone <@> scoring operator (used when the planner picks a
-# sequential scan instead of an index scan) opened segment pages by block
-# number WITHOUT holding the per-index LWLock. A concurrent spill/merge
-# (LW_EXCLUSIVE) frees old segment pages and the memtable recycles those
-# blocks, so the unlocked reader could read a recycled memtable page where
-# a segment header was expected:
-#
-#   ERROR: invalid segment header at block N
-#   DETAIL: magic=0x5450544D, expected 0x54505347
-#
-# The reader below forces the standalone path (enable_indexscan=off) on a
-# selective partial index while writers and spill/merge run concurrently.
-# Before the fix this fails within a few seconds; after the fix it must
-# complete cleanly.
+# The reader forces the standalone path (enable_indexscan=off) on a
+# partial index while writers and spill/merge run concurrently. Before the
+# fix this fails within seconds; after it, it completes cleanly.
 #
 
 set -e
@@ -96,10 +86,8 @@ SELECT bm25_spill_index('docs_de_bm25');
 SELECT bm25_force_merge('docs_de_bm25');
 SQL
 
-    # Guard against silent planner drift: the regression only exercises the
-    # buggy code path if the reader query runs as a Seq Scan (standalone
-    # <@> scoring). Fail loudly if a future planner change picks an index
-    # scan instead, which would make this test silently stop covering #404.
+    # The test only covers #404 if the reader runs as a Seq Scan
+    # (standalone <@> scoring); fail loudly if the planner picks otherwise.
     local plan
     plan=$($PSQL -c "SET enable_indexscan=off; SET enable_bitmapscan=off;
         EXPLAIN (COSTS off)
@@ -131,10 +119,8 @@ merger() {
     done
 }
 
-# "Partial" is incidental here: the trigger is the standalone <@> scoring
-# path, which the planner uses for a sequential scan (enable_indexscan=off
-# below). A partial index just makes that plan more likely; there is no
-# distinct partial-index code path involved.
+# "Partial" is incidental: the trigger is the standalone <@> seqscan path
+# (forced by enable_indexscan=off), not any partial-index-specific code.
 reader() {
     local tag=$1
     for i in $(seq 1 300); do


### PR DESCRIPTION
Fixes #404. The standalone `<@>` scoring path (used on a seqscan) opened segment pages without the per-index lock, so a concurrent spill/merge could free and recycle those blocks under the reader — surfacing as `invalid segment header ... magic=0x5450544D, expected 0x54505347`. It now takes the lock `LW_SHARED` and re-reads the `level_heads` snapshot under it before the segment reads (the unlocked snapshot can already name a recycled block), lazily on IDF cache-miss so cache-hit rows stay lock-free. The acquire is ownership-aware to coexist with the memtable chain source. The same unlocked segment walk in `bm25_summarize_index`/`bm25_dump_index` is fixed too.

Adds `test/scripts/partial_concurrent_read.sh` (run by `test-concurrency`), which forces the standalone path under concurrent spill/merge; it fails before the fix and passes after.