### PR TITLE
ci(benchmark): pin wikiextractor to 3.0.6 to fix Wikipedia validation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -561,7 +561,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget ca-certificates build-essential bc
-        pip install wikiextractor
+        pip install 'wikiextractor==3.0.6'
 
         # Install PostgreSQL 17
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
@@ -1091,7 +1091,9 @@ jobs:
         echo "After cleanup:"
         df -h /
 
-    # wikiextractor requires Python 3.10 (unmaintained, breaks on newer versions)
+    # wikiextractor requires Python 3.10 (unmaintained, breaks on newer versions).
+    # Pinned to 3.0.6: 3.0.8+ changes extraction output and breaks the committed
+    # Wikipedia ground_truth.tsv (see benchmarks/datasets/wikipedia/download.sh).
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
@@ -1101,7 +1103,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget ca-certificates build-essential bc
-        pip install wikiextractor
+        pip install 'wikiextractor==3.0.6'
 
         # PostgreSQL
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
@@ -1681,7 +1683,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget ca-certificates build-essential bc gdb
-        pip install wikiextractor
+        pip install 'wikiextractor==3.0.6'
 
         # PostgreSQL
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
@@ -2353,7 +2355,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget ca-certificates build-essential bc
-        pip install wikiextractor
+        pip install 'wikiextractor==3.0.6'
 
         # PostgreSQL
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -64,7 +64,7 @@ The main runner script is `runner/run_benchmark.sh`:
 ### Prerequisites
 
 1. PostgreSQL with pg_textsearch installed
-2. For Wikipedia: `pip install wikiextractor`
+2. For Wikipedia: `pip install 'wikiextractor==3.0.6'`
 3. For best results, use a release build of Postgres (port 5433)
 
 ### Download Data

--- a/benchmarks/datasets/wikipedia/download.sh
+++ b/benchmarks/datasets/wikipedia/download.sh
@@ -67,10 +67,12 @@ if [ "$SUBSET_SIZE" = "full" ]; then
     echo "Processing Wikipedia XML dump..."
     echo "This requires WikiExtractor: python3.10 -m pip install 'wikiextractor==3.0.6'"
 
-    if ! "$PYTHON_BIN" -c "import wikiextractor" &> /dev/null; then
-        echo "Installing wikiextractor..."
-        "$PYTHON_BIN" -m pip install 'wikiextractor==3.0.6'
-    fi
+    # Always (re)install the pinned version. An importability check would
+    # skip the pin on a persistent/self-hosted env that already has a
+    # different (e.g. drift-inducing 3.0.8+) wikiextractor; pip with an
+    # exact pin is idempotent when satisfied and downgrades otherwise.
+    echo "Installing wikiextractor==3.0.6..."
+    "$PYTHON_BIN" -m pip install 'wikiextractor==3.0.6'
 
     # Extract to JSON format
     if [ ! -d "extracted" ]; then
@@ -164,10 +166,11 @@ else
         wget -q --show-progress -O "$DUMP_FILE" "$DUMP_URL"
     fi
 
-    if ! "$PYTHON_BIN" -c "import wikiextractor" &> /dev/null; then
-        echo "Installing wikiextractor..."
-        "$PYTHON_BIN" -m pip install 'wikiextractor==3.0.6'
-    fi
+    # Always (re)install the pinned version (see note above); do not gate
+    # on importability, which would skip the pin when a different version
+    # is already present.
+    echo "Installing wikiextractor==3.0.6..."
+    "$PYTHON_BIN" -m pip install 'wikiextractor==3.0.6'
 
     if [ ! -d "simple_extracted" ]; then
         echo "Extracting Simple Wikipedia..."

--- a/benchmarks/datasets/wikipedia/download.sh
+++ b/benchmarks/datasets/wikipedia/download.sh
@@ -65,11 +65,11 @@ if [ "$SUBSET_SIZE" = "full" ]; then
     fi
 
     echo "Processing Wikipedia XML dump..."
-    echo "This requires WikiExtractor: python3.10 -m pip install wikiextractor"
+    echo "This requires WikiExtractor: python3.10 -m pip install 'wikiextractor==3.0.6'"
 
     if ! "$PYTHON_BIN" -c "import wikiextractor" &> /dev/null; then
         echo "Installing wikiextractor..."
-        "$PYTHON_BIN" -m pip install wikiextractor
+        "$PYTHON_BIN" -m pip install 'wikiextractor==3.0.6'
     fi
 
     # Extract to JSON format
@@ -148,6 +148,13 @@ else
     # makes the ground truth go stale every time Wikimedia publishes
     # a new dump. When bumping SIMPLE_WIKI_DUMP_DATE, regenerate the
     # ground truth with precompute_ground_truth.sql in the same PR.
