### PR TITLE
Fix duplicate rows from BM25 index scan under concurrent writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,6 +495,14 @@ jobs:
           cd test/scripts && ./concurrency.sh
         "
 
+        echo "Running concurrent duplicate-read tests under sanitizer..."
+        timeout 600s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && ./concurrent_duplicate_read.sh
+        "
+
         echo "Running crash recovery tests under sanitizer..."
         timeout 600s bash -c "
           export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,13 @@ jobs:
           echo "✗ VACUUM concurrency tests failed"
           exit 1
         fi
+        echo "Running concurrent duplicate-read tests..."
+        if (cd test/scripts && ./concurrent_duplicate_read.sh); then
+          echo "✓ Concurrent duplicate-read tests passed"
+        else
+          echo "✗ Concurrent duplicate-read tests failed"
+          exit 1
+        fi
         echo "Running segment tests..."
         if (cd test/scripts && ./segment.sh); then
           echo "✓ Segment tests passed"

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ test-concurrency:
 	@echo "Running concurrency tests..."
 	@cd test/scripts && ./concurrency.sh
 	@cd test/scripts && ./partial_concurrent_read.sh
+	@cd test/scripts && ./concurrent_duplicate_read.sh
 	@cd test/scripts && ./vacuum_concurrent_merge.sh
 
 test-recovery:

--- a/src/access/am.h
+++ b/src/access/am.h
@@ -41,21 +41,7 @@ typedef struct TpScanOpaqueData
 	int limit;			  /* Query LIMIT value, -1 if none */
 	int max_results_used; /* Internal limit used for current batch */
 
-	/*
-	 * Set of heap CTIDs already emitted by this scan.  The
-	 * limit-doubling re-execution in tp_gettuple re-scores the whole
-	 * corpus from scratch with a larger limit; under concurrent writes
-	 * the BM25 score ordering (IDF/avgdl) can change between passes.
-	 * After a re-execution the scan re-walks the new batch from the
-	 * start and skips any CTID already in this set, so previously
-	 * returned rows are filtered by identity, not by position.  That
-	 * makes emission idempotent -- each heap tuple is returned at most
-	 * once -- while still emitting rows the reorder moved ahead of the
-	 * previous resume point (avoiding a short, under-LIMIT result).
-	 * Within a single scoring pass the dedup is incidental (a pass
-	 * should not produce duplicate CTIDs); the set's purpose is
-	 * cross-pass dedup.  Lives in scan_context; reset on rescan.
-	 */
+	/* CTIDs already emitted; used across limit-doubling re-execs. */
 	struct HTAB *returned_ctids;
 } TpScanOpaqueData;
 

--- a/src/access/am.h
+++ b/src/access/am.h
@@ -43,12 +43,17 @@ typedef struct TpScanOpaqueData
 	/*
 	 * Set of heap CTIDs already emitted by this scan.  The
 	 * limit-doubling re-execution in tp_gettuple re-scores the whole
-	 * corpus from scratch with a larger limit; under concurrent
-	 * writes the corpus (and thus IDF/score ordering) changes between
-	 * passes, so skipping already-returned rows by position can
-	 * re-emit a row that moved.  Tracking emitted CTIDs lets the scan
-	 * skip them by identity and guarantees each heap tuple is returned
-	 * at most once.  Lives in scan_context; reset on rescan.
+	 * corpus from scratch with a larger limit; under concurrent writes
+	 * the BM25 score ordering (IDF/avgdl) can change between passes.
+	 * After a re-execution the scan re-walks the new batch from the
+	 * start and skips any CTID already in this set, so previously
+	 * returned rows are filtered by identity, not by position.  That
+	 * makes emission idempotent -- each heap tuple is returned at most
+	 * once -- while still emitting rows the reorder moved ahead of the
+	 * previous resume point (avoiding a short, under-LIMIT result).
+	 * Within a single scoring pass the dedup is incidental (a pass
+	 * should not produce duplicate CTIDs); the set's purpose is
+	 * cross-pass dedup.  Lives in scan_context; reset on rescan.
 	 */
 	struct HTAB *returned_ctids;
 } TpScanOpaqueData;

--- a/src/access/am.h
+++ b/src/access/am.h
@@ -39,6 +39,18 @@ typedef struct TpScanOpaqueData
 	/* LIMIT optimization */
 	int limit;			  /* Query LIMIT value, -1 if none */
 	int max_results_used; /* Internal limit used for current batch */
+
+	/*
+	 * Set of heap CTIDs already emitted by this scan.  The
+	 * limit-doubling re-execution in tp_gettuple re-scores the whole
+	 * corpus from scratch with a larger limit; under concurrent
+	 * writes the corpus (and thus IDF/score ordering) changes between
+	 * passes, so skipping already-returned rows by position can
+	 * re-emit a row that moved.  Tracking emitted CTIDs lets the scan
+	 * skip them by identity and guarantees each heap tuple is returned
+	 * at most once.  Lives in scan_context; reset on rescan.
+	 */
+	struct HTAB *returned_ctids;
 } TpScanOpaqueData;
 
 typedef TpScanOpaqueData *TpScanOpaque;

