### PR TITLE
Avoid FSM allocation for VACUUM tombstones

### DIFF
--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -656,10 +656,10 @@ tp_vacuum_replace_segment(
 	if (old_pages && old_page_count > 0)
 	{
 		/*
-		 * Other pending_free_head writers hold LW_EXCLUSIVE; this VACUUM
-		 * holds LW_SHARED across the enqueue and metapage update.
+		 * VACUUM holds only LW_SHARED here, so tombstone pages must not
+		 * allocate from the FSM and race concurrent inserts.
 		 */
-		batch_head = tp_tombstone_enqueue(
+		batch_head = tp_tombstone_enqueue_extend(
 				index,
 				old_pages,
 				old_page_count,

--- a/src/segment/tombstone.c
+++ b/src/segment/tombstone.c
@@ -59,14 +59,17 @@ tp_tombstone_page_is_valid(Page page)
  * pre-existing contents are irrelevant.
  */
 static BlockNumber
-tombstone_alloc_page(Relation index)
+tombstone_alloc_page(Relation index, bool use_fsm)
 {
 	Buffer		buffer;
 	BlockNumber block;
 
-	block = GetFreeIndexPage(index);
-	if (block != InvalidBlockNumber)
-		return block;
+	if (use_fsm)
+	{
+		block = GetFreeIndexPage(index);
+		if (block != InvalidBlockNumber)
+			return block;
+	}
 
 	buffer = ReadBufferExtended(
 			index, MAIN_FORKNUM, P_NEW, RBM_ZERO_AND_LOCK, NULL);
@@ -75,13 +78,14 @@ tombstone_alloc_page(Relation index)
 	return block;
 }
 
-BlockNumber
-tp_tombstone_enqueue(
+static BlockNumber
+tombstone_enqueue_internal(
 		Relation		  index,
 		BlockNumber		 *blocks,
 		uint32			  num_blocks,
 		FullTransactionId merged_fxid,
-		BlockNumber		  old_head)
+		BlockNumber		  old_head,
+		bool			  use_fsm)
 {
 	BlockNumber batch_head = old_head;
 	uint32		remaining  = num_blocks;
@@ -102,7 +106,7 @@ tp_tombstone_enqueue(
 	{
 		uint32			  chunk = Min(remaining, TP_TOMBSTONE_CAPACITY);
 		uint32			  start = remaining - chunk;
-		BlockNumber		  blk	= tombstone_alloc_page(index);
+		BlockNumber		  blk	= tombstone_alloc_page(index, use_fsm);
 		GenericXLogState *state;
 		Buffer			  buf;
 		Page			  page;
@@ -129,6 +133,30 @@ tp_tombstone_enqueue(
 	}
 
 	return batch_head;
+}
+
+BlockNumber
+tp_tombstone_enqueue(
+		Relation		  index,
+		BlockNumber		 *blocks,
+		uint32			  num_blocks,
+		FullTransactionId merged_fxid,
+		BlockNumber		  old_head)
+{
+	return tombstone_enqueue_internal(
+			index, blocks, num_blocks, merged_fxid, old_head, true);
+}
+
+BlockNumber
+tp_tombstone_enqueue_extend(
+		Relation		  index,
+		BlockNumber		 *blocks,
+		uint32			  num_blocks,
+		FullTransactionId merged_fxid,
+		BlockNumber		  old_head)
+{
+	return tombstone_enqueue_internal(
+			index, blocks, num_blocks, merged_fxid, old_head, false);
 }
 
 /*

--- a/src/segment/tombstone.h
+++ b/src/segment/tombstone.h
@@ -81,6 +81,17 @@ extern BlockNumber tp_tombstone_enqueue(
 		BlockNumber		  old_head);
 
 /*
+ * Variant for callers that do not serialize against concurrent FSM
+ * allocators.  Extends the relation instead of calling GetFreeIndexPage().
+ */
+extern BlockNumber tp_tombstone_enqueue_extend(
+		Relation		  index,
+		BlockNumber		 *blocks,
+		uint32			  num_blocks,
+		FullTransactionId merged_fxid,
+		BlockNumber		  old_head);
+
+/*
  * Drain past-horizon tombstones.  For each tombstone whose
  * merged_fxid < `horizon`, WAL-unlink it then RecordFreeIndexPage its
  * listed blocks and its own page.

--- a/test/expected/segment_reclaim.out
+++ b/test/expected/segment_reclaim.out
@@ -119,17 +119,50 @@ NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 1500 documents, avg_length=4.00
 -- Add a second segment through the on-disk memtable, then delete exactly
--- those rows so VACUUM drops that all-dead segment.
+-- those rows so VACUUM drops that all-dead segment.  First create an FSM
+-- free-page pool: VACUUM's tombstone pages must not consume it while
+-- running under LW_SHARED, or they can race concurrent insert allocation.
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum pool beta term' || (g % 50)
+FROM generate_series(1501, 3000) g;
+\pset format unaligned
+SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_pool_spilled;
+vacuum_pool_spilled
+t
+(1 row)
+SELECT bm25_force_merge('reclaim_idx');
+bm25_force_merge
+
+(1 row)
+SELECT txid_current() IS NOT NULL AS vp1;
+vp1
+t
+(1 row)
+SELECT txid_current() IS NOT NULL AS vp2;
+vp2
+t
+(1 row)
+VACUUM reclaim_docs;
+SELECT bm25_pending_free_pages('reclaim_idx') AS pool_after_vacuum;
+pool_after_vacuum
+0
+(1 row)
 INSERT INTO reclaim_docs
 SELECT g, 'vacuum dropped beta term' || (g % 50)
-FROM generate_series(1501, 2500) g;
-\pset format unaligned
+FROM generate_series(3001, 3020) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_spilled;
 vacuum_spilled
 t
 (1 row)
-DELETE FROM reclaim_docs WHERE id BETWEEN 1501 AND 2500;
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    AS blocks_before_vacuum_drop \gset
+DELETE FROM reclaim_docs WHERE id BETWEEN 3001 AND 3020;
 VACUUM reclaim_docs;
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
+vacuum_tombstone_extended
+t
+(1 row)
 -- VACUUM should park the dropped segment's pages, not recycle them yet.
 SELECT bm25_pending_free_pages('reclaim_idx') > 0 AS parked_after_vacuum_drop;
 parked_after_vacuum_drop
@@ -155,7 +188,7 @@ SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
     AS blocks_before_vacuum_reuse \gset
 INSERT INTO reclaim_docs
 SELECT g, 'vacuum reuse beta term' || (g % 50)
-FROM generate_series(2501, 3200) g;
+FROM generate_series(3021, 3720) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
 vacuum_reuse_spilled
 t

--- a/test/sql/segment_reclaim.sql
+++ b/test/sql/segment_reclaim.sql
@@ -76,14 +76,30 @@ CREATE INDEX reclaim_idx ON reclaim_docs
     USING bm25 (body) WITH (text_config = 'english');
 
 -- Add a second segment through the on-disk memtable, then delete exactly
--- those rows so VACUUM drops that all-dead segment.
+-- those rows so VACUUM drops that all-dead segment.  First create an FSM
+-- free-page pool: VACUUM's tombstone pages must not consume it while
+-- running under LW_SHARED, or they can race concurrent insert allocation.
+INSERT INTO reclaim_docs
+SELECT g, 'vacuum pool beta term' || (g % 50)
+FROM generate_series(1501, 3000) g;
+\pset format unaligned
+SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_pool_spilled;
+SELECT bm25_force_merge('reclaim_idx');
+SELECT txid_current() IS NOT NULL AS vp1;
+SELECT txid_current() IS NOT NULL AS vp2;
+VACUUM reclaim_docs;
+SELECT bm25_pending_free_pages('reclaim_idx') AS pool_after_vacuum;
+
 INSERT INTO reclaim_docs
 SELECT g, 'vacuum dropped beta term' || (g % 50)
-FROM generate_series(1501, 2500) g;
-\pset format unaligned
+FROM generate_series(3001, 3020) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_spilled;
-DELETE FROM reclaim_docs WHERE id BETWEEN 1501 AND 2500;
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    AS blocks_before_vacuum_drop \gset
+DELETE FROM reclaim_docs WHERE id BETWEEN 3001 AND 3020;
 VACUUM reclaim_docs;
+SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+    > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
 
 -- VACUUM should park the dropped segment's pages, not recycle them yet.
 SELECT bm25_pending_free_pages('reclaim_idx') > 0 AS parked_after_vacuum_drop;
@@ -100,7 +116,7 @@ SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
     AS blocks_before_vacuum_reuse \gset
 INSERT INTO reclaim_docs
 SELECT g, 'vacuum reuse beta term' || (g % 50)
-FROM generate_series(2501, 3200) g;
+FROM generate_series(3021, 3720) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
 SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
     <= :blocks_before_vacuum_reuse AS vacuum_reused_freed_pages_no_extension;


### PR DESCRIPTION
## Problem

PR #418 moved VACUUM-displaced segment pages into the tombstone chain, but the VACUUM path allocated tombstone pages with `GetFreeIndexPage()` while holding only the per-index `LW_SHARED` lock. `GetFreeIndexPage()` is not an atomic claim, so a concurrent insert could be handed the same FSM block for a memtable page.

That creates a possible double-allocation: the same block can be linked into both the tombstone chain and the memtable chain, with the last page writer winning.

## Fix

- Add an extend-only tombstone enqueue variant for callers that do not serialize against other FSM allocators.
- Use that variant from VACUUM segment replacement/drop.
- Keep the existing FSM-reuse enqueue for merge, which already runs under `LW_EXCLUSIVE`.
- Extend the regression test to prove VACUUM tombstone pages do not consume an available FSM page pool.

## Testing

- `make PG_CONFIG=/home/azureuser/pg18/bin/pg_config`
- `make install PG_CONFIG=/home/azureuser/pg18/bin/pg_config`
- `/home/azureuser/pg18/bin/pg_ctl -D /home/azureuser/pg18/data -m fast -w restart -o "-c shared_preload_libraries=pg_textsearch -c port=5518 -c unix_socket_directories=/tmp"`
- `PG_CONFIG=/home/azureuser/pg18/bin/pg_config PGHOST=/tmp PGPORT=5518 $(/home/azureuser/pg18/bin/pg_config --pgxs | xargs dirname)/../../src/test/regress/pg_regress --bindir=/home/azureuser/pg18/bin --inputdir=test --outputdir=test segment_reclaim`
- `make format-check`
- `git diff --check`
