### PR TITLE
test(expression_index): don't assert non-deterministic build doc count

### DIFF
--- a/test/expected/expression_index.out
+++ b/test/expected/expression_index.out
@@ -231,14 +231,13 @@ DROP TABLE expr_part CASCADE;
 -- ============================================================
 -- Suppress build-progress NOTICEs for this index: its reported
 -- document count is not deterministic here.  expr_jsonb had rows
--- deleted and vacuumed above, but if any concurrent backend holds
--- back OldestXmin (autovacuum, a parallel session, or background
--- work on disaggregated-storage forks) VACUUM keeps the deleted
--- tuples "recently dead", and this fresh build indexes them --
--- table_index_build_scan passes recently-dead tuples to the build
--- callback, exactly as any access method does.  The exact count is
+-- deleted and vacuumed above, but if a concurrent backend holds
+-- back OldestXmin (autovacuum or a parallel session), VACUUM leaves
+-- the deleted tuples "recently dead" and this fresh build indexes
+-- them -- table_index_build_scan passes recently-dead tuples to the
+-- build callback, as any access method does.  The exact count is
 -- irrelevant to what this section tests (the multiple-index
--- resolution warning), so don't let it perturb the expected output.
+-- resolution warning), so suppress it.
 SET client_min_messages = warning;
 CREATE INDEX expr_jsonb_idx2 ON expr_jsonb
     USING bm25 ((data->>'content'))

--- a/test/expected/expression_index.out
+++ b/test/expected/expression_index.out
@@ -229,13 +229,21 @@ DROP TABLE expr_part CASCADE;
 -- ============================================================
 -- Multiple expression indexes trigger warning
 -- ============================================================
+-- Suppress build-progress NOTICEs for this index: its reported
+-- document count is not deterministic here.  expr_jsonb had rows
+-- deleted and vacuumed above, but if any concurrent backend holds
+-- back OldestXmin (autovacuum, a parallel session, or background
+-- work on disaggregated-storage forks) VACUUM keeps the deleted
+-- tuples "recently dead", and this fresh build indexes them --
+-- table_index_build_scan passes recently-dead tuples to the build
+-- callback, exactly as any access method does.  The exact count is
+-- irrelevant to what this section tests (the multiple-index
+-- resolution warning), so don't let it perturb the expected output.
+SET client_min_messages = warning;
 CREATE INDEX expr_jsonb_idx2 ON expr_jsonb
     USING bm25 ((data->>'content'))
     WITH (text_config='simple');