--- a/src/access/scan.c
+++ b/src/access/scan.c
@@ -45,16 +45,7 @@ tp_get_cached_score(void)
 	return tp_cached_score;
 }
 
-/*
- * Record that a heap CTID has been emitted by this scan, returning
- * true if it was already emitted earlier.
- *
- * Used to guarantee each heap tuple is returned at most once even
- * when the limit-doubling re-execution in tp_gettuple re-scores the
- * corpus under concurrent writes (which can reorder results between
- * passes).  The set is created lazily in the scan's memory context
- * and torn down on rescan / endscan.
- */
+/* Track CTIDs already emitted by this scan. */
 static bool
 tp_ctid_seen_or_mark(TpScanOpaque so, ItemPointer tid)
 {
@@ -70,13 +61,7 @@ tp_ctid_seen_or_mark(TpScanOpaque so, ItemPointer tid)
 		ctl.entrysize = sizeof(ItemPointerData);
 		ctl.hcxt	  = so->scan_context;
 
-		/*
-		 * Size the table to the current batch (the number of rows we
-		 * expect to emit in the common single-pass case) rather than a
-		 * fixed constant, so small-LIMIT scans don't over-allocate the
-		 * bucket directory.  dynahash grows on demand if re-execution
-		 * pushes the emitted set past this hint.
-		 */
+		/* Use the current batch size as the initial dynahash hint. */
 		nelem = so->max_results_used > 0 ? so->max_results_used : 256;
 
 		so->returned_ctids = hash_create(
@@ -90,10 +75,7 @@ tp_ctid_seen_or_mark(TpScanOpaque so, ItemPointer tid)
 	return found;
 }
 
-/*
- * Drop the emitted-CTID set so the next batch of results starts
- * fresh.  Called when a scan is restarted.
- */
+/* Reset emitted-CTID tracking for a restarted scan. */
 static void
 tp_returned_ctids_reset(TpScanOpaque so)
 {
@@ -501,15 +483,7 @@ tp_gettuple(IndexScanDesc scan, ScanDirection dir)
 		}
 	}
 
-	/*
-	 * Advance to the next emittable result, re-executing the scoring
-	 * query with a larger limit when the current batch is exhausted.
-	 * Positions are skipped when they carry an invalid block number or
-	 * when their CTID was already returned by an earlier pass (the
-	 * re-execution re-scores from scratch and can reorder results under
-	 * concurrent writes, so position-based skipping alone would
-	 * re-emit rows).
-	 */
+	/* Advance, growing the scoring batch if needed. */
 	for (;;)
 	{
 		if (so->current_pos >= so->result_count || so->eof_reached)
@@ -534,22 +508,8 @@ tp_gettuple(IndexScanDesc scan, ScanDirection dir)
 					so->result_count > old_count)
 				{
 					/*
-					 * Re-walk the freshly scored batch from the
-					 * start instead of resuming at old_count.  The
-					 * larger pass re-scores the whole corpus from
-					 * scratch, so under concurrent writes its ordering
-					 * can differ from the previous pass: a row we have
-					 * not emitted yet can now sit *before* old_count,
-					 * while a row we already emitted can drift *after*
-					 * it.  Resuming by position (at old_count) would
-					 * both re-emit the latter and silently drop the
-					 * former, returning fewer than LIMIT rows.  Walking
-					 * from 0 and filtering against the emitted-CTID set
-					 * below skips exactly the rows already returned --
-					 * by identity, not position -- so each heap tuple
-					 * is returned at most once and no newly-ranked row
-					 * is lost.  The extra work is O(old_count) hash
-					 * probes, dwarfed by the full re-score just done.
+					 * Re-scoring can reorder concurrent results, so
+					 * restart and filter by emitted CTID, not position.
 					 */
 					so->current_pos = 0;
 					continue;

--- a/src/access/scan.c
+++ b/src/access/scan.c
@@ -14,6 +14,7 @@
 #include <pgstat.h>
 #include <storage/bufmgr.h>
 #include <utils/builtins.h>
+#include <utils/hsearch.h>
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/regproc.h>
@@ -42,6 +43,55 @@ float8
 tp_get_cached_score(void)
 {
 	return tp_cached_score;
+}
+
+/*
+ * Record that a heap CTID has been emitted by this scan, returning
+ * true if it was already emitted earlier.
+ *
+ * Used to guarantee each heap tuple is returned at most once even
+ * when the limit-doubling re-execution in tp_gettuple re-scores the
+ * corpus under concurrent writes (which can reorder results between
+ * passes).  The set is created lazily in the scan's memory context
+ * and torn down on rescan / endscan.
+ */
+static bool
+tp_ctid_seen_or_mark(TpScanOpaque so, ItemPointer tid)
+{
+	bool found;
+
+	if (so->returned_ctids == NULL)
+	{
+		HASHCTL ctl;
+
+		memset(&ctl, 0, sizeof(ctl));
+		ctl.keysize	  = sizeof(ItemPointerData);
+		ctl.entrysize = sizeof(ItemPointerData);
+		ctl.hcxt	  = so->scan_context;
+
+		so->returned_ctids = hash_create(
+				"Tapir scan returned ctids",
+				1024,
+				&ctl,
+				HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+	}
+
+	(void)hash_search(so->returned_ctids, tid, HASH_ENTER, &found);
+	return found;
+}
+
+/*
+ * Drop the emitted-CTID set so the next batch of results starts
+ * fresh.  Called when a scan is restarted.
+ */
+static void
+tp_returned_ctids_reset(TpScanOpaque so)
+{
+	if (so && so->returned_ctids)
+	{
+		hash_destroy(so->returned_ctids);
+		so->returned_ctids = NULL;
+	}
 }
 
 /*
@@ -230,6 +280,9 @@ tp_rescan(
 	{
 		/* Clean up any previous results */
 		tp_rescan_cleanup_results(so);
+
+		/* Drop the emitted-CTID dedup set from any prior scan */
+		tp_returned_ctids_reset(so);
 
 		/* Reset scan position and state */
 		so->current_pos	 = 0;
@@ -438,57 +491,81 @@ tp_gettuple(IndexScanDesc scan, ScanDirection dir)
 		}
 	}
 
