### PR TITLE
test(unlogged_index): make alive-bitset shrinkage assert robust to OldestXmin retention

### DIFF
--- a/test/expected/unlogged_index.out
+++ b/test/expected/unlogged_index.out
@@ -192,28 +192,12 @@ CREATE TABLE unlogged_shrink_diag (
 -- the regression .out file stays focused on the final diagnostic
 -- SELECTs.
 \set ECHO none
-SELECT docs_persisted, post_merge_segs,
-       count(*) AS n_iter
+SELECT iter, pre_merge_segs, docs_persisted, post_merge_segs
 FROM unlogged_shrink_diag
-GROUP BY docs_persisted, post_merge_segs
-ORDER BY docs_persisted, post_merge_segs;
-   docs_persisted    |          post_merge_segs           | n_iter 
----------------------+------------------------------------+--------
- docs_persisted: 100 |  L1 Segment 1: terms=203, docs=100 |      8
-(1 row)
-
-WITH most_common AS (
-    SELECT docs_persisted, post_merge_segs
-    FROM unlogged_shrink_diag
-    GROUP BY docs_persisted, post_merge_segs
-    ORDER BY count(*) DESC, docs_persisted, post_merge_segs
-    LIMIT 1
-)
-SELECT d.iter, d.pre_merge_segs, d.docs_persisted, d.post_merge_segs
-FROM unlogged_shrink_diag d, most_common m
-WHERE (d.docs_persisted, d.post_merge_segs)
-   IS DISTINCT FROM (m.docs_persisted, m.post_merge_segs)
-ORDER BY d.iter;
+WHERE pre_merge_segs ~ 'dead='
+  AND (docs_persisted IS DISTINCT FROM 'docs_persisted: 100'
+       OR post_merge_segs !~ 'docs=100')
+ORDER BY iter;
  iter | pre_merge_segs | docs_persisted | post_merge_segs 
 ------+----------------+----------------+-----------------
 (0 rows)

--- a/test/sql/unlogged_index.sql
+++ b/test/sql/unlogged_index.sql
@@ -294,35 +294,27 @@ RESET client_min_messages;
 \o
 \set ECHO queries
 
--- The merge-time alive-bitset shrinkage path can only run when
--- VACUUM actually marked the deleted docs dead, which requires
--- OldestXmin to have advanced past our DELETE.  If a concurrent
--- backend holds OldestXmin back (autovacuum on the catalog, a
--- parallel regression session, or background work on
--- disaggregated-storage forks such as HorizonDB), the index
--- ambulkdelete callback classifies the deleted tuples as "dead but
--- not yet removable", the per-segment alive_bitset never shrinks
--- (its post-VACUUM summary keeps docs=100 with no `dead=`
--- annotation) and the merge legitimately keeps all 200 source
--- docs.  That is the setup failing to meet its precondition, not a
--- regression -- and it is exactly the #397 flake that previously
--- forced this subtest to be disabled on the Orion fork.
+-- The merge-time alive-bitset shrinkage path only runs when VACUUM
+-- marked the deleted docs dead, which requires OldestXmin to have
+-- advanced past our DELETE.  If a concurrent backend holds
+-- OldestXmin back (e.g. autovacuum on the catalog or a parallel
+-- regression session), ambulkdelete classifies the tuples as "dead
+-- but not yet removable", the alive_bitset never shrinks (its
+-- post-VACUUM summary keeps docs=100 with no `dead=`), and the
+-- merge legitimately keeps all 200 source docs.  That is the setup
+-- failing its precondition (the #397 flake), not a regression.
 --
--- So assert correctness only for iterations where VACUUM *did*
--- shrink the bitset (pre_merge_segs annotated `dead=`): each such
--- iteration must report `docs_persisted: 100` and a merged L1
--- segment holding `docs=100`.  Iterations where OldestXmin was
--- pinned are skipped.  The output is invariant to how many
--- iterations fell into each bucket, so the test is deterministic
--- under concurrent load while still catching a genuinely broken
--- shrinkage path.
+-- So assert correctness only for iterations where VACUUM did shrink
+-- the bitset (pre_merge_segs annotated `dead=`): each must report
+-- `docs_persisted: 100` and a merged L1 segment with `docs=100`.
+-- Iterations where OldestXmin was pinned are skipped, leaving the
+-- test deterministic under concurrent load while still catching a
+-- broken shrinkage path.
 
--- Regression detector: iterations whose alive_bitset shrank at
--- VACUUM but whose merge did NOT drop the dead docs (the #397
--- "2x drift" symptom).  Must be empty.  pre_merge_segs and
--- post_merge_segs are included so a failure carries enough evidence
--- to confirm the shrinkage step ran (segments annotated
--- `(alive=50, dead=50)` after VACUUM).
+-- Regression detector: iterations whose bitset shrank at VACUUM but
+-- whose merge did NOT drop the dead docs (the #397 "2x drift").
+-- Must be empty; the segment columns are included so a failure
+-- shows the shrinkage ran (`(alive=50, dead=50)` after VACUUM).
 SELECT iter, pre_merge_segs, docs_persisted, post_merge_segs
 FROM unlogged_shrink_diag
 WHERE pre_merge_segs ~ 'dead='

--- a/test/sql/unlogged_index.sql
+++ b/test/sql/unlogged_index.sql
@@ -294,36 +294,41 @@ RESET client_min_messages;
 \o
 \set ECHO queries
 
--- Distinct-value collapse.  On the happy path every iteration
--- produced `docs_persisted: 100` with one merged L1 segment
--- holding `docs=100`, so we get exactly one row and n_iter = 8.
--- A divergent docs_persisted or post_merge_segs would split the
--- group and signal the #397 regression has returned.
-SELECT docs_persisted, post_merge_segs,
-       count(*) AS n_iter
-FROM unlogged_shrink_diag
-GROUP BY docs_persisted, post_merge_segs
-ORDER BY docs_persisted, post_merge_segs;
+-- The merge-time alive-bitset shrinkage path can only run when
+-- VACUUM actually marked the deleted docs dead, which requires
+-- OldestXmin to have advanced past our DELETE.  If a concurrent
+-- backend holds OldestXmin back (autovacuum on the catalog, a
+-- parallel regression session, or background work on
+-- disaggregated-storage forks such as HorizonDB), the index
+-- ambulkdelete callback classifies the deleted tuples as "dead but
+-- not yet removable", the per-segment alive_bitset never shrinks
+-- (its post-VACUUM summary keeps docs=100 with no `dead=`
+-- annotation) and the merge legitimately keeps all 200 source
+-- docs.  That is the setup failing to meet its precondition, not a
+-- regression -- and it is exactly the #397 flake that previously
+-- forced this subtest to be disabled on the Orion fork.
+--
+-- So assert correctness only for iterations where VACUUM *did*
+-- shrink the bitset (pre_merge_segs annotated `dead=`): each such
+-- iteration must report `docs_persisted: 100` and a merged L1
+-- segment holding `docs=100`.  Iterations where OldestXmin was
+-- pinned are skipped.  The output is invariant to how many
+-- iterations fell into each bucket, so the test is deterministic
+-- under concurrent load while still catching a genuinely broken
+-- shrinkage path.
 
--- Outlier rows -- iterations whose (docs_persisted,
--- post_merge_segs) tuple does not match the most common.  Zero
--- rows on the happy path; on a flake this names the specific
--- iteration numbers and includes the post-VACUUM segment summary
--- so the regression .out diff carries enough evidence to confirm
--- whether the alive-bitset shrinkage step ran (segments should be
--- annotated `(alive=50, dead=50)` after VACUUM).
-WITH most_common AS (
-    SELECT docs_persisted, post_merge_segs
-    FROM unlogged_shrink_diag
-    GROUP BY docs_persisted, post_merge_segs
-    ORDER BY count(*) DESC, docs_persisted, post_merge_segs
-    LIMIT 1
-)
-SELECT d.iter, d.pre_merge_segs, d.docs_persisted, d.post_merge_segs
-FROM unlogged_shrink_diag d, most_common m
-WHERE (d.docs_persisted, d.post_merge_segs)
-   IS DISTINCT FROM (m.docs_persisted, m.post_merge_segs)
-ORDER BY d.iter;
+-- Regression detector: iterations whose alive_bitset shrank at
+-- VACUUM but whose merge did NOT drop the dead docs (the #397
+-- "2x drift" symptom).  Must be empty.  pre_merge_segs and
+-- post_merge_segs are included so a failure carries enough evidence
+-- to confirm the shrinkage step ran (segments annotated
+-- `(alive=50, dead=50)` after VACUUM).
+SELECT iter, pre_merge_segs, docs_persisted, post_merge_segs
+FROM unlogged_shrink_diag
+WHERE pre_merge_segs ~ 'dead='
+  AND (docs_persisted IS DISTINCT FROM 'docs_persisted: 100'
+       OR post_merge_segs !~ 'docs=100')
+ORDER BY iter;
 
 -- Cleanup
 DROP TABLE unlogged_shrink_diag;


### PR DESCRIPTION
## Summary

Makes the `unlogged_index` alive-bitset shrinkage check deterministic
under concurrent load. The diagnostic loop deletes 100 of 200 docs,
`VACUUM`s, `bm25_force_merge`s, and asserts every iteration reports
`docs_persisted: 100`. That assertion only holds when `VACUUM` actually
marked the deleted docs **dead**, which requires `OldestXmin` to have
advanced past the `DELETE`.

If any concurrent backend holds `OldestXmin` back (autovacuum on the
catalog, or a parallel regression session), the index `ambulkdelete`
callback classifies the deleted tuples as *dead but not yet removable*,
the per-segment `alive_bitset` never shrinks, and the merge legitimately
keeps all 200 source docs → `docs_persisted: 200`. That's the test setup
failing its precondition — the #397 flake — not a regression. The
existing "wait for `backend_xmin`" guard is a soft 30 s timeout and does
not survive a *persistent* xmin holder.

## Reproduction

Holding one `REPEATABLE READ` snapshot open during the run reproduces
the flake deterministically:

| Condition | `VACUUM` | `docs_persisted` |
|---|---|---|
| isolated (today's CI) | `100 removed, 100 remain` | `100` (pass) |
| concurrent snapshot pinning `OldestXmin` | `0 removed, 200 remain, 100 dead but not yet removable` | `200` — **8/8 iterations fail** |

## Fix

Replace the distinct-value/outlier diagnostics with a single
deterministic **regression detector** that asserts correctness only for
iterations where `VACUUM` actually shrank the bitset (`pre_merge_segs`
annotated `dead=`): those must report `docs_persisted: 100` and a merged
L1 segment with `docs=100`. Iterations where `OldestXmin` was pinned are
skipped. The output is invariant to how many iterations fall into each
bucket, so the test is deterministic under concurrent load while still
catching a genuinely broken shrinkage path (shrank-but-merge-kept-200).

## Verification

- Passes in isolation (unchanged behavior; all 8 iterations shrink).
- Passes under a concurrent `REPEATABLE READ` snapshot pinning
  `OldestXmin` — the exact condition that previously failed 8/8 (clean
  run, zero `regression.diffs`).

## Notes

- Companion to #414 (`expression_index`); both are the same
  recently-dead-tuple / `OldestXmin`-retention class of test fragility.
- With the assertion now robust, the soft 30 s `backend_xmin` wait-guard
  is arguably redundant (it only bounds how often the shrinkage path is
  exercised, no longer correctness). Left in place here to keep the diff
  focused; happy to drop it in a follow-up if you prefer.
