### PR TITLE
fix: use huge-allocation variants for all per-term arrays sized by segment term count (fixes #431)

### DIFF
--- a/src/access/build_context.c
+++ b/src/access/build_context.c
@@ -224,8 +224,9 @@ tp_build_context_get_sorted_terms(TpBuildContext *ctx, uint32 *num_terms)
 		return NULL;
 	}
 
-	terms = palloc(count * sizeof(TpBuildTermInfo));
-	i	  = 0;
+	terms = palloc_extended(
+			(Size)count * sizeof(TpBuildTermInfo), MCXT_ALLOC_HUGE);
+	i = 0;
 
 	hash_seq_init(&status, ctx->terms_ht);
 	while ((entry = hash_seq_search(&status)) != NULL)
@@ -328,8 +329,10 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 			&writer, &dict, offsetof(TpDictionary, string_offsets));
 
 	/* Build string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			(Size)num_terms * sizeof(uint32),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
 		string_offsets[i] = string_pos;
@@ -369,11 +372,15 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	header.postings_offset = writer.current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(TermBlockInfo));
+	term_blocks = palloc_extended(
+			(Size)num_terms * sizeof(TermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;
-	all_skip_entries = palloc(skip_entries_capacity * sizeof(TpSkipEntry));
+	all_skip_entries	  = palloc_extended(
+			 (Size)skip_entries_capacity * sizeof(TpSkipEntry),
+			 MCXT_ALLOC_HUGE);
 
 	/*
 	 * Streaming pass: for each term, read postings from EXPULL
@@ -470,9 +477,9 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 			if (skip_entries_count >= skip_entries_capacity)
 			{
 				skip_entries_capacity *= 2;
-				all_skip_entries = repalloc(
+				all_skip_entries = repalloc_huge(
 						all_skip_entries,
-						skip_entries_capacity * sizeof(TpSkipEntry));
+						(Size)skip_entries_capacity * sizeof(TpSkipEntry));
 			}
 			all_skip_entries[skip_entries_count++] = skip;
 		}
@@ -791,8 +798,10 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	current_offset += offsetof(TpDictionary, string_offsets);
 
 	/* Build string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			(Size)num_terms * sizeof(uint32),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
 		string_offsets[i] = string_pos;
@@ -835,11 +844,15 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	header.postings_offset = current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(TermBlockInfo));
+	term_blocks = palloc_extended(
+			(Size)num_terms * sizeof(TermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;
-	all_skip_entries = palloc(skip_entries_capacity * sizeof(TpSkipEntry));
+	all_skip_entries	  = palloc_extended(
+			 (Size)skip_entries_capacity * sizeof(TpSkipEntry),
+			 MCXT_ALLOC_HUGE);
 
 	/* Streaming pass: write posting blocks */
 	for (i = 0; i < num_terms; i++)
@@ -924,9 +937,9 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 			if (skip_entries_count >= skip_entries_capacity)
 			{
 				skip_entries_capacity *= 2;
-				all_skip_entries = repalloc(
+				all_skip_entries = repalloc_huge(
 						all_skip_entries,
-						skip_entries_capacity * sizeof(TpSkipEntry));
+						(Size)skip_entries_capacity * sizeof(TpSkipEntry));
 			}
 			all_skip_entries[skip_entries_count++] = skip;
 		}
@@ -995,7 +1008,8 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 		/* Save end position */
 		BufFileTell(file, &end_fileno, &end_file_offset);
 
-		dict_entries = palloc(num_terms * sizeof(TpDictEntry));
+		dict_entries = palloc_extended(
+				(Size)num_terms * sizeof(TpDictEntry), MCXT_ALLOC_HUGE);
 		for (i = 0; i < num_terms; i++)
 		{
 			dict_entries[i].skip_index_offset =

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -198,7 +198,8 @@ merge_source_init(TpMergeSource *source, Relation index, BlockNumber root)
 			sizeof(dict_header.num_terms));
 
 	/* Cache all string offsets for this segment */
-	source->string_offsets = palloc(sizeof(uint32) * source->num_terms);
+	source->string_offsets = palloc_extended(
+			sizeof(uint32) * (Size)source->num_terms, MCXT_ALLOC_HUGE);
 	tp_segment_read(
 			source->reader,
 			header->dictionary_offset + sizeof(dict_header.num_terms),
@@ -256,7 +257,8 @@ merge_source_init_from_reader(TpMergeSource *source, TpSegmentReader *reader)
 			sizeof(dict_header.num_terms));
 
 	/* Cache all string offsets for this segment */
