### PR TITLE
fix(parallel-build): ERROR instead of silently truncating worker segments (#409)

### DIFF
--- a/src/access/build_parallel.c
+++ b/src/access/build_parallel.c
@@ -406,23 +406,33 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 	{
 		uint32 i;
 
+		/*
+		 * The shared result struct can only report
+		 * TP_MAX_WORKER_SEGMENTS segment offsets/sizes to the leader.
+		 * If a worker produced more than that, truncating would
+		 * silently drop the extra segments and build an incomplete
+		 * index.  Fail the build instead so the missing postings are
+		 * never committed.  See issue #409.
+		 */
+		if (tracker.count > TP_MAX_WORKER_SEGMENTS)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("parallel index build: worker %d "
+							"produced too many segments (%u, "
+							"limit %d)",
+							worker_id,
+							tracker.count,
+							TP_MAX_WORKER_SEGMENTS),
+					 errhint("Increase maintenance_work_mem or "
+							 "reduce "
+							 "max_parallel_maintenance_workers.")));
+
 		for (i = 0; i < tracker.count; i++)
 		{
-			if (i >= TP_MAX_WORKER_SEGMENTS)
-			{
-				elog(WARNING,
-					 "worker %d has too many segments (%u), "
-					 "truncating",
-					 worker_id,
-					 tracker.count);
-				break;
-			}
-
 			my_result->seg_offsets[i] = tracker.entries[i].offset;
 			my_result->seg_sizes[i]	  = tracker.entries[i].data_size;
 		}
-		my_result->final_segment_count =
-				Min(tracker.count, TP_MAX_WORKER_SEGMENTS);
+		my_result->final_segment_count = tracker.count;
 	}
 
 	/* Export BufFile so leader can reopen */


### PR DESCRIPTION
## Summary

Closes #409.

Parallel `CREATE INDEX USING bm25` could silently drop worker-produced
segments. Each worker reports its segments to the leader through a
fixed-size array of `TP_MAX_WORKER_SEGMENTS` (64) offset/size entries in
shared memory. When a worker produced more than 64 segments (e.g. low
`maintenance_work_mem` over a high-token-volume table), the build only
logged:

```text
worker 0 has too many segments (77), truncating
```

and then continued, copying just the first 64 segment offsets to the
leader. The resulting index was missing the truncated segments'
documents/postings, while the metapage corpus stats still reflected
every processed document — a silent correctness bug.

## Change

Upgrade the `WARNING` to an `ERROR` (`ERRCODE_PROGRAM_LIMIT_EXCEEDED`)
so an incomplete index is never committed. The check fires in the worker
before it reports results and propagates to the leader, aborting the
build. The error hint points at the operational workarounds documented
in the issue:

- raise `maintenance_work_mem` so each worker produces ≤ 64 segments, or
- set `max_parallel_maintenance_workers = 0` to use a serial build.

This is the short-term safety fix described in the issue (option 2:
"fail the build with an ERROR if the implementation cannot safely
represent all segments"). A fuller fix would make worker segment
reporting dynamic so every worker-produced segment can be merged; that
is left as follow-up.

## Testing

- `make` against PostgreSQL 17 — builds cleanly.
- `make format-single` (clang-format 21.1.8) — no formatting changes.