### PR TITLE
Fix VACUUM-vs-merge race: read segment metapage under the per-index lock (#411)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,13 @@ jobs:
           echo "✗ Concurrency tests failed"
           exit 1
         fi
+        echo "Running VACUUM concurrency tests..."
+        if (cd test/scripts && ./vacuum_concurrent_merge.sh); then
+          echo "✓ VACUUM concurrency tests passed"
+        else
+          echo "✗ VACUUM concurrency tests failed"
+          exit 1
+        fi
         echo "Running segment tests..."
         if (cd test/scripts && ./segment.sh); then
           echo "✓ Segment tests passed"

--- a/.github/workflows/sanitizer-build-and-test.yml
+++ b/.github/workflows/sanitizer-build-and-test.yml
@@ -185,6 +185,14 @@ jobs:
           cd test/scripts && ./concurrency.sh
         "
 
+        echo "Running VACUUM concurrency tests under sanitizer..."
+        timeout 1200s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./vacuum_concurrent_merge.sh
+        "
+
         echo "Running crash recovery tests under sanitizer..."
         timeout 600s bash -c "
           export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ test-concurrency:
 	@echo "Running concurrency tests..."
 	@cd test/scripts && ./concurrency.sh
 	@cd test/scripts && ./partial_concurrent_read.sh
+	@cd test/scripts && ./vacuum_concurrent_merge.sh
 
 test-recovery:
 	@echo "Running crash recovery tests..."

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -851,7 +851,28 @@ tp_bulkdelete(
 	if (index_state != NULL)
 		tp_spill_memtable_if_needed(info->index, index_state, 1);
 
-	/* Re-read metapage after spill */
+	/*
+	 * Hold the per-index LWLock in shared mode across Phase 2 (identify)
+	 * and Phase 3 (mark / replace).  A concurrent spill / merge /
+	 * compaction takes LW_EXCLUSIVE to mutate level_heads and free
+	 * segment pages via the FSM, so without this lock a segment we
+	 * identify in Phase 2 can be shrunk or have its blocks recycled
+	 * before Phase 3 reopens it by block number -- yielding an
+	 * "invalid segment header" error or, when a shrunk segment still
+	 * passes the header magic check, an out-of-bounds alive-bitset
+	 * write from a now-stale doc_id (tp_alive_bitset_mark_dead).  See
+	 * tp_vacuumcleanup, which holds the same lock for the same reason.
+	 *
+	 * Acquire after Phase 1's spill (which takes LW_EXCLUSIVE itself) to
+	 * avoid a shared->exclusive upgrade, and before re-reading the
+	 * metapage so the level_heads snapshot we walk stays stable.  Inserts
+	 * and scans also hold this lock LW_SHARED, so they are unaffected;
+	 * only the exclusive block-recyclers wait.
+	 */
+	if (index_state != NULL)
+		tp_acquire_index_lock(index_state, LW_SHARED);
+
+	/* Re-read metapage after spill (now under the shared lock) */
 	pfree(metap);
 	metap = tp_get_metapage(info->index);
 	if (!metap)
@@ -859,6 +880,7 @@ tp_bulkdelete(
 		stats->num_pages		= 1;
 		stats->num_index_tuples = 0;
 		stats->tuples_removed	= 0;
+		tp_release_index_lock(index_state);
 		return stats;
 	}
 
@@ -880,6 +902,7 @@ tp_bulkdelete(
 		stats->pages_deleted	= 0;
 		pfree(metap);
 		pfree(segments);
+		tp_release_index_lock(index_state);
 		return stats;
 	}
 
@@ -1002,6 +1025,9 @@ tp_bulkdelete(
 				info->index, docs_shrinkage, tokens_shrinkage);
 	}
 
+	/* Identify + mark complete; drop the shared lock. */
+	tp_release_index_lock(index_state);
+
 	/*
 	 * tp_vacuumcleanup will set num_index_tuples to the actual live
 	 * count; only tuples_removed needs to carry through from here.
@@ -1050,7 +1076,20 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 		tp_spill_memtable_if_needed(
 				info->index, index_state, TP_MIN_SPILL_PAGES);
 
-	/* Get current index statistics from metapage */
+	/*
+	 * Acquire the per-index LWLock in shared mode *before* reading the
+	 * metapage so the level_heads snapshot we walk in tp_count_live_docs
+	 * stays valid: concurrent spills / compactions take LW_EXCLUSIVE to
+	 * mutate level_heads and free segment pages via the FSM, so a snapshot
+	 * read outside the lock could leave us opening a block a merge has
+	 * already recycled ("invalid segment header").  Acquire after the
+	 * spill above (which takes LW_EXCLUSIVE itself) to avoid a
+	 * shared->exclusive upgrade.
+	 */
+	if (index_state != NULL)
+		tp_acquire_index_lock(index_state, LW_SHARED);
+
+	/* Get current index statistics from metapage (under the shared lock) */
 	metap = tp_get_metapage(info->index);
 	if (metap)
 	{
@@ -1063,14 +1102,10 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 		 * regardless of whether tp_bulkdelete ran or this is a
 		 * no-deletes maintenance round.
 		 *
-		 * Hold the per-index LWLock in shared mode across the walk
-		 * so concurrent spills / compactions (which take
-		 * LW_EXCLUSIVE to mutate level_heads and free segment
-		 * pages via the FSM) can't recycle a page we're about to
-		 * tp_segment_open.
+		 * The per-index LWLock acquired above is held across the walk
+		 * so concurrent spills / compactions can't recycle a page we're
+		 * about to tp_segment_open.
 		 */
-		if (index_state != NULL)
-			tp_acquire_index_lock(index_state, LW_SHARED);
 		stats->num_index_tuples = (double)
 				tp_count_live_docs(info->index, metap);
 		if (index_state != NULL)
@@ -1105,6 +1140,9 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 	}
 	else
 	{
+		if (index_state != NULL)
+			tp_release_index_lock(index_state);
+
 		elog(WARNING,
 			 "Tapir vacuum cleanup: couldn't read metapage "
 			 "for index %s",

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -866,8 +866,12 @@ tp_bulkdelete(
 	 * Acquire after Phase 1's spill (which takes LW_EXCLUSIVE itself) to
 	 * avoid a shared->exclusive upgrade, and before re-reading the
 	 * metapage so the level_heads snapshot we walk stays stable.  Inserts
-	 * and scans also hold this lock LW_SHARED, so they are unaffected;
-	 * only the exclusive block-recyclers wait.
+	 * and scans also hold this lock LW_SHARED, so they neither block nor
+	 * are blocked by this walk; only the exclusive spill/merge/compaction
+	 * recyclers are excluded.  (VACUUM's own Phase-3 page reclamation also
+	 * runs under LW_SHARED and so is not excluded against concurrent
+	 * scans -- a separate, pre-existing concern tracked in issue #413, not
+	 * addressed here.)
 	 */
 	if (index_state != NULL)
 		tp_acquire_index_lock(index_state, LW_SHARED);
@@ -880,7 +884,8 @@ tp_bulkdelete(
 		stats->num_pages		= 1;
 		stats->num_index_tuples = 0;
 		stats->tuples_removed	= 0;
-		tp_release_index_lock(index_state);
+		if (index_state != NULL)
+			tp_release_index_lock(index_state);
 		return stats;
 	}
 
@@ -902,7 +907,8 @@ tp_bulkdelete(
 		stats->pages_deleted	= 0;
 		pfree(metap);
 		pfree(segments);
-		tp_release_index_lock(index_state);
+		if (index_state != NULL)
+			tp_release_index_lock(index_state);
 		return stats;
 	}
 
@@ -1026,7 +1032,8 @@ tp_bulkdelete(
 	}
 
 	/* Identify + mark complete; drop the shared lock. */
-	tp_release_index_lock(index_state);
+	if (index_state != NULL)
+		tp_release_index_lock(index_state);
 
 	/*
 	 * tp_vacuumcleanup will set num_index_tuples to the actual live

--- a/src/segment/alive_bitset.c
+++ b/src/segment/alive_bitset.c
@@ -90,7 +90,7 @@ tp_alive_bitset_load(TpSegmentReader *reader)
  * Mark a document as dead in the in-memory bitset.
  *
  * Returns true if the document was previously alive (and alive_count
- * was decremented), false if it was already dead.
+ * was decremented), false if it was already dead or out of range.
  */
 bool
 tp_alive_bitset_mark_dead(TpAliveBitset *bitset, uint32 doc_id)
@@ -99,6 +99,16 @@ tp_alive_bitset_mark_dead(TpAliveBitset *bitset, uint32 doc_id)
 	uint8  bit_mask;
 
 	Assert(doc_id < bitset->num_docs);
+
+	/*
+	 * Defense in depth for non-assert builds: a doc_id past num_docs is a
+	 * stale id -- e.g. a segment shrunk by a concurrent merge between
+	 * VACUUM's identify and mark phases (callers must hold the per-index
+	 * lock to prevent this; see tp_bulkdelete).  Never write out of
+	 * bounds if one slips through.
+	 */
+	if (doc_id >= bitset->num_docs)
+		return false;
 
 	byte_idx = doc_id >> 3;
 	bit_mask = (uint8)(1 << (doc_id & 7));

--- a/src/segment/alive_bitset.h
+++ b/src/segment/alive_bitset.h
@@ -80,7 +80,9 @@ extern TpAliveBitset *tp_alive_bitset_load(TpSegmentReader *reader);
 
 /*
  * Mark a doc as dead.  Returns true if it was alive
- * (i.e., the alive_count was decremented).
+ * (i.e., the alive_count was decremented), false if it was
+ * already dead or out of range (doc_id >= num_docs; a no-op
+ * that leaves alive_count unchanged).
  */
 extern bool tp_alive_bitset_mark_dead(TpAliveBitset *bitset, uint32 doc_id);
 

--- a/test/scripts/vacuum_concurrent_merge.sh
+++ b/test/scripts/vacuum_concurrent_merge.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+#
+# Regression test for the VACUUM-vs-merge race (issue #411): the index
+# bulk-delete (tp_bulkdelete) and cleanup (tp_vacuumcleanup) paths walked
+# segments by block number while reading the metapage snapshot outside the
+# per-index LWLock, so a concurrent spill/merge could free and recycle those
+# blocks between identifying a segment and reopening it.  This produced
+# "invalid segment header" errors ("while cleaning up index" / "while
+# vacuuming index") and, when a recycled block still passed the header magic
+# check, an out-of-bounds alive-bitset write (TRAP: failed
+# Assert("doc_id < bitset->num_docs"), or a SIGSEGV in release builds).
+#
+# Writers spill many small segments, a merger force-merges them, a deleter
+# creates dead tuples, and a vacuumer runs VACUUM concurrently (autovacuum
+# is also aggressive).  Before the fix this fails within seconds; after it,
+# it completes cleanly with no segment-header errors and no crash.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PORT=55442
+TEST_DB=vacuum_concurrent_merge_test
+DATA_DIR="${SCRIPT_DIR}/../tmp_vacuum_concurrent_merge"
+LOGFILE="${DATA_DIR}/postgres.log"
+ERR_DIR="${DATA_DIR}/client_logs"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"; }
+warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARNING: $1${NC}"; }
+error() { echo -e "${RED}[$(date '+%H:%M:%S')] ERROR: $1${NC}"; exit 1; }
+
+cleanup() {
+    local exit_code=$?
+    log "Cleaning up (exit code: $exit_code)..."
+    jobs -p | xargs -r kill 2>/dev/null || true
+    if [ -f "${DATA_DIR}/postmaster.pid" ]; then
+        pg_ctl stop -D "${DATA_DIR}" -m immediate &>/dev/null || true
+    fi
+    rm -rf "${DATA_DIR}"
+    exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+setup_test_db() {
+    log "Setting up PostgreSQL instance..."
+    rm -rf "${DATA_DIR}"
+    mkdir -p "${DATA_DIR}"
+
+    initdb -D "${DATA_DIR}" --auth-local=trust --auth-host=trust >/dev/null 2>&1
+    mkdir -p "${ERR_DIR}"
+
+    cat >> "${DATA_DIR}/postgresql.conf" << EOF
+port = ${TEST_PORT}
+unix_socket_directories = '${DATA_DIR}'
+listen_addresses = 'localhost'
+shared_preload_libraries = 'pg_textsearch'
+logging_collector = on
+log_directory = '.'
+log_filename = 'postgres.log'
+autovacuum = on
+autovacuum_naptime = 1s
+EOF
+
+    pg_ctl start -D "${DATA_DIR}" -l "${LOGFILE}" -w -o "-p ${TEST_PORT}" || \
+        error "Failed to start PostgreSQL"
+
+    createdb -h "${DATA_DIR}" -p ${TEST_PORT} ${TEST_DB}
+    psql -h "${DATA_DIR}" -p ${TEST_PORT} -d ${TEST_DB} \
+        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+    log "Test database ready"
+}
+
+PSQL="psql -h ${DATA_DIR} -p ${TEST_PORT} -d ${TEST_DB} -qAt -v ON_ERROR_STOP=1"
+
+seed_data() {
+    log "Creating bm25 index and seeding data..."
+    $PSQL <<'SQL' >/dev/null
+SET client_min_messages=warning;
+CREATE TABLE docs (id bigserial PRIMARY KEY, body text NOT NULL);
+CREATE INDEX docs_bm25 ON docs USING bm25(body) WITH (text_config='english');
+-- Force frequent autovacuum bulk-delete on this table.
+ALTER TABLE docs SET (autovacuum_vacuum_scale_factor=0,
+                      autovacuum_vacuum_threshold=200);
+INSERT INTO docs (body)
+SELECT 'seed postgres bm25 ' || md5(gs::text)
+FROM generate_series(1, 2000) gs;
+SELECT bm25_spill_index('docs_bm25');
+SQL
+}
+
+# Spill the memtable aggressively so many small segments accrue for the
+# merger to compact.
+writer() {
+    for i in $(seq 1 120); do
+        $PSQL -c "SET pg_textsearch.memtable_pages_threshold=4;
+          SET statement_timeout='60s'; SET lock_timeout='30s';
+          INSERT INTO docs (body)
+          SELECT 'w postgres bm25 ' || md5(random()::text)
+          FROM generate_series(1, 200) gs;
+          SELECT bm25_spill_index('docs_bm25')" \
+          >>"${ERR_DIR}/writer.log" 2>&1 || return 10
+    done
+}
+
+# Concurrent spill + force-merge: the LW_EXCLUSIVE segment recycler that
+# races VACUUM.
+merger() {
+    for i in $(seq 1 250); do
+        $PSQL -c "SELECT bm25_spill_index('docs_bm25');
+                  SELECT bm25_force_merge('docs_bm25')" \
+          >>"${ERR_DIR}/merger.log" 2>&1 || return 30
+    done
+}
+
+# Delete the oldest rows by id (monotonic -> no row-lock deadlocks) to
+# create dead tuples for VACUUM bulk-delete to reclaim.
+deleter() {
+    for i in $(seq 1 250); do
+        $PSQL -c "DELETE FROM docs
+                  WHERE id IN (SELECT id FROM docs ORDER BY id ASC LIMIT 120)" \
+          >>"${ERR_DIR}/deleter.log" 2>&1 || return 40
+        sleep 0.1
+    done
+}
+
+# Explicit VACUUM in a loop deterministically exercises the bulk-delete and
+# cleanup paths concurrently with the merger.
+vacuumer() {
+    for i in $(seq 1 200); do
+        $PSQL -c "VACUUM docs" >>"${ERR_DIR}/vacuumer.log" 2>&1 || return 50
+        sleep 0.05
+    done
+}
+
+run_test() {
+    log "Running concurrent writer + merger + deleter + vacuumer..."
+
+    writer & w_pid=$!
+    merger & m_pid=$!
+    deleter & d_pid=$!
+    vacuumer & v_pid=$!
+
+    local failed=0
+    wait $w_pid || { warn "writer failed"; failed=1; }
+    wait $m_pid || { warn "merger failed"; failed=1; }
+    wait $d_pid || { warn "deleter failed"; failed=1; }
+    wait $v_pid || { warn "vacuumer failed"; failed=1; }
+
+    # The bug surfaces both server-side (autovacuum) and client-side
+    # (explicit VACUUM).  Check both the server log and client logs.
+    if grep -RIl "invalid segment header" "${ERR_DIR}" "${LOGFILE}" \
+        >/dev/null 2>&1; then
+        warn "Found 'invalid segment header':"
+        grep -RIn "invalid segment header" "${ERR_DIR}" "${LOGFILE}" | head -5
+        error "TEST FAILED: issue #411 reproduced (invalid segment header)"
+    fi
+
+    # An out-of-bounds alive-bitset write crashes the backend.
+    if grep -qE "TRAP: failed Assert|was terminated by signal|server closed the connection unexpectedly" \
+        "${LOGFILE}" "${ERR_DIR}"/*.log 2>/dev/null; then
+        warn "Found a crash signature:"
+        grep -hE "TRAP: failed Assert|was terminated by signal|alive_bitset" \
+            "${LOGFILE}" 2>/dev/null | head -5
+        error "TEST FAILED: issue #411 reproduced (backend crash)"
+    fi
+
+    if [ "$failed" -ne 0 ]; then
+        warn "Client logs:"
+        tail -n 20 "${ERR_DIR}"/*.log 2>/dev/null || true
+        error "TEST FAILED: a concurrent client exited with an error"
+    fi
+
+    log "TEST PASSED: VACUUM survived concurrent spill/merge"
+}
+
+# Main
+setup_test_db
+seed_data
+run_test
+
+log "All tests passed!"
+exit 0


### PR DESCRIPTION
## Summary

Fixes #411 — a TOCTOU race between `VACUUM`/autovacuum and concurrent segment spill/merge that produced `invalid segment header` errors and, in the worst case, an out-of-bounds write in the alive bitset (`TRAP: failed Assert("doc_id < bitset->num_docs")` under cassert, or a SIGSEGV in release builds).

The race affects **both** VACUUM paths in `src/access/vacuum.c`. Both read the metapage `level_heads` snapshot and then open segments **by block number**, while a concurrent spill/merge/compaction (`tp_do_spill` → `tp_maybe_compact_level`, or `bm25_force_merge`, all under `LW_EXCLUSIVE`) frees and recycles those blocks via the FSM:

- **`tp_bulkdelete`** (`ambulkdelete`, `CONTEXT: while vacuuming index`) held **no** per-index lock across Phase 2 (`tp_vacuum_identify_affected`) → Phase 3 (`tp_vacuum_mark_dead`). A segment shrunk by a merge between the phases makes a previously-collected `doc_id` exceed the reloaded bitset's `num_docs`, driving the out-of-bounds write in `tp_alive_bitset_mark_dead`.
- **`tp_vacuumcleanup`** (`amvacuumcleanup`, `CONTEXT: while cleaning up index`) *did* take the per-index lock `LW_SHARED`, but **acquired it after reading the metapage**, so the snapshot walked by `tp_count_live_docs` was already stale. Under autovacuum this is the dominant manifestation of `invalid segment header`.

## Changes

- **`tp_bulkdelete`**: acquire the per-index lock `LW_SHARED` after Phase 1's spill (which itself takes `LW_EXCLUSIVE`, so this avoids a shared→exclusive upgrade) and hold it across identify + mark/replace; release on every exit path.
- **`tp_vacuumcleanup`**: acquire `LW_SHARED` **before** reading the metapage so the `level_heads` snapshot is taken under the lock.
- **`tp_alive_bitset_mark_dead`**: skip `doc_id >= num_docs` instead of writing out of bounds — defense in depth for non-assert builds (the assert is preserved as a canary).

Inserts and scans already hold this lock `LW_SHARED`, so they are unaffected; only the exclusive segment-recyclers wait. This matches the existing convention already used by `tp_vacuumcleanup`'s reclaim walk and the #404 read-path fix.

## Test

Adds `test/scripts/vacuum_concurrent_merge.sh` (wired into `make test-concurrency`): concurrent writers (spilling many small segments) + `bm25_force_merge` loop + monotonic deleter + `VACUUM` loop on one shared `bm25` index, with aggressive autovacuum. It checks the server and client logs for `invalid segment header` and crash signatures. A serial `installcheck` cannot catch this concurrency bug, so a dedicated stress script is needed.

## Verification (stock PostgreSQL 17.9, `--enable-cassert`)

A/B with a concurrent harness (6 writers + force-merge loop + monotonic deleter + 2 readers, aggressive autovacuum):

| build | duration | `invalid segment header` (VACUUM ctx) | crash |
|---|---|---|---|
| unmodified `main` | 4 min | **18** | — |
| `tp_bulkdelete` fix only | 10 min | 24 (all cleanup ctx) | — |
| **both paths fixed (this PR)** | 10 min | **0** | none |

- `vacuum_concurrent_merge.sh`: **fails within ~30 s on `main`**, **passes** with this change.
- `make installcheck`: all 70 tests pass.
- `make format-check`: clean on the changed files.