-	source->string_offsets = palloc(sizeof(uint32) * source->num_terms);
+	source->string_offsets = palloc_extended(
+			sizeof(uint32) * (Size)source->num_terms, MCXT_ALLOC_HUGE);
 	tp_segment_read(
 			source->reader,
 			header->dictionary_offset + sizeof(dict_header.num_terms),
@@ -1050,8 +1052,10 @@ write_merged_segment_to_sink(
 	merge_sink_write(sink, &dict, offsetof(TpDictionary, string_offsets));
 
 	/* Calculate string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			(Size)num_terms * sizeof(uint32),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
 		string_offsets[i] = string_pos;
@@ -1088,11 +1092,15 @@ write_merged_segment_to_sink(
 	header.postings_offset = sink->current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(MergeTermBlockInfo));
+	term_blocks = palloc_extended(
+			(Size)num_terms * sizeof(MergeTermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;
-	all_skip_entries = palloc(skip_entries_capacity * sizeof(TpSkipEntry));
+	all_skip_entries	  = palloc_extended(
+			 (Size)skip_entries_capacity * sizeof(TpSkipEntry),
+			 MCXT_ALLOC_HUGE);
 
 	/*
 	 * Helper macro: flush a full or partial block_buf to the sink.
@@ -1364,7 +1372,8 @@ write_merged_segment_to_sink(
 	{
 		TpDictEntry *dict_entries;
 
-		dict_entries = palloc(num_terms * sizeof(TpDictEntry));
+		dict_entries = palloc_extended(
+				(Size)num_terms * sizeof(TpDictEntry), MCXT_ALLOC_HUGE);
 		for (i = 0; i < num_terms; i++)
 		{
 			dict_entries[i].skip_index_offset =

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -1048,8 +1048,10 @@ tp_write_segment(
 			&writer, &dict, offsetof(TpDictionary, string_offsets));
 
 	/* Build string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			(Size)num_terms * sizeof(uint32),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
 		string_offsets[i] = string_pos;
@@ -1088,11 +1090,15 @@ tp_write_segment(
 	header.postings_offset = writer.current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(TermBlockInfo));
+	term_blocks = palloc_extended(
+			(Size)num_terms * sizeof(TermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;
-	all_skip_entries = palloc(skip_entries_capacity * sizeof(TpSkipEntry));
+	all_skip_entries	  = palloc_extended(
+			 (Size)skip_entries_capacity * sizeof(TpSkipEntry),
+			 MCXT_ALLOC_HUGE);
 
 	/*
 	 * Streaming pass: for each term, convert postings and write immediately.
@@ -1836,7 +1842,8 @@ tp_dump_segment_to_output(
 				sizeof(dict_header.num_terms));
 
 		/* Read string offsets */
-		string_offsets = palloc(sizeof(uint32) * dict_header.num_terms);
+		string_offsets = palloc_extended(
+				sizeof(uint32) * (Size)dict_header.num_terms, MCXT_ALLOC_HUGE);
 		tp_segment_read(
 				reader,
 				header.dictionary_offset + sizeof(dict_header.num_terms),


### PR DESCRIPTION
## Summary

`#431` reports `invalid memory alloc request size` on parallel `CREATE INDEX`
for a large-vocabulary corpus. The report correctly identifies one allocation
site (`merge.c`'s `MergeTermBlockInfo` array), but the underlying pattern —
plain `palloc`/`palloc0`/`repalloc` sized by a segment's distinct-term
count, which caps at PostgreSQL's 1 GB `MaxAllocSize` — appears at **8
distinct arrays across 3 files**, not just the one reported.

Fixing only `#431`'s reported site does not fix the bug: it just moves the
next parallel-build wall from 44,739,242 terms to 67,108,863 (the
`TpDictEntry` allocation, 16 bytes/term).

**Also found while investigating:** the *serial* build path
(`max_parallel_maintenance_workers = 0`) hits a smaller, previously
undocumented ceiling **first**, at **33,554,431 terms** — 1.33x earlier than
`#431`'s reported parallel-path limit of 44,739,242. A corpus with a term
count between those two numbers builds successfully in parallel and fails
serially, which is easy to miss testing only one path (as `#431`'s own repro
does, by forcing `max_parallel_maintenance_workers = 8`).

## Root cause

Term count is a property of the corpus being indexed, not of any tunable
setting, so a `MaxAllocSize`-capped allocation sized by term count is a
silent hard ceiling with no config workaround. The codebase already
establishes the correct pattern for exactly this situation —
`docmap.c`, `merge.c`'s dict-merge path, and `build_parallel.c` already use
`palloc_extended(..., MCXT_ALLOC_HUGE)` / `repalloc_huge` for oversized
allocations. The sites patched here are missed applications of that same
pattern, located via `backtrace_functions = 'MemoryContextSizeFailure'` and
confirmed against DWARF-reported struct sizes (`gdb -batch -ex "print
sizeof(struct X)"` against the built `.so` — hand-computed struct sizes are
not reliable here; `TpSkipEntry` in particular is `__attribute__((packed))`
and is 20 bytes, not the 32 a naive layout calculation suggests).

| Path | Site | Array | B/term | Original ceiling | Fixed to |
|---|---|---|---|---|---|
| SERIAL | `build_context.c` `tp_build_context_get_sorted_terms` | `terms` (`TpBuildTermInfo`) | 32 | **33,554,431** (undocumented) | `palloc_extended(..., MCXT_ALLOC_HUGE)` |
| SERIAL (x2 fns) | `build_context.c` | `term_blocks` (`TermBlockInfo`) | 24 | 44,739,242 | huge |
| **PARALLEL** | `merge.c` | `term_blocks` (`MergeTermBlockInfo`) | 24 | 44,739,242 — **this is `#431`** | huge |
| SERIAL + PARALLEL | `build_context.c`, `merge.c` | `dict_entries` (`TpDictEntry`) | 16 | 67,108,863 | huge |
| both paths (x3 sites) | `build_context.c`, `merge.c`, `segment.c` | `string_offsets` (`uint32`) | 4 | 268,435,455 | huge |
| SERIAL (x2 sites) | `build_context.c` | `all_skip_entries` growth (`TpSkipEntry`) | 20 | 33,554,432 skip entries | `repalloc` → `repalloc_huge` (matches the already-correct sites in `segment.c`/`merge.c`) |

## Testing

- `make format-check` — clean, using clang-format 21.1.8 (the version CI
  pins in `.clang-format`/`formatting.yml`)
- `make installcheck` — **all 71 regression tests pass unchanged**
- `make test-concurrency` — all suites pass unchanged, including
  `concurrent_duplicate_read.sh` (the `#417` regression test), confirming
  this change doesn't interact with the recent concurrency fix cluster
- **Manual repro**, same fixture shape as `#431`'s own report (unique
  md5 tokens so distinct-term count is deterministic): 1,500,000 rows ×
  40 tokens/row = 61,800,079 distinct terms.

  Before this patch:
  ```
  -- serial (max_parallel_maintenance_workers = 0)
  ERROR:  invalid memory alloc request size 1977602528

  -- parallel (max_parallel_maintenance_workers = 8)  <- this is #431
  ERROR:  invalid memory alloc request size 1483201896
  ```
  Both values are exact multiples of 61,800,079 (× 32 and × 24
  respectively), confirming both allocation sites.

  After this patch, both builds succeed (7m12s serial / 9m16s parallel on
  a 44-vCPU host), and the resulting index returns **correct results**: a
  probe term belonging to exactly one of the 1.5M rows retrieves exactly
  that row via `<@>` / `to_bm25query()`.

No fast regression test is included — triggering this class of bug needs
tens of millions of distinct terms, impractical for a CI-scoped test. The
manual repro above is reproducible in a few minutes with
`generate_series()` + `md5()`, matching the shape of `#431`'s own report.

## Notes for reviewers

- This does not touch `#432` (a separate `uint32` narrowing bug on segment
  section offsets, unrelated allocation class) or `#430` (unreproducible
  index-corruption report). Neither is affected by this change.
- Happy to split into multiple commits (e.g. one per file, or
  serial-path/parallel-path separately) if that's preferred for review —
  kept as one commit since all sites are the identical pattern.
- I can add a slow/opt-in regression test gated behind an env var if
  that's wanted despite the CI-time cost; held off since none of the
  existing tests in this size class currently exist in the suite.

Fixes #431
