### PR TITLE
Fix VACUUM segment page reclaim race

### DIFF
--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -276,7 +276,7 @@ tp_apply_vacuum_shrinkage(
 
 	xlog_state = GenericXLogStart(index);
 	mpage	   = GenericXLogRegisterBuffer(xlog_state, mbuf, 0);
-	/* v6 -> v7 in-place upgrade (issue #383). */
+	/* Upgrade legacy metapage before applying shrinkage. */
 	tp_metapage_upgrade_to_current(index, mpage);
 	mp = (TpIndexMetaPage)PageGetContents(mpage);
 
@@ -654,12 +654,18 @@ tp_vacuum_replace_segment(
 	old_page_count = tp_segment_collect_pages(index, old_root, &old_pages);
 	vacuum_fxid	   = ReadNextFullTransactionId();
 	if (old_pages && old_page_count > 0)
+	{
+		/*
+		 * Other pending_free_head writers hold LW_EXCLUSIVE; this VACUUM
+		 * holds LW_SHARED across the enqueue and metapage update.
+		 */
 		batch_head = tp_tombstone_enqueue(
 				index,
 				old_pages,
 				old_page_count,
 				vacuum_fxid,
 				tp_tombstone_read_head(index));
+	}
 
 	/*
 	 * Update chain pointers atomically via GenericXLog.
@@ -677,7 +683,7 @@ tp_vacuum_replace_segment(
 
 		xlog_state = GenericXLogStart(index);
 		meta_copy  = GenericXLogRegisterBuffer(xlog_state, metabuf, 0);
-		/* v6 -> v7 in-place upgrade (issue #383). */
+		/* Upgrade legacy metapage before writing pending_free_head. */
 		tp_metapage_upgrade_to_current(index, meta_copy);
 		meta_ptr = (TpIndexMetaPage)PageGetContents(meta_copy);
 

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -618,7 +618,10 @@ tp_vacuum_rebuild_segment(
  * the chain entirely.
  *
  * Updates the metapage level_heads/level_counts as needed.
- * Frees old segment pages.
+ *
+ * Parks old segment pages in the deferred-free tombstone chain so they are
+ * not recycled until a later VACUUM observes that the replacement horizon is
+ * past every active snapshot.
  */
 static void
 tp_vacuum_replace_segment(
@@ -628,10 +631,12 @@ tp_vacuum_replace_segment(
 		BlockNumber new_root,
 		BlockNumber prev_root)
 {
-	Buffer		 metabuf;
-	BlockNumber *old_pages;
-	uint32		 old_page_count;
-	BlockNumber	 old_next;
+	Buffer			  metabuf;
+	BlockNumber		 *old_pages;
+	uint32			  old_page_count;
+	BlockNumber		  old_next;
+	FullTransactionId vacuum_fxid;
+	BlockNumber		  batch_head = InvalidBlockNumber;
 
 	/*
 	 * Read old segment's next_segment pointer before we free it.
@@ -645,8 +650,16 @@ tp_vacuum_replace_segment(
 		tp_segment_close(old_reader);
 	}
 
-	/* Collect old segment pages for freeing */
+	/* Collect old segment pages for deferred reclaim. */
 	old_page_count = tp_segment_collect_pages(index, old_root, &old_pages);
+	vacuum_fxid	   = ReadNextFullTransactionId();
+	if (old_pages && old_page_count > 0)
+		batch_head = tp_tombstone_enqueue(
+				index,
+				old_pages,
+				old_page_count,
+				vacuum_fxid,
+				tp_tombstone_read_head(index));
 
 	/*
 	 * Update chain pointers atomically via GenericXLog.
@@ -732,6 +745,9 @@ tp_vacuum_replace_segment(
 				meta_ptr->level_counts[level]--;
 		}
 
+		if (batch_head != InvalidBlockNumber)
+			meta_ptr->pending_free_head = batch_head;
+
 		GenericXLogFinish(xlog_state);
 		if (BufferIsValid(prev_buf))
 			UnlockReleaseBuffer(prev_buf);
@@ -740,13 +756,9 @@ tp_vacuum_replace_segment(
 		UnlockReleaseBuffer(metabuf);
 	}
 
-	/* Free old segment pages */
-	if (old_pages && old_page_count > 0)
-		tp_segment_free_pages(index, old_pages, old_page_count);
+	/* Old pages are parked in the tombstone chain and drained later. */
 	if (old_pages)
 		pfree(old_pages);
-
-	IndexFreeSpaceMapVacuum(index);
 }
 
 /*
@@ -877,10 +889,10 @@ tp_bulkdelete(
 	 * metapage so the level_heads snapshot we walk stays stable.  Inserts
 	 * and scans also hold this lock LW_SHARED, so they neither block nor
 	 * are blocked by this walk; only the exclusive spill/merge/compaction
-	 * recyclers are excluded.  (VACUUM's own Phase-3 page reclamation also
-	 * runs under LW_SHARED and so is not excluded against concurrent
-	 * scans -- a separate, pre-existing concern tracked in issue #413, not
-	 * addressed here.)
+	 * recyclers are excluded.  VACUUM's own Phase-3 replacement/drop path
+	 * parks displaced segment pages in the tombstone chain instead of
+	 * returning them to the FSM here, so concurrent LW_SHARED scans cannot
+	 * see those pages recycled out from under a metapage snapshot.
 	 */
 	if (index_state != NULL)
 		tp_acquire_index_lock(index_state, LW_SHARED);

--- a/src/debug/dump.c
+++ b/src/debug/dump.c
@@ -1416,15 +1416,17 @@ write_pageviz_map(
 static void
 tp_debug_pageviz_to_file(const char *index_name, const char *filename)
 {
-	Oid				index_oid;
-	Relation		index_rel	 = NULL;
-	TpIndexMetaPage metap		 = NULL;
-	BlockNumber		total_blocks = 0;
-	PageMapEntry   *page_map	 = NULL;
-	SegmentInfo	   *segments	 = NULL;
-	int				num_segments = 0;
-	PageCounts		counts;
-	FILE		   *fp;
+	Oid				   index_oid;
+	Relation		   index_rel = NULL;
+	TpIndexMetaPage	   metap	 = NULL;
+	TpLocalIndexState *index_state;
+	bool			   acquired_lock = false;
+	BlockNumber		   total_blocks	 = 0;
+	PageMapEntry	  *page_map		 = NULL;
+	SegmentInfo		  *segments		 = NULL;
+	int				   num_segments	 = 0;
+	PageCounts		   counts;
+	FILE			  *fp;
 
 	/* Open output file */
 	fp = fopen(filename, "w");
@@ -1448,6 +1450,20 @@ tp_debug_pageviz_to_file(const char *index_name, const char *filename)
 	index_rel	 = index_open(index_oid, AccessShareLock);
 	total_blocks = RelationGetNumberOfBlocks(index_rel);
 	metap		 = tp_get_metapage(index_rel);
+	index_state	 = tp_get_local_index_state(index_oid);
+	if (index_state != NULL && !index_state->lock_held)
+	{
+		tp_acquire_index_lock(index_state, LW_SHARED);
+		acquired_lock = true;
+	}
+	if (index_state != NULL)
+	{
+		TpIndexMetaPage fresh = tp_get_metapage(index_rel);
+
+		if (metap)
+			pfree(metap);
+		metap = fresh;
+	}
 
 	if (total_blocks == 0)
 	{
@@ -1476,6 +1492,8 @@ tp_debug_pageviz_to_file(const char *index_name, const char *filename)
 	write_pageviz_map(fp, page_map, total_blocks, &counts);
 
 cleanup:
+	if (acquired_lock)
+		tp_release_index_lock(index_state);
 	if (segments)
 		pfree(segments);
 	if (page_map)

--- a/test/expected/segment_reclaim.out
+++ b/test/expected/segment_reclaim.out
@@ -103,5 +103,68 @@ SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
  t
 (1 row)
 
+-- VACUUM's own segment replacement/drop path must also park displaced
+-- pages instead of returning them to the FSM immediately (#413). Build a
+-- fresh index layout so the observation is independent of the merge case
+-- above.
+DROP INDEX reclaim_idx;
+TRUNCATE reclaim_docs;
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum alpha beta term' || (g % 50)
+FROM generate_series(1, 1500) g;
+CREATE INDEX reclaim_idx ON reclaim_docs
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation reclaim_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1500 documents, avg_length=4.00
+-- Add a second segment through the on-disk memtable, then delete exactly
+-- those rows so VACUUM drops that all-dead segment.
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum dropped beta term' || (g % 50)
+FROM generate_series(1501, 2500) g;
+\pset format unaligned
+SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_spilled;
+vacuum_spilled
+t
+(1 row)
+DELETE FROM reclaim_docs WHERE id BETWEEN 1501 AND 2500;
+VACUUM reclaim_docs;
+-- VACUUM should park the dropped segment's pages, not recycle them yet.
+SELECT bm25_pending_free_pages('reclaim_idx') > 0 AS parked_after_vacuum_drop;
+parked_after_vacuum_drop
+t
+(1 row)
+-- Once the xid horizon advances, a later VACUUM drains the parked pages.
+SELECT txid_current() IS NOT NULL AS vt1;
+vt1
+t
+(1 row)
+SELECT txid_current() IS NOT NULL AS vt2;
+vt2
+t
+(1 row)
+VACUUM reclaim_docs;
+SELECT bm25_pending_free_pages('reclaim_idx') AS parked_after_vacuum_drain;
+parked_after_vacuum_drain
+0
+(1 row)
+-- The drained pages must be reusable from the FSM without extending the
+-- index relation.
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    AS blocks_before_vacuum_reuse \gset
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum reuse beta term' || (g % 50)
+FROM generate_series(2501, 3200) g;
+SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
+vacuum_reuse_spilled
+t
+(1 row)
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    <= :blocks_before_vacuum_reuse AS vacuum_reused_freed_pages_no_extension;
+vacuum_reused_freed_pages_no_extension
+t
+(1 row)
+\pset format aligned
 DROP TABLE reclaim_docs;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/segment_reclaim.sql
+++ b/test/sql/segment_reclaim.sql
@@ -63,5 +63,48 @@ SELECT bm25_spill_index('reclaim_idx') > 0 AS reuse_spilled;
 SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
     <= :blocks_before_reuse AS reused_freed_pages_no_extension;
 
+-- VACUUM's own segment replacement/drop path must also park displaced
+-- pages instead of returning them to the FSM immediately (#413). Build a
+-- fresh index layout so the observation is independent of the merge case
+-- above.
+DROP INDEX reclaim_idx;
+TRUNCATE reclaim_docs;
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum alpha beta term' || (g % 50)
+FROM generate_series(1, 1500) g;
+CREATE INDEX reclaim_idx ON reclaim_docs
+    USING bm25 (body) WITH (text_config = 'english');
+
+-- Add a second segment through the on-disk memtable, then delete exactly
+-- those rows so VACUUM drops that all-dead segment.
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum dropped beta term' || (g % 50)
+FROM generate_series(1501, 2500) g;
+\pset format unaligned
+SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_spilled;
+DELETE FROM reclaim_docs WHERE id BETWEEN 1501 AND 2500;
+VACUUM reclaim_docs;
+
+-- VACUUM should park the dropped segment's pages, not recycle them yet.
+SELECT bm25_pending_free_pages('reclaim_idx') > 0 AS parked_after_vacuum_drop;
+
+-- Once the xid horizon advances, a later VACUUM drains the parked pages.
+SELECT txid_current() IS NOT NULL AS vt1;
+SELECT txid_current() IS NOT NULL AS vt2;
+VACUUM reclaim_docs;
+SELECT bm25_pending_free_pages('reclaim_idx') AS parked_after_vacuum_drain;
+
+-- The drained pages must be reusable from the FSM without extending the
+-- index relation.
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    AS blocks_before_vacuum_reuse \gset
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum reuse beta term' || (g % 50)
+FROM generate_series(2501, 3200) g;
+SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    <= :blocks_before_vacuum_reuse AS vacuum_reused_freed_pages_no_extension;
+\pset format aligned
+
 DROP TABLE reclaim_docs;
 DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Problem

VACUUM Phase 3 could unlink a dead/rebuilt segment and immediately return its pages to the FSM while concurrent scans still held only `LW_SHARED` on the same index. A scan that had already read the old level chain could then open a block after an insert reused it, producing the same recycled-segment failure class as #411 (`invalid segment header` or stale doc IDs).

## Fix

- Park VACUUM-displaced segment pages in the existing deferred-free tombstone chain instead of freeing them immediately.
- Install the new `pending_free_head` in the same GenericXLog record that unlinks/replaces the segment.
- Keep common V5 partial deletes as in-place alive-bitset updates under `LW_SHARED`.
- Wrap debug-only page visualization segment walks in `LW_SHARED` and re-read the metapage under it.

## Migration / upgrade path

No user-visible migration is needed. This reuses the existing tombstone chain and metapage `pending_free_head` field; older metapages are already upgraded in-place before that field is written. Existing indexes continue to work, and pages are parked only when a future VACUUM replacement/drop occurs.

## Testing

- `make PG_CONFIG=/home/azureuser/pg18/bin/pg_config`
- `make install PG_CONFIG=/home/azureuser/pg18/bin/pg_config`
- `/home/azureuser/pg18/bin/pg_ctl -D /home/azureuser/pg18/data -m fast -w restart -o "-c shared_preload_libraries=pg_textsearch -c port=5518 -c unix_socket_directories=/tmp"`
- `PG_CONFIG=/home/azureuser/pg18/bin/pg_config PGHOST=/tmp PGPORT=5518 $(/home/azureuser/pg18/bin/pg_config --pgxs | xargs dirname)/../../src/test/regress/pg_regress --bindir=/home/azureuser/pg18/bin --inputdir=test --outputdir=test segment_reclaim`
- `make format-check`
- `git diff --check`

Fixes #413
