### PR TITLE
Restrict debug_panic_after_spill_finalize to superusers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ make format-single FILE=path/to/file.c  # format specific file
 | `pg_textsearch.memtable_pages_threshold` | Chain pages before auto-spill (0 = disable) | 64 |
 | `pg_textsearch.segments_per_level` | Segments before compaction | 8 |
 | `pg_textsearch.compress_segments` | Enable compression for new segment blocks | true |
-| `pg_textsearch.debug_panic_after_spill_finalize` | Trigger PANIC after spill finalize (testing only) | false |
+| `pg_textsearch.debug_panic_after_spill_finalize` | Trigger PANIC after spill finalize (testing only, superuser-only) | false |
 | `pg_textsearch.memtable_cache_enabled` | Serve query reads from the in-memory memtable cache instead of the on-disk chain (chain remains source of truth; standbys always use the chain) | true |
 | `pg_textsearch.log_cache_state` | Log in-memory cache apply outcomes (OK / BUDGET_EXCEEDED / cold_build / RETRY / ABORT / fall back to chain) | false |
 | `pg_textsearch.memory_limit` | Max shared memory (KB, `PGC_SIGHUP`) for the in-memory memtable cache. Three-tier budget: per-index soft cap (`limit/8`) → BUDGET_EXCEEDED + chain fallback; global soft cap (`limit/2`) → evict largest non-caller cache; global hard cap (`limit`) → refuse new cache builds. `0` = no limit. See `docs/memtable_cache.md` | 2 GB |

--- a/src/mod.c
+++ b/src/mod.c
@@ -325,7 +325,8 @@ _PG_init(void)
 			"testing crash-safe spill ordering.",
 			&tp_debug_panic_after_spill_finalize,
 			false,
-			PGC_USERSET,
+			PGC_SUSET, /* superuser-only: forces a server-wide PANIC,
+						* so unprivileged roles must not reach it */
 			0,
 			NULL,
 			NULL,


### PR DESCRIPTION
`pg_textsearch.debug_panic_after_spill_finalize` was `PGC_USERSET` but forces an `elog(PANIC)` in the spill path, which crashes the whole cluster into recovery. Any role able to trigger a spill (e.g. a bulk INSERT past the threshold) could use it as a repeatable full-cluster DoS, so this makes it `PGC_SUSET` like the other debug GUCs. The crash-safety shell test connects as the bootstrap superuser, so it's unaffected; verified manually that a non-superuser `SET` now gets permission denied.