### PR TITLE
bench: bump ParadeDB baseline to 0.25.2

### DIFF
--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -260,6 +260,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y postgresql-17 postgresql-server-dev-17
 
+        # pg_search (>= 0.24) requires the vector (pgvector) extension
+        sudo apt-get install -y postgresql-17-pgvector
+
         # Install ParadeDB
         wget -q "https://github.com/paradedb/paradedb/releases/download/v${PARADEDB_VERSION}/postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
         sudo apt-get install -y "./postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
@@ -287,7 +290,7 @@ jobs:
         pg_ctl start -D tmp_bench/data -l tmp_bench/postgres.log -w
         export PGHOST="$PWD/tmp_bench/socket"
         createdb bench_test
-        psql -d bench_test -c "CREATE EXTENSION pg_search"
+        psql -d bench_test -c "CREATE EXTENSION pg_search CASCADE"
         echo "PGHOST=$PWD/tmp_bench/socket" >> $GITHUB_ENV
 
     - name: Download MS MARCO dataset

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -262,7 +262,7 @@ jobs:
 
         # Install ParadeDB
         wget -q "https://github.com/paradedb/paradedb/releases/download/v${PARADEDB_VERSION}/postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
-        sudo dpkg -i "postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
+        sudo apt-get install -y "./postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
 
     - name: Configure and start PostgreSQL
       run: |

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -285,6 +285,7 @@ jobs:
         checkpoint_completion_target = 0.9
         wal_buffers = 16MB
         max_parallel_maintenance_workers = $NCPUS
+        shared_preload_libraries = 'pg_search'
         EOF
 
         pg_ctl start -D tmp_bench/data -l tmp_bench/postgres.log -w

--- a/.github/workflows/benchmark-concurrent-insert.yml
+++ b/.github/workflows/benchmark-concurrent-insert.yml
@@ -5,7 +5,7 @@ permissions:
   deployments: write
 
 env:
-  PARADEDB_VERSION: "0.21.6"
+  PARADEDB_VERSION: "0.25.2"
 
 on:
   # TODO: remove push trigger before merging

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -570,6 +570,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y postgresql-17 postgresql-server-dev-17
 
+        # pg_search (>= 0.24) requires the vector (pgvector) extension
+        sudo apt-get install -y postgresql-17-pgvector
+
         # Install ParadeDB extension from GitHub releases
         # ubuntu-latest is Ubuntu 24.04 (Noble)
         wget -q "https://github.com/paradedb/paradedb/releases/download/v${PARADEDB_VERSION}/postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
@@ -608,7 +611,7 @@ jobs:
         fi
         export PGHOST="$PWD/tmp_bench/socket"
         createdb bench_test
-        psql -d bench_test -c "CREATE EXTENSION pg_search"
+        psql -d bench_test -c "CREATE EXTENSION pg_search CASCADE"
         echo "PGHOST=$PWD/tmp_bench/socket" >> $GITHUB_ENV
 
     - name: Determine datasets to run

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ permissions:
 
 env:
   # ParadeDB (competitive baseline) version for benchmarking
-  PARADEDB_VERSION: "0.21.6"
+  PARADEDB_VERSION: "0.25.2"
 
 on:
   # Nightly benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -573,7 +573,7 @@ jobs:
         # Install ParadeDB extension from GitHub releases
         # ubuntu-latest is Ubuntu 24.04 (Noble)
         wget -q "https://github.com/paradedb/paradedb/releases/download/v${PARADEDB_VERSION}/postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
-        sudo dpkg -i "postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
+        sudo apt-get install -y "./postgresql-17-pg-search_${PARADEDB_VERSION}-1PARADEDB-noble_amd64.deb"
 
     - name: Configure PostgreSQL
       run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -589,6 +589,7 @@ jobs:
         # (ubuntu-latest: 2-4 vCPUs, ~7GB RAM)
         NCPUS=$(nproc)
         cat >> tmp_bench/data/postgresql.conf << EOF
+        shared_preload_libraries = 'pg_search'
         unix_socket_directories = '$PWD/tmp_bench/socket'
         shared_buffers = 1GB
         effective_cache_size = 4GB


### PR DESCRIPTION
## Summary

Bumps the pinned ParadeDB (`pg_search`) competitive-baseline version used by the
benchmark workflows from **0.21.6** to **0.25.2** (current latest release), in
both `benchmark.yml` and `benchmark-concurrent-insert.yml`.

0.25.2 has stricter runtime requirements than 0.21.6, so the ParadeDB install /
setup in both workflows is updated accordingly:

- **Install the `.deb` via `apt-get install ./<file>.deb`** instead of `dpkg -i`
  — 0.25.2 adds a `libopenblas0` dependency, which `dpkg -i` does not resolve.
- **Install `postgresql-17-pgvector` and create the extension with `CASCADE`** —
  `pg_search` 0.25.2 requires the `vector` extension, which 0.21.6 did not.
- **Add `pg_search` to `shared_preload_libraries`** — 0.25.2 refuses
  `CREATE EXTENSION` unless preloaded; 0.21.6 did not require this.

The benchmark SQL is unchanged: the existing
`USING bm25 (...) WITH (key_field=...)` DDL and the `paradedb.match()` /
`paradedb.score()` / `@@@` queries remain compatible with 0.25.2.

## Validation

These workflows aren't part of regular PR CI (they run on schedule /
`workflow_dispatch`), so the bump was validated by dispatching the ParadeDB
Cranfield benchmark on this branch (`dataset=cranfield`,
`benchmark_suite=paradedb`, `dry_run=true`). The `paradedb-benchmark` job is
**green**: install, extension creation, index build (`01-load.sql`), queries
(`02-queries.sql`), insert, and concurrent-insert all succeed against 0.25.2.

Historical results under `benchmarks/gh-pages/` and
`benchmarks/datasets/.../results/` are left unchanged — they record the version
that produced those numbers (0.21.6).