-	/* Check if we've reached the end of current result set */
-	if (so->current_pos >= so->result_count || so->eof_reached)
+	/*
+	 * Advance to the next emittable result, re-executing the scoring
+	 * query with a larger limit when the current batch is exhausted.
+	 * Positions are skipped when they carry an invalid block number or
+	 * when their CTID was already returned by an earlier pass (the
+	 * re-execution re-scores from scratch and can reorder results under
+	 * concurrent writes, so position-based skipping alone would
+	 * re-emit rows).
+	 */
+	for (;;)
 	{
-		/*
-		 * If result_count hit the internal limit, there may be more
-		 * documents.  Double the limit and re-execute the scoring
-		 * query, skipping already-returned results.
-		 */
-		if (!so->eof_reached && so->result_count > 0 &&
-			so->result_count >= so->max_results_used &&
-			so->max_results_used < TP_MAX_QUERY_LIMIT)
+		if (so->current_pos >= so->result_count || so->eof_reached)
 		{
-			int old_count = so->result_count;
-			int new_limit = so->max_results_used * 2;
-
-			if (new_limit > TP_MAX_QUERY_LIMIT)
-				new_limit = TP_MAX_QUERY_LIMIT;
-
-			so->limit = new_limit;
-			if (tp_execute_scoring_query(scan) && so->result_count > old_count)
+			/*
+			 * If result_count hit the internal limit, there may be
+			 * more documents.  Double the limit and re-execute the
+			 * scoring query.
+			 */
+			if (!so->eof_reached && so->result_count > 0 &&
+				so->result_count >= so->max_results_used &&
+				so->max_results_used < TP_MAX_QUERY_LIMIT)
 			{
-				/* Skip already-returned results */
-				so->current_pos = old_count;
-				/* Fall through to return next tuple */
+				int old_count = so->result_count;
+				int new_limit = so->max_results_used * 2;
+
+				if (new_limit > TP_MAX_QUERY_LIMIT)
+					new_limit = TP_MAX_QUERY_LIMIT;
+
+				so->limit = new_limit;
+				if (tp_execute_scoring_query(scan) &&
+					so->result_count > old_count)
+				{
+					/*
+					 * Resume just past the rows the previous pass
+					 * produced.  Any of those that re-appear here are
+					 * filtered by the emitted-CTID check below, which
+					 * is what makes re-execution safe under concurrent
+					 * writes.
+					 */
+					so->current_pos = old_count;
+					continue;
+				}
+				else
+				{
+					so->eof_reached = true;
+					return false;
+				}
 			}
 			else
-			{
-				so->eof_reached = true;
 				return false;
-			}
 		}
-		else
-			return false;
-	}
 
-	Assert(so->scan_context != NULL);
-	Assert(so->result_ctids != NULL);
-	Assert(so->current_pos < so->result_count);
+		Assert(so->scan_context != NULL);
+		Assert(so->result_ctids != NULL);
+		Assert(so->current_pos < so->result_count);
+		Assert(ItemPointerIsValid(&so->result_ctids[so->current_pos]));
 
-	Assert(ItemPointerIsValid(&so->result_ctids[so->current_pos]));
-
-	/* Skip results with invalid block numbers */
-	blknum = BlockIdGetBlockNumber(
-			&(so->result_ctids[so->current_pos].ip_blkid));
-	while (blknum == InvalidBlockNumber)
-	{
-		so->current_pos++;
-		if (so->current_pos >= so->result_count)
-			return false;
+		/* Skip results with invalid block numbers */
 		blknum = BlockIdGetBlockNumber(
 				&(so->result_ctids[so->current_pos].ip_blkid));
+		if (blknum == InvalidBlockNumber)
+		{
+			so->current_pos++;
+			continue;
+		}
+
+		/* Skip CTIDs already emitted by an earlier pass (dedup) */
+		if (tp_ctid_seen_or_mark(so, &so->result_ctids[so->current_pos]))
+		{
+			so->current_pos++;
+			continue;
+		}
+
+		/* This position is emittable. */
+		break;
 	}
 
 	scan->xs_heaptid		= so->result_ctids[so->current_pos];