-NOTICE:  BM25 index build started for relation expr_jsonb_idx2
-NOTICE:  Using text search configuration: simple
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 1 documents, avg_length=5.00
+RESET client_min_messages;
 -- Implicit resolution should warn about multiple indexes
 SELECT id,
        ROUND(((data->>'content') <@>

--- a/test/sql/expression_index.sql
+++ b/test/sql/expression_index.sql
@@ -207,14 +207,13 @@ DROP TABLE expr_part CASCADE;
 
 -- Suppress build-progress NOTICEs for this index: its reported
 -- document count is not deterministic here.  expr_jsonb had rows
--- deleted and vacuumed above, but if any concurrent backend holds
--- back OldestXmin (autovacuum, a parallel session, or background
--- work on disaggregated-storage forks) VACUUM keeps the deleted
--- tuples "recently dead", and this fresh build indexes them --
--- table_index_build_scan passes recently-dead tuples to the build
--- callback, exactly as any access method does.  The exact count is
+-- deleted and vacuumed above, but if a concurrent backend holds
+-- back OldestXmin (autovacuum or a parallel session), VACUUM leaves
+-- the deleted tuples "recently dead" and this fresh build indexes
+-- them -- table_index_build_scan passes recently-dead tuples to the
+-- build callback, as any access method does.  The exact count is
 -- irrelevant to what this section tests (the multiple-index
--- resolution warning), so don't let it perturb the expected output.
+-- resolution warning), so suppress it.
 SET client_min_messages = warning;
 CREATE INDEX expr_jsonb_idx2 ON expr_jsonb
     USING bm25 ((data->>'content'))

--- a/test/sql/expression_index.sql
+++ b/test/sql/expression_index.sql
@@ -205,9 +205,21 @@ DROP TABLE expr_part CASCADE;
 -- Multiple expression indexes trigger warning
 -- ============================================================
 
+-- Suppress build-progress NOTICEs for this index: its reported
+-- document count is not deterministic here.  expr_jsonb had rows
+-- deleted and vacuumed above, but if any concurrent backend holds
+-- back OldestXmin (autovacuum, a parallel session, or background
+-- work on disaggregated-storage forks) VACUUM keeps the deleted
+-- tuples "recently dead", and this fresh build indexes them --
+-- table_index_build_scan passes recently-dead tuples to the build
+-- callback, exactly as any access method does.  The exact count is
+-- irrelevant to what this section tests (the multiple-index
+-- resolution warning), so don't let it perturb the expected output.
+SET client_min_messages = warning;
 CREATE INDEX expr_jsonb_idx2 ON expr_jsonb
     USING bm25 ((data->>'content'))
     WITH (text_config='simple');
+RESET client_min_messages;
 
 -- Implicit resolution should warn about multiple indexes
 SELECT id,


### PR DESCRIPTION
## Summary

Makes the `expression_index` regression test deterministic. The
"multiple expression indexes trigger warning" section builds
`expr_jsonb_idx2` on `expr_jsonb` **after** rows have been `DELETE`d and
`VACUUM`ed, and asserts the build-progress NOTICE
`BM25 index build completed: 1 documents, avg_length=5.00`.

That document count is only correct when `VACUUM` has *physically
removed* the deleted tuples. If a concurrent backend holds back
`OldestXmin` (autovacuum or a parallel regression session), `VACUUM`
leaves the deleted tuples **recently dead**, and the fresh `CREATE
INDEX` indexes them — `table_index_build_scan` passes recently-dead
tuples to the build callback, exactly as every access method does
(`tp_build_callback` intentionally ignores `tupleIsAlive`). The NOTICE
then reports `3 documents, avg_length=4.00` and the test fails.

## This is standard MVCC

Reproduced by holding one `REPEATABLE READ` snapshot open during the
run:

| Condition | `VACUUM` result | Build NOTICE | Test |
|---|---|---|---|
| isolated (today's CI) | `2 removed, 1 remain` | `1 documents, avg_length=5.00` | pass |
| concurrent snapshot pinning `OldestXmin` | `0 removed, 3 remain, 2 dead but not yet removable` | `3 documents, avg_length=4.00` | **fail** |

Running the real `expression_index` test under the held snapshot fails
with exactly this one-line diff:

```
-NOTICE:  BM25 index build completed: 1 documents, avg_length=5.00
+NOTICE:  BM25 index build completed: 3 documents, avg_length=4.00
```

CI passes today only because the suite runs isolated; any concurrent
backend that reliably pins `OldestXmin` makes it fail deterministically.

## Fix

The exact count is irrelevant to what the section tests (the
multiple-index *resolution warning*), so suppress the build-progress
NOTICEs for that one index with `client_min_messages = warning`. No
production code change.

## Verification

- Passes in isolation (unchanged behavior).
- Passes under a concurrent `REPEATABLE READ` snapshot pinning
  `OldestXmin` — the condition that previously produced the failing diff
  (clean run, zero `regression.diffs`).

## Notes

I deliberately did **not** copy the `unlogged_index` "wait for
`backend_xmin` to clear, then VACUUM" guard: it is not robust against a
*persistent* xmin holder (it still flakes), whereas removing the timing
dependency is. A similar robustness pass for `inheritance` /
`unlogged_index` can follow separately.
