### PR TITLE
docs: recommend periodic REINDEX for fragmented indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,21 @@ This is analogous to Lucene's `forceMerge(1)`. It rewrites all segments into
 a single segment and reclaims the freed pages. Best used after large batch
 inserts, not during ongoing write traffic.
 
+#### Index fragmentation on update-heavy workloads
+
+Sustained INSERT/DELETE/UPDATE traffic can cause index pages to become
+physically scattered across the relation file, reducing sequential-read
+efficiency. If cold-cache query latency degrades over time, a periodic
+`REINDEX` rebuilds the index with contiguous page layout:
+
+```sql
+REINDEX INDEX docs_idx;
+```
+
+This is the same as `DROP INDEX` + `CREATE INDEX` but keeps the index
+name. Schedule it during low-traffic windows since it takes an
+exclusive lock.
+
 #### Use LIMIT with ORDER BY
 
 Top-k queries (`ORDER BY ... LIMIT n`) enable Block-Max WAND optimization,


### PR DESCRIPTION
## Summary

Adds a short subsection to the README's Performance Tuning section noting
that update-heavy workloads can fragment an index over time, and that a
periodic `REINDEX` restores a contiguous page layout.

That is the entire change: **15 lines of README, no code.**

## How this PR got here

It started as an implementation of segment defragmentation — a two-phase
merge (segment → BufFile → contiguous page range) so that `bm25_force_merge`
would produce physically sequential pages, behind a
`pg_textsearch.defrag_on_merge` GUC. That code has been dropped. The
benchmarking done to justify it is what led here, and it's worth recording,
because it answers two separate questions:

**Does fragmentation hurt? Enormously — when it exists.**
An experimental `debug_randomize_pages` GUC pre-extended the relation and
served page allocations in shuffled order, giving a worst-case layout. Two
otherwise identical bulk builds over MS MARCO v2 (138M passages, 691
multi-token queries, cold cache) differed only in physical page order:

| | Normal | Randomized |
|---|---|---|
| Weighted avg latency | 63.8 ms | 594.4 ms (**9.3x**) |
| p99, 8+ token queries | 558 ms | 12,513 ms (**22x**) |

Multi-token queries degraded 5-12x. ([full results](https://github.com/timescale/pg_textsearch/pull/425#issuecomment-5331169374))

**Does it happen in practice? Not from normal operation.**
An incremental build of the same dataset (138M rows in 1M-row batches, 135
forced spills, 12 segments across L0-L5) followed by a cross-level force
merge moved the weighted average from 63.98 ms to 63.66 ms — 0.5%, inside
the noise. When no free pages are available the FSM extends the relation
sequentially, so the large segments were already laid out contiguously and
defragmentation had nothing to fix. An earlier run on the standard build
found force merge was a literal no-op, because auto-compaction had already
left one segment per level and `tp_force_merge_all` needs two at a level to
do anything. ([details](https://github.com/timescale/pg_textsearch/pull/425#issuecomment-5291722505))

So the defrag path worked correctly but addressed a state the allocator
doesn't currently produce, at the cost of a second write path, ~59% added
force-merge time, and index bloat — force merge grew the relation 28 GB →
45 GB, since displaced pages are tombstoned for deferred reclaim rather
than freed in place.

Given that, and that `REINDEX` already recovers a clean layout for the
pathological cases, the conclusion was that the complexity isn't warranted
yet. Hence: document the workaround, drop the code.

## Follow-ups this surfaced

- Contiguous layout is better baked into the compaction write path than
  bolted onto force merge. Worth revisiting under background
  compaction / index health maintenance.
- `bm25_force_merge` only merges *within* a level, so it cannot consolidate
  to a single segment once auto-compaction has left one per level. Note that
  the README's Force-merging section still claims it "rewrites all segments
  into a single segment", which is inaccurate; worth a separate fix.
- The `debug_randomize_pages` GUC and the benchmark scripts are useful for
  validating any future layout work, and are preserved in the PR history.

Thanks @mory91 for the implementation and for the several rounds of
benchmarking that produced this result — the negative result plus the
worst-case bound is more useful than the feature would have been.