+    #
+    # For the same reason, wikiextractor is pinned to 3.0.6 everywhere
+    # it is installed (here and in .github/workflows/benchmark.yml):
+    # 3.0.8 (released 2026-07-23) changed extraction output, which
+    # shifts doc_ids and BM25 scores and broke the committed
+    # ground_truth.tsv. Bumping the wikiextractor pin likewise requires
+    # regenerating the ground truth in the same PR.
     SIMPLE_WIKI_DUMP_DATE="${SIMPLE_WIKI_DUMP_DATE:-20260501}"
     DUMP_FILE="simplewiki-${SIMPLE_WIKI_DUMP_DATE}-pages-articles.xml.bz2"
     DUMP_URL="https://dumps.wikimedia.org/simplewiki/${SIMPLE_WIKI_DUMP_DATE}/${DUMP_FILE}"
@@ -159,7 +166,7 @@ else
 
     if ! "$PYTHON_BIN" -c "import wikiextractor" &> /dev/null; then
         echo "Installing wikiextractor..."
-        "$PYTHON_BIN" -m pip install wikiextractor
+        "$PYTHON_BIN" -m pip install 'wikiextractor==3.0.6'
     fi
 
     if [ ! -d "simple_extracted" ]; then

--- a/benchmarks/runner/format_for_action.sh
+++ b/benchmarks/runner/format_for_action.sh
@@ -47,7 +47,7 @@ else
 fi
 
 # Build the output array using jq
-jq --arg dataset "$DATASET_LABEL" '[
+RESULT=$(jq --arg dataset "$DATASET_LABEL" '[
     # Index build time
     (if .metrics.index_build_time_ms != null then
         {
@@ -248,7 +248,18 @@ jq --arg dataset "$DATASET_LABEL" '[
             value: .metrics.vacuum.update_query_avg_ms
         }
     else empty end)
-]' "$INPUT_FILE" > "$OUTPUT_FILE"
+]' "$INPUT_FILE")
 
-echo "Converted $INPUT_FILE to github-action-benchmark format:"
-cat "$OUTPUT_FILE"
+# github-action-benchmark errors out on an empty array ("Benchmark output
+# was '[]'"). When no metrics were parsed -- e.g. an upstream benchmark
+# step was skipped or produced no output -- do not write an output file at
+# all. The publish steps gate on hashFiles('..._action.json') != '', so a
+# missing file is skipped cleanly instead of failing the job.
+if [ "$(printf '%s' "$RESULT" | jq 'length')" -gt 0 ]; then
+    printf '%s\n' "$RESULT" > "$OUTPUT_FILE"
+    echo "Converted $INPUT_FILE to github-action-benchmark format:"
+    cat "$OUTPUT_FILE"
+else
+    echo "No metrics parsed from $INPUT_FILE; not writing $OUTPUT_FILE (nothing to publish)"
+    rm -f "$OUTPUT_FILE"
+fi


### PR DESCRIPTION
## Summary

Fixes the nightly `Benchmarks` workflow, which has failed every night since
**2026-07-23** — two related failures in the `full-benchmark` and
`insert-benchmark` jobs.

## 1. Wikipedia validation (root cause)

CI installs `wikiextractor` **unpinned**. `wikiextractor 3.0.8` was released on
**2026-07-23** — the exact day the nightly started failing (previous release
`3.0.6` was from 2021-10-14). 3.0.8 changes extraction output: with the *same*
pinned dump (`simplewiki 20260501`) it produces different article text/ordering,
which shifts `doc_id`s and BM25 scores so results no longer match the committed
`ground_truth.tsv`. MS MARCO validation is unaffected (it does not use
wikiextractor), confirming corpus drift rather than a scoring regression.

**Fix:** pin `wikiextractor==3.0.6` — the last version for which the committed
`ground_truth.tsv` is correct — everywhere it is installed (the four
`benchmark.yml` install steps, both `download.sh` sites, and the `README.md`
prerequisite). The `download.sh` install is now unconditional (the previous
`import wikiextractor` guard only checked importability, not version, so a
persistent env with 3.0.8+ would skip the pin). No ground-truth regeneration
needed.

## 2. Empty concurrent-benchmark JSON (`[]`)

The `insert-benchmark` job also failed at "Publish … concurrent benchmark"
(`No benchmark result was found … output was '[]'`). This is a **cascade**: the
concurrent-insert steps run *after* Wikipedia insert validation and lack
`if: always()`, so when that validation failed they were skipped, no
`CONCURRENT_INSERT_TIME` was logged, and `format_for_action.sh` emitted an empty
array that `github-action-benchmark` rejects. Fixing #1 stops the cascade.

**Fix (defense in depth):** `format_for_action.sh` no longer writes an output
file when the metric array is empty. The publish steps already gate on
`hashFiles('…_action.json') != ''`, so a missing file is skipped cleanly instead
of hard-failing the job.

## Validation

- Wikipedia: dispatched `benchmark.yml` (`dataset=wikipedia`, `size=100K`,
  `suite=full`, `dry_run=true`) — `VALIDATION PASSED: All 80 queries match`
  (previously 80/80 failed).
- `[]` guard: unit-tested `format_for_action.sh` (empty input → no file written;
  non-empty → file written) and smoke-tested the insert-benchmark path in CI.