--- a/src/access/scan.c
+++ b/src/access/scan.c
@@ -63,15 +63,25 @@ tp_ctid_seen_or_mark(TpScanOpaque so, ItemPointer tid)
 	if (so->returned_ctids == NULL)
 	{
 		HASHCTL ctl;
+		long	nelem;
 
 		memset(&ctl, 0, sizeof(ctl));
 		ctl.keysize	  = sizeof(ItemPointerData);
 		ctl.entrysize = sizeof(ItemPointerData);
 		ctl.hcxt	  = so->scan_context;
 
+		/*
+		 * Size the table to the current batch (the number of rows we
+		 * expect to emit in the common single-pass case) rather than a
+		 * fixed constant, so small-LIMIT scans don't over-allocate the
+		 * bucket directory.  dynahash grows on demand if re-execution
+		 * pushes the emitted set past this hint.
+		 */
+		nelem = so->max_results_used > 0 ? so->max_results_used : 256;
+
 		so->returned_ctids = hash_create(
 				"Tapir scan returned ctids",
-				1024,
+				nelem,
 				&ctl,
 				HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 	}
@@ -524,13 +534,24 @@ tp_gettuple(IndexScanDesc scan, ScanDirection dir)
 					so->result_count > old_count)
 				{
 					/*
-					 * Resume just past the rows the previous pass
-					 * produced.  Any of those that re-appear here are
-					 * filtered by the emitted-CTID check below, which
-					 * is what makes re-execution safe under concurrent
-					 * writes.
+					 * Re-walk the freshly scored batch from the
+					 * start instead of resuming at old_count.  The
+					 * larger pass re-scores the whole corpus from
+					 * scratch, so under concurrent writes its ordering
+					 * can differ from the previous pass: a row we have
+					 * not emitted yet can now sit *before* old_count,
+					 * while a row we already emitted can drift *after*
+					 * it.  Resuming by position (at old_count) would
+					 * both re-emit the latter and silently drop the
+					 * former, returning fewer than LIMIT rows.  Walking
+					 * from 0 and filtering against the emitted-CTID set
+					 * below skips exactly the rows already returned --
+					 * by identity, not position -- so each heap tuple
+					 * is returned at most once and no newly-ranked row
+					 * is lost.  The extra work is O(old_count) hash
+					 * probes, dwarfed by the full re-score just done.
 					 */
-					so->current_pos = old_count;
+					so->current_pos = 0;
 					continue;
 				}
 				else

--- a/test/scripts/concurrent_duplicate_read.sh
+++ b/test/scripts/concurrent_duplicate_read.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+#
+# Regression test for the duplicate-results bug in the BM25 index scan.
+#
+# tp_gettuple() sizes its first scoring pass to the query LIMIT.  When the
+# corpus is larger than the limit, the buffer fills and, once it is
+# exhausted, the scan re-executes the scoring query with a doubled limit and
+# resumes by INTEGER POSITION (so->current_pos = old_count).  Under
+# concurrent writes the corpus (and thus IDF / score ordering) changes
+# between the two passes, so a row already returned by the first pass can
+# move past old_count in the second pass and be emitted again: the same heap
+# tuple is returned twice, with two different scores.
+#
+# This test drives concurrent inserters while readers run a top-k query whose
+# LIMIT is smaller than the corpus, and checks that no single query ever
+# returns the same ctid twice.  Before the fix this trips within seconds;
+# after it (tp_gettuple skips already-returned ctids by identity) it stays
+# clean.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PORT=55459
+TEST_DB=concurrent_duplicate_read_test
+DATA_DIR="${SCRIPT_DIR}/../tmp_concurrent_duplicate_read"
+LOGFILE="${DATA_DIR}/postgres.log"
+ERR_DIR="${DATA_DIR}/client_logs"
+
+# Tunables (kept small so the test is fast but still reproduces reliably).
+QUERY_LIMIT=3000      # top-k limit; must be < corpus to force re-execution
+SEED_ROWS=3500        # initial corpus, just above QUERY_LIMIT
+DURATION=45           # seconds of concurrent insert + read activity
+N_INSERTERS=6
+N_READERS=2
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"; }
+warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARNING: $1${NC}"; }
+error() { echo -e "${RED}[$(date '+%H:%M:%S')] ERROR: $1${NC}"; exit 1; }
+
+cleanup() {
+    local exit_code=$?
+    log "Cleaning up (exit code: $exit_code)..."
+    jobs -p | xargs -r kill 2>/dev/null || true
+    if [ -f "${DATA_DIR}/postmaster.pid" ]; then
+        pg_ctl stop -D "${DATA_DIR}" -m immediate &>/dev/null || true
+    fi
+    rm -rf "${DATA_DIR}"
+    exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+setup_test_db() {
+    log "Setting up PostgreSQL instance..."
+    rm -rf "${DATA_DIR}"
+    mkdir -p "${DATA_DIR}"
+
+    initdb -D "${DATA_DIR}" --auth-local=trust --auth-host=trust >/dev/null 2>&1
+    mkdir -p "${ERR_DIR}"
+
+    cat >> "${DATA_DIR}/postgresql.conf" << EOF
+port = ${TEST_PORT}
+unix_socket_directories = '${DATA_DIR}'
+listen_addresses = 'localhost'
+shared_preload_libraries = 'pg_textsearch'
+logging_collector = on
+log_directory = '.'
+log_filename = 'postgres.log'
+# Insert-only workload: keep autovacuum out so this test targets the scan
+# re-execution bug, not the (separate) VACUUM-vs-merge race.
+autovacuum = off
+# Spill / merge aggressively so the chain churns under concurrent inserts,
+# which is what makes the re-execution path fire.
+pg_textsearch.memtable_pages_threshold = 2
+pg_textsearch.segments_per_level = 2
+pg_textsearch.bulk_load_threshold = 0
+EOF
+
+    pg_ctl start -D "${DATA_DIR}" -l "${LOGFILE}" -w -o "-p ${TEST_PORT}" || \
+        error "Failed to start PostgreSQL"
+
+    createdb -h "${DATA_DIR}" -p ${TEST_PORT} ${TEST_DB}
+    psql -h "${DATA_DIR}" -p ${TEST_PORT} -d ${TEST_DB} \
+        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+    log "Test database ready"
+}
+
+PSQL="psql -h ${DATA_DIR} -p ${TEST_PORT} -d ${TEST_DB} -qAt -v ON_ERROR_STOP=1"
+
+seed_data() {
+    log "Creating index, seeding ${SEED_ROWS} docs, and defining helpers..."
+    $PSQL <<SQL >/dev/null
+SET client_min_messages=warning;
+CREATE TABLE docs (id bigserial PRIMARY KEY, content text NOT NULL);
+CREATE INDEX docs_idx ON docs USING bm25(content) WITH (text_config='english');
+
+-- Every doc shares the common token 'alpha' so the query matches the whole
+-- corpus; a few random tokens add per-doc variation.
+INSERT INTO docs(content)
+SELECT 'alpha w' || (gs % 50)
+FROM generate_series(1, ${SEED_ROWS}) gs;
+
+-- Signal table: a reader inserts here if it ever sees a duplicate ctid.
+CREATE TABLE dup_signal (detected_at timestamptz, extra int, sample_query text);
+
+-- Inserter: commit frequently so the corpus grows between a reader's two
+-- scoring passes.  Time-bounded so the test always terminates.
+CREATE PROCEDURE insert_docs(seconds int) LANGUAGE plpgsql AS \$\$
+DECLARE
+    deadline timestamptz := clock_timestamp() + make_interval(secs => seconds);
+    i bigint := 0;
+BEGIN
+    LOOP
+        INSERT INTO docs(content) VALUES ('alpha w' || (i % 50));
+        i := i + 1;
+        IF i % 5 = 0 THEN
+            COMMIT;
+        END IF;
+        EXIT WHEN clock_timestamp() > deadline;
+    END LOOP;
+    COMMIT;
+END
+\$\$;
+SQL
+
+    # The bug only manifests on the index-scan path (ORDER BY ... LIMIT).
+    # Fail loudly if the planner stops choosing it.
+    local plan
+    plan=$($PSQL -c "EXPLAIN (COSTS off)
+        SELECT ctid FROM docs
+        ORDER BY content <@> to_bm25query('alpha', 'docs_idx')
+        LIMIT ${QUERY_LIMIT}")
+    if ! echo "$plan" | grep -qi "Index Scan"; then
+        warn "Reader plan was not an Index Scan:"
+        echo "$plan"
+        error "TEST SETUP FAILED: reader no longer exercises the index-scan path"
+    fi
+}
+
+inserter() {
+    $PSQL -c "CALL insert_docs(${DURATION});" \
+        >>"${ERR_DIR}/inserter_$1.log" 2>&1 || return 10
+}
+
+# Reader: repeatedly run a top-k query and check whether any single result
+# set contains the same ctid more than once.  Records the first violation in
+# dup_signal and stops.
+reader() {
+    local tag=$1
+    $PSQL >>"${ERR_DIR}/reader_${tag}.log" 2>&1 <<SQL || return 20
+DO \$\$
+DECLARE
+    d int;
+    deadline timestamptz := clock_timestamp() + make_interval(secs => ${DURATION});
+BEGIN
+    LOOP
+        SELECT count(*) - count(DISTINCT ctid)
+          INTO d
+          FROM (
+              SELECT ctid FROM docs
+              ORDER BY content <@> to_bm25query('alpha', 'docs_idx')
+              LIMIT ${QUERY_LIMIT}
+          ) s;
+        IF d > 0 THEN
+            INSERT INTO dup_signal(detected_at, extra, sample_query)
+            VALUES (clock_timestamp(), d, 'reader ${tag}');
+            RAISE WARNING 'DUPLICATE DETECTED by reader ${tag}: % extra row(s)', d;
+            RETURN;
+        END IF;
+        EXIT WHEN clock_timestamp() > deadline;
+    END LOOP;
+END
+\$\$;
+SQL
+}
+
+run_test() {
+    log "Running ${N_INSERTERS} inserters + ${N_READERS} readers for ~${DURATION}s..."
+
+    local pids=()
+    for i in $(seq 1 ${N_INSERTERS}); do
+        inserter "$i" & pids+=("$!")
+    done
+    for i in $(seq 1 ${N_READERS}); do
+        reader "$i" & pids+=("$!")
+    done
+
+    local failed=0
+    for p in "${pids[@]}"; do
+        wait "$p" || { warn "a client (pid $p) exited non-zero"; failed=1; }
+    done
+
+    local dups
+    dups=$($PSQL -c "SELECT count(*) FROM dup_signal;" 2>/dev/null || echo "0")
+    if [ "${dups:-0}" -gt 0 ]; then
+        warn "Duplicate ctids observed in a single index-scan result set:"
+        $PSQL -c "SELECT detected_at, extra, sample_query FROM dup_signal;" || true
+        error "TEST FAILED: BM25 index scan returned the same row more than once"
+    fi
+
+    if [ "$failed" -ne 0 ]; then
+        warn "Client logs:"
+        tail -n 20 "${ERR_DIR}"/*.log 2>/dev/null || true
+        error "TEST FAILED: a concurrent client exited with an error"
+    fi
+
+    log "TEST PASSED: no duplicate ctids across concurrent top-k reads"
+}
+
+# Main
+setup_test_db
+seed_data
+run_test
+
+log "All tests passed!"
+exit 0

--- a/test/scripts/concurrent_duplicate_read.sh
+++ b/test/scripts/concurrent_duplicate_read.sh
@@ -1,21 +1,6 @@
 #!/bin/bash
 #
-# Regression test for the duplicate-results bug in the BM25 index scan.
-#
-# tp_gettuple() sizes its first scoring pass to the query LIMIT.  When the
-# corpus is larger than the limit, the buffer fills and, once it is
-# exhausted, the scan re-executes the scoring query with a doubled limit and
-# resumes by INTEGER POSITION (so->current_pos = old_count).  Under
-# concurrent writes the corpus (and thus IDF / score ordering) changes
-# between the two passes, so a row already returned by the first pass can
-# move past old_count in the second pass and be emitted again: the same heap
-# tuple is returned twice, with two different scores.
-#
-# This test drives concurrent inserters while readers run a top-k query whose
-# LIMIT is smaller than the corpus, and checks that no single query ever
-# returns the same ctid twice.  Before the fix this trips within seconds;
-# after it (tp_gettuple skips already-returned ctids by identity) it stays
-# clean.
+# Regression test for duplicate CTIDs during concurrent top-k index scans.
 #
 
 set -e
@@ -27,17 +12,14 @@ DATA_DIR="${SCRIPT_DIR}/../tmp_concurrent_duplicate_read"
 LOGFILE="${DATA_DIR}/postgres.log"
 ERR_DIR="${DATA_DIR}/client_logs"
 
-# Tunables (kept small so the test is fast but still reproduces reliably).
+# Tunables.
 QUERY_LIMIT=3000      # top-k limit; must be < corpus to force re-execution
 SEED_ROWS=3500        # initial corpus, just above QUERY_LIMIT
 DURATION=45           # seconds of concurrent insert + read activity
 N_INSERTERS=6
 N_READERS=2
 
-# Per-session safety nets (mirrors the sibling concurrency scripts).  The
-# inserter CALL and the reader DO-block each run for ~DURATION as a single
-# statement, so statement_timeout must comfortably exceed DURATION; it only
-# fires if a client wedges.
+# Per-session safety nets for long-running CALL/DO statements.
 STMT_TIMEOUT="$((DURATION + 30))s"
 LOCK_TIMEOUT="30s"
 
@@ -79,11 +61,9 @@ shared_preload_libraries = 'pg_textsearch'
 logging_collector = on
 log_directory = '.'
 log_filename = 'postgres.log'
-# Insert-only workload: keep autovacuum out so this test targets the scan
-# re-execution bug, not the (separate) VACUUM-vs-merge race.
+# Keep this focused on scan re-execution, not VACUUM races.
 autovacuum = off
-# Spill / merge aggressively so the chain churns under concurrent inserts,
-# which is what makes the re-execution path fire.
+# Churn the index under concurrent inserts.
 pg_textsearch.memtable_pages_threshold = 2
 pg_textsearch.segments_per_level = 2
 pg_textsearch.bulk_load_threshold = 0
@@ -107,17 +87,15 @@ SET client_min_messages=warning;
 CREATE TABLE docs (id bigserial PRIMARY KEY, content text NOT NULL);
 CREATE INDEX docs_idx ON docs USING bm25(content) WITH (text_config='english');
 
--- Every doc shares the common token 'alpha' so the query matches the whole
--- corpus; a few random tokens add per-doc variation.
+-- Match the whole corpus while preserving some score variation.
 INSERT INTO docs(content)
 SELECT 'alpha w' || (gs % 50)
 FROM generate_series(1, ${SEED_ROWS}) gs;
 
--- Signal table: a reader inserts here if it ever sees a duplicate ctid.
+-- Reader-visible failure signal.
 CREATE TABLE dup_signal (detected_at timestamptz, extra int, sample_query text);
 
--- Inserter: commit frequently so the corpus grows between a reader's two
--- scoring passes.  Time-bounded so the test always terminates.
+-- Commit frequently so readers can re-score a changing corpus.
 CREATE PROCEDURE insert_docs(seconds int) LANGUAGE plpgsql AS \$\$
 DECLARE
     deadline timestamptz := clock_timestamp() + make_interval(secs => seconds);
@@ -136,8 +114,7 @@ END
 \$\$;
 SQL
 
-    # The bug only manifests on the index-scan path (ORDER BY ... LIMIT).
-    # Fail loudly if the planner stops choosing it.
+    # This test must exercise ORDER BY ... LIMIT via index scan.
     local plan
     plan=$($PSQL -c "EXPLAIN (COSTS off)
         SELECT ctid FROM docs
@@ -156,9 +133,7 @@ inserter() {
         >>"${ERR_DIR}/inserter_$1.log" 2>&1 || return 10
 }
 
-# Reader: repeatedly run a top-k query and check whether any single result
-# set contains the same ctid more than once.  Records the first violation in
-# dup_signal and stops.
+# Repeatedly check each top-k result set for duplicate CTIDs.
 reader() {
     local tag=$1
     PGOPTIONS="-c statement_timeout=${STMT_TIMEOUT} -c lock_timeout=${LOCK_TIMEOUT}" \
@@ -224,26 +199,18 @@ run_test() {
     log "TEST PASSED: no duplicate ctids across concurrent top-k reads"
 }
 
-# Post-run, quiescent checks on the now-static corpus.  These don't reproduce
-# the race (a single static corpus re-scores identically across passes, so
-# nothing reorders) -- they are deterministic sanity nets that the top-k path
-# returns a complete, duplicate-free result, and they confirm the concurrent
-# phase actually exercised the LIMIT < corpus re-execution path.
+# Quiescent sanity checks after the concurrent phase.
 verify_postrun() {
     local corpus expected total distinct
 
     corpus=$($PSQL -c "SELECT count(*) FROM docs;")
 
-    # Sentinel: the inserters must have grown the corpus past QUERY_LIMIT,
-    # otherwise the readers never had LIMIT < corpus and the re-execution
-    # path this test targets was never reachable.
+    # Ensure readers could hit the limit-doubling path.
     if [ "${corpus:-0}" -le "${QUERY_LIMIT}" ]; then
         error "TEST INCONCLUSIVE: corpus (${corpus}) did not exceed QUERY_LIMIT (${QUERY_LIMIT}); re-execution path not exercised"
     fi
 
-    # Completeness: a top-k over the static corpus must return exactly
-    # min(QUERY_LIMIT, corpus) rows, all distinct -- catching a gross
-    # under-return (miss) or duplicate in the scan/backfill path.
+    # Static top-k should be complete and duplicate-free.
     expected=${QUERY_LIMIT}
     read -r total distinct <<<"$($PSQL -c "
         SELECT count(*), count(DISTINCT ctid)

--- a/test/scripts/concurrent_duplicate_read.sh
+++ b/test/scripts/concurrent_duplicate_read.sh
@@ -34,6 +34,13 @@ DURATION=45           # seconds of concurrent insert + read activity
 N_INSERTERS=6
 N_READERS=2
 
+# Per-session safety nets (mirrors the sibling concurrency scripts).  The
+# inserter CALL and the reader DO-block each run for ~DURATION as a single
+# statement, so statement_timeout must comfortably exceed DURATION; it only
+# fires if a client wedges.
+STMT_TIMEOUT="$((DURATION + 30))s"
+LOCK_TIMEOUT="30s"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -144,7 +151,8 @@ SQL
 }
 
 inserter() {
-    $PSQL -c "CALL insert_docs(${DURATION});" \
+    PGOPTIONS="-c statement_timeout=${STMT_TIMEOUT} -c lock_timeout=${LOCK_TIMEOUT}" \
+        $PSQL -c "CALL insert_docs(${DURATION});" \
         >>"${ERR_DIR}/inserter_$1.log" 2>&1 || return 10
 }
 
@@ -153,7 +161,8 @@ inserter() {
 # dup_signal and stops.
 reader() {
     local tag=$1
-    $PSQL >>"${ERR_DIR}/reader_${tag}.log" 2>&1 <<SQL || return 20
+    PGOPTIONS="-c statement_timeout=${STMT_TIMEOUT} -c lock_timeout=${LOCK_TIMEOUT}" \
+        $PSQL >>"${ERR_DIR}/reader_${tag}.log" 2>&1 <<SQL || return 20
 DO \$\$
 DECLARE
     d int;
@@ -197,7 +206,9 @@ run_test() {
     done
 
     local dups
-    dups=$($PSQL -c "SELECT count(*) FROM dup_signal;" 2>/dev/null || echo "0")
+    if ! dups=$($PSQL -c "SELECT count(*) FROM dup_signal;"); then
+        error "TEST FAILED: could not query dup_signal (server down?)"
+    fi
     if [ "${dups:-0}" -gt 0 ]; then
         warn "Duplicate ctids observed in a single index-scan result set:"
         $PSQL -c "SELECT detected_at, extra, sample_query FROM dup_signal;" || true
@@ -213,10 +224,50 @@ run_test() {
     log "TEST PASSED: no duplicate ctids across concurrent top-k reads"
 }
 
+# Post-run, quiescent checks on the now-static corpus.  These don't reproduce
+# the race (a single static corpus re-scores identically across passes, so
+# nothing reorders) -- they are deterministic sanity nets that the top-k path
+# returns a complete, duplicate-free result, and they confirm the concurrent
+# phase actually exercised the LIMIT < corpus re-execution path.
+verify_postrun() {
+    local corpus expected total distinct
+
+    corpus=$($PSQL -c "SELECT count(*) FROM docs;")
+
+    # Sentinel: the inserters must have grown the corpus past QUERY_LIMIT,
+    # otherwise the readers never had LIMIT < corpus and the re-execution
+    # path this test targets was never reachable.
+    if [ "${corpus:-0}" -le "${QUERY_LIMIT}" ]; then
+        error "TEST INCONCLUSIVE: corpus (${corpus}) did not exceed QUERY_LIMIT (${QUERY_LIMIT}); re-execution path not exercised"
+    fi
+
+    # Completeness: a top-k over the static corpus must return exactly
+    # min(QUERY_LIMIT, corpus) rows, all distinct -- catching a gross
+    # under-return (miss) or duplicate in the scan/backfill path.
+    expected=${QUERY_LIMIT}
+    read -r total distinct <<<"$($PSQL -c "
+        SELECT count(*), count(DISTINCT ctid)
+        FROM (
+            SELECT ctid FROM docs
+            ORDER BY content <@> to_bm25query('alpha', 'docs_idx')
+            LIMIT ${QUERY_LIMIT}
+        ) s;" | tr '|' ' ')"
+
+    if [ "${total}" != "${expected}" ]; then
+        error "TEST FAILED: top-k returned ${total} rows, expected ${expected} (corpus=${corpus}) -- under-return/miss"
+    fi
+    if [ "${distinct}" != "${total}" ]; then
+        error "TEST FAILED: top-k returned ${total} rows but only ${distinct} distinct ctids -- duplicate"
+    fi
+
+    log "POST-RUN PASSED: top-k returns ${total} distinct rows on a ${corpus}-row corpus"
+}
+
 # Main
 setup_test_db
 seed_data
 run_test
+verify_postrun
 
 log "All tests passed!"
 exit 0


### PR DESCRIPTION
## Summary

A BM25 index scan can return **the same heap row twice in a single
`ORDER BY ... LIMIT` query, with two different scores**, when the index is
queried while it is being written to concurrently.

This is the bug behind a user report: a ~280k-article Wikipedia import (each row
inserted and then updated by a background embedding writer) immediately started
yielding duplicate full-text results. It reproduces on v1.1.0 through current
`main`. It is **distinct from the VACUUM-vs-merge race fixed in #411** — that
fix removed the `invalid segment header` crash, but the duplicate-results
symptom remained.

## Root cause

`tp_gettuple()` (`src/access/scan.c`) sizes its first scoring pass to the query
`LIMIT`. When the corpus is larger than the limit, the result buffer fills; once
it is exhausted the scan **re-executes the whole scoring query with a doubled
limit and resumes by integer position** (`so->current_pos = old_count`):

```c
so->limit = new_limit;
if (tp_execute_scoring_query(scan) && so->result_count > old_count)
    so->current_pos = old_count;   /* skip the rows the previous pass returned */
```

This assumes the second pass orders results identically to the first. Under
concurrent `INSERT`s the corpus grows between the two passes, so IDF/avgdl shift
and near‑equal‑scored documents reorder. A row already returned by pass 1 can
move *past* `old_count` in pass 2 and get emitted again — same `ctid`, but with
pass 2's score.

The bug is purely at query time: it needs no `VACUUM`, no `UPDATE`, no storage
duplication, and reproduces even with a single inserter. It only fires when the
re-execution path runs, i.e. when `LIMIT < corpus` (a `LIMIT` larger than the
corpus never triggers re-execution and never duplicates).

### How it was confirmed

Instrumented runs on an isolated PG17 cluster showed the re-execution
(`old_count=3000 new_limit=6000`) firing exactly when duplicates appeared;
a static corpus (no concurrent writes) never duplicated even though the limit
was below the corpus size.

## Fix

Track the heap CTIDs a scan has already emitted in a small hash set
(`returned_ctids`, in the scan memory context) and skip any that reappear, so
each tuple is returned at most once regardless of how the re-scored result set
is ordered. The set is reset on rescan and freed with the scan context. As a
side effect it also de-duplicates a CTID that appears more than once within a
single scoring pass.

## Test

`test/scripts/concurrent_duplicate_read.sh` (wired into `test-concurrency`)
drives 6 concurrent inserters against top-k readers (`LIMIT < corpus`) and fails
if any single index-scan result set contains a duplicate `ctid`.

- **Before the fix:** trips within ~1s.
- **After the fix:** stays clean for the full run.

## Verification

- `make test-local` — all 70 SQL regression tests pass.
- `make format-check` — passes (clang-format 21.1.8).
- New concurrency test: fails on the unpatched build, passes on the patched
  build.

## Notes for reviewers

This is a targeted fix that makes emission idempotent per `ctid`. An
alternative, more invasive direction would be to avoid re-execution entirely by
taking a single consistent top-k snapshot sized to `LIMIT` plus slack for
invalid-row skips; happy to pursue that instead if preferred.
