### PR TITLE
test: stabilize explicit_index tie ordering

### DIFF
--- a/test/expected/explicit_index.out
+++ b/test/expected/explicit_index.out
@@ -56,8 +56,9 @@ CREATE TABLE multi_index_test (
     content TEXT
 );
 -- Insert test data - enough rows to make planner consider index choices
-INSERT INTO multi_index_test (category_id, content)
+INSERT INTO multi_index_test (id, category_id, content)
 SELECT
+    i,
     (i % 10),
     'Les ressources humaines gèrent les employés et leurs contrats de travail'
 FROM generate_series(1, 1000) i;
@@ -94,6 +95,7 @@ LIMIT 10;
 
 -- Positive test: without explicit index, implicit resolution works
 -- (uses first found index, with a warning about multiple indexes)
+EXPLAIN (COSTS OFF)
 SELECT id, content <@> 'ressources' AS score
 FROM multi_index_test
 WHERE category_id = 1
@@ -103,6 +105,20 @@ WARNING:  multiple BM25 indexes exist on the same column
 HINT:  Use explicit to_bm25query('query', 'index_name') to specify which index to use.
 WARNING:  planner chose index "content_idx_simple" instead of "content_idx_french"
 HINT:  If this is not desired, use a planner hint to force a specific index, or use explicit to_bm25query('query', 'index_name').
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Limit
+   ->  Index Scan using content_idx_simple on multi_index_test
+         Order By: (content <@> 'content_idx_french:ressources'::bm25query)
+         Filter: (category_id = 1)
+(4 rows)
+
+SET client_min_messages = error;
+SELECT id, content <@> 'ressources' AS score
+FROM multi_index_test
+WHERE category_id = 1
+ORDER BY score, id
+LIMIT 3;
  id |         score          
 ----+------------------------
   1 | -0.0004996252828277647
@@ -110,6 +126,84 @@ HINT:  If this is not desired, use a planner hint to force a specific index, or 
  21 | -0.0004996252828277647
 (3 rows)
 
+RESET client_min_messages;
+-- Verify the same tie-breaking for ascending and descending physical order
+CREATE TABLE multi_index_test_asc (
+    id SERIAL PRIMARY KEY,
+    category_id INT,
+    content TEXT
+);
+INSERT INTO multi_index_test_asc (id, category_id, content)
+SELECT
+    i,
+    (i % 10),
+    'Les ressources humaines gèrent les employés et leurs contrats de travail'
+FROM generate_series(1, 1000) i;
+CREATE INDEX content_idx_french_asc ON multi_index_test_asc USING bm25 (content)
+    WITH (text_config = 'french');
+NOTICE:  BM25 index build started for relation content_idx_french_asc
+NOTICE:  Using text search configuration: french
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1000 documents, avg_length=9.00
+CREATE INDEX content_idx_simple_asc ON multi_index_test_asc USING bm25 (content)
+    WITH (text_config = 'simple');
+NOTICE:  BM25 index build started for relation content_idx_simple_asc
+NOTICE:  Using text search configuration: simple
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1000 documents, avg_length=11.00
+ANALYZE multi_index_test_asc;
+SET client_min_messages = error;
+SELECT 'ascending' AS physical_order, id, content <@> 'ressources' AS score
+FROM multi_index_test_asc
+WHERE category_id = 1
+ORDER BY score, id
+LIMIT 3;
+ physical_order | id |         score          
+----------------+----+------------------------
+ ascending      |  1 | -0.0004996252828277647
+ ascending      | 11 | -0.0004996252828277647
+ ascending      | 21 | -0.0004996252828277647
+(3 rows)
+
+RESET client_min_messages;
+CREATE TABLE multi_index_test_desc (
+    id SERIAL PRIMARY KEY,
+    category_id INT,
+    content TEXT
+);
+INSERT INTO multi_index_test_desc (id, category_id, content)
+SELECT
+    i,
+    (i % 10),
+    'Les ressources humaines gèrent les employés et leurs contrats de travail'
+FROM generate_series(1000, 1, -1) i;
+CREATE INDEX content_idx_french_desc ON multi_index_test_desc USING bm25 (content)
+    WITH (text_config = 'french');
+NOTICE:  BM25 index build started for relation content_idx_french_desc
+NOTICE:  Using text search configuration: french
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1000 documents, avg_length=9.00
+CREATE INDEX content_idx_simple_desc ON multi_index_test_desc USING bm25 (content)
+    WITH (text_config = 'simple');
+NOTICE:  BM25 index build started for relation content_idx_simple_desc
+NOTICE:  Using text search configuration: simple
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 1000 documents, avg_length=11.00
+ANALYZE multi_index_test_desc;
+SET client_min_messages = error;
+SELECT 'descending' AS physical_order, id, content <@> 'ressources' AS score
+FROM multi_index_test_desc
+WHERE category_id = 1
+ORDER BY score, id
+LIMIT 3;
+ physical_order | id |         score          
+----------------+----+------------------------
+ descending     |  1 | -0.0004996252828277647
+ descending     | 11 | -0.0004996252828277647
+ descending     | 21 | -0.0004996252828277647
+(3 rows)
+
+RESET client_min_messages;
 -- Positive test: explicit index matching the scanned index works
 -- Drop the simple index so french is the only choice
 DROP INDEX content_idx_simple;
@@ -128,5 +222,7 @@ LIMIT 10;
 (4 rows)
 
 -- Clean up
+DROP TABLE multi_index_test_asc;
+DROP TABLE multi_index_test_desc;
 DROP TABLE multi_index_test;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/explicit_index.out
+++ b/test/expected/explicit_index.out
@@ -95,7 +95,7 @@ LIMIT 10;
 -- Positive test: without explicit index, implicit resolution works
 -- (uses first found index, with a warning about multiple indexes)
 EXPLAIN (COSTS OFF)
-SELECT id, content <@> 'ressources' AS score
+SELECT content <@> 'ressources' AS score
 FROM multi_index_test
 WHERE category_id = 1
 ORDER BY score
@@ -112,24 +112,22 @@ HINT:  If this is not desired, use a planner hint to force a specific index, or 
          Filter: (category_id = 1)
 (4 rows)
 
--- All rows contain the same text, so BM25 scores tie and the ids returned
--- by the index scan are not deterministic. Count the index-ordered rows
--- instead of printing them; the subquery keeps the BM25 index scan (proved
--- by the EXPLAIN above) on the query path. Warnings are silenced here
--- because the EXPLAIN above already asserts both of them.
+-- All matching rows contain the same text, so the score is deterministic
+-- even though the tied tuple ids are not. Re-run the exact statement with
+-- warnings silenced and assert the repeated BM25 score values.
 SET client_min_messages = error;
-SELECT count(*) AS rows_returned FROM (
-    SELECT id
-    FROM multi_index_test
-    WHERE category_id = 1
-    ORDER BY content <@> 'ressources'
-    LIMIT 3
-) sub;
- rows_returned 
----------------
-             3
-(1 row)
-
+\pset format unaligned
+SELECT content <@> 'ressources' AS score
+FROM multi_index_test
+WHERE category_id = 1
+ORDER BY score
+LIMIT 3;
+score
+-0.0004996252828277647
+-0.0004996252828277647
+-0.0004996252828277647
+(3 rows)
+\pset format aligned
 RESET client_min_messages;
 -- Positive test: explicit index matching the scanned index works
 -- Drop the simple index so french is the only choice

--- a/test/expected/explicit_index.out
+++ b/test/expected/explicit_index.out
@@ -56,9 +56,8 @@ CREATE TABLE multi_index_test (
     content TEXT
 );
 -- Insert test data - enough rows to make planner consider index choices
-INSERT INTO multi_index_test (id, category_id, content)
+INSERT INTO multi_index_test (category_id, content)
 SELECT
-    i,
     (i % 10),
     'Les ressources humaines gèrent les employés et leurs contrats de travail'
 FROM generate_series(1, 1000) i;
@@ -113,95 +112,23 @@ HINT:  If this is not desired, use a planner hint to force a specific index, or 
          Filter: (category_id = 1)
 (4 rows)
 
+-- All rows contain the same text, so BM25 scores tie and the ids returned
+-- by the index scan are not deterministic. Count the index-ordered rows
+-- instead of printing them; the subquery keeps the BM25 index scan (proved
+-- by the EXPLAIN above) on the query path. Warnings are silenced here
+-- because the EXPLAIN above already asserts both of them.
 SET client_min_messages = error;
-SELECT id, content <@> 'ressources' AS score
-FROM multi_index_test
-WHERE category_id = 1
-ORDER BY score, id
-LIMIT 3;
- id |         score          
-----+------------------------
-  1 | -0.0004996252828277647
- 11 | -0.0004996252828277647
- 21 | -0.0004996252828277647
-(3 rows)
-
-RESET client_min_messages;
--- Verify the same tie-breaking for ascending and descending physical order
-CREATE TABLE multi_index_test_asc (
-    id SERIAL PRIMARY KEY,
-    category_id INT,
-    content TEXT
-);
-INSERT INTO multi_index_test_asc (id, category_id, content)
-SELECT
-    i,
-    (i % 10),
-    'Les ressources humaines gèrent les employés et leurs contrats de travail'
-FROM generate_series(1, 1000) i;
-CREATE INDEX content_idx_french_asc ON multi_index_test_asc USING bm25 (content)
-    WITH (text_config = 'french');
-NOTICE:  BM25 index build started for relation content_idx_french_asc
-NOTICE:  Using text search configuration: french
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 1000 documents, avg_length=9.00
-CREATE INDEX content_idx_simple_asc ON multi_index_test_asc USING bm25 (content)
-    WITH (text_config = 'simple');
-NOTICE:  BM25 index build started for relation content_idx_simple_asc
-NOTICE:  Using text search configuration: simple
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 1000 documents, avg_length=11.00
-ANALYZE multi_index_test_asc;
-SET client_min_messages = error;
-SELECT 'ascending' AS physical_order, id, content <@> 'ressources' AS score
-FROM multi_index_test_asc
-WHERE category_id = 1
-ORDER BY score, id
-LIMIT 3;
- physical_order | id |         score          
-----------------+----+------------------------
- ascending      |  1 | -0.0004996252828277647
- ascending      | 11 | -0.0004996252828277647
- ascending      | 21 | -0.0004996252828277647
-(3 rows)
-
-RESET client_min_messages;
-CREATE TABLE multi_index_test_desc (
-    id SERIAL PRIMARY KEY,
-    category_id INT,
-    content TEXT
-);
-INSERT INTO multi_index_test_desc (id, category_id, content)
-SELECT
-    i,
-    (i % 10),
-    'Les ressources humaines gèrent les employés et leurs contrats de travail'
-FROM generate_series(1000, 1, -1) i;
-CREATE INDEX content_idx_french_desc ON multi_index_test_desc USING bm25 (content)
-    WITH (text_config = 'french');
-NOTICE:  BM25 index build started for relation content_idx_french_desc
-NOTICE:  Using text search configuration: french
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 1000 documents, avg_length=9.00
-CREATE INDEX content_idx_simple_desc ON multi_index_test_desc USING bm25 (content)
-    WITH (text_config = 'simple');
-NOTICE:  BM25 index build started for relation content_idx_simple_desc
-NOTICE:  Using text search configuration: simple
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 1000 documents, avg_length=11.00
-ANALYZE multi_index_test_desc;
-SET client_min_messages = error;
-SELECT 'descending' AS physical_order, id, content <@> 'ressources' AS score
-FROM multi_index_test_desc
-WHERE category_id = 1
-ORDER BY score, id
-LIMIT 3;
- physical_order | id |         score          
-----------------+----+------------------------
- descending     |  1 | -0.0004996252828277647
- descending     | 11 | -0.0004996252828277647
- descending     | 21 | -0.0004996252828277647
-(3 rows)
+SELECT count(*) AS rows_returned FROM (
+    SELECT id
+    FROM multi_index_test
+    WHERE category_id = 1
+    ORDER BY content <@> 'ressources'
+    LIMIT 3
+) sub;
+ rows_returned 
+---------------
+             3
+(1 row)
 
 RESET client_min_messages;
 -- Positive test: explicit index matching the scanned index works
@@ -222,7 +149,5 @@ LIMIT 10;
 (4 rows)
 
 -- Clean up
-DROP TABLE multi_index_test_asc;
-DROP TABLE multi_index_test_desc;
 DROP TABLE multi_index_test;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/explicit_index.sql
+++ b/test/sql/explicit_index.sql
@@ -53,8 +53,9 @@ CREATE TABLE multi_index_test (
 );
 
 -- Insert test data - enough rows to make planner consider index choices
-INSERT INTO multi_index_test (category_id, content)
+INSERT INTO multi_index_test (id, category_id, content)
 SELECT
+    i,
     (i % 10),
     'Les ressources humaines gèrent les employés et leurs contrats de travail'
 FROM generate_series(1, 1000) i;
@@ -79,11 +80,71 @@ LIMIT 10;
 
 -- Positive test: without explicit index, implicit resolution works
 -- (uses first found index, with a warning about multiple indexes)
+EXPLAIN (COSTS OFF)
 SELECT id, content <@> 'ressources' AS score
 FROM multi_index_test
 WHERE category_id = 1
 ORDER BY score
 LIMIT 3;
+
+SET client_min_messages = error;
+SELECT id, content <@> 'ressources' AS score
+FROM multi_index_test
+WHERE category_id = 1
+ORDER BY score, id
+LIMIT 3;
+RESET client_min_messages;
+
+-- Verify the same tie-breaking for ascending and descending physical order
+CREATE TABLE multi_index_test_asc (
+    id SERIAL PRIMARY KEY,
+    category_id INT,
+    content TEXT
+);
+INSERT INTO multi_index_test_asc (id, category_id, content)
+SELECT
+    i,
+    (i % 10),
+    'Les ressources humaines gèrent les employés et leurs contrats de travail'
+FROM generate_series(1, 1000) i;
+CREATE INDEX content_idx_french_asc ON multi_index_test_asc USING bm25 (content)
+    WITH (text_config = 'french');
+CREATE INDEX content_idx_simple_asc ON multi_index_test_asc USING bm25 (content)
+    WITH (text_config = 'simple');
+ANALYZE multi_index_test_asc;
+
+SET client_min_messages = error;
+SELECT 'ascending' AS physical_order, id, content <@> 'ressources' AS score
+FROM multi_index_test_asc
+WHERE category_id = 1
+ORDER BY score, id
+LIMIT 3;
+RESET client_min_messages;
+
+CREATE TABLE multi_index_test_desc (
+    id SERIAL PRIMARY KEY,
+    category_id INT,
+    content TEXT
+);
+INSERT INTO multi_index_test_desc (id, category_id, content)
+SELECT
+    i,
+    (i % 10),
+    'Les ressources humaines gèrent les employés et leurs contrats de travail'
+FROM generate_series(1000, 1, -1) i;
+CREATE INDEX content_idx_french_desc ON multi_index_test_desc USING bm25 (content)
+    WITH (text_config = 'french');
+CREATE INDEX content_idx_simple_desc ON multi_index_test_desc USING bm25 (content)
+    WITH (text_config = 'simple');
+ANALYZE multi_index_test_desc;
+
+SET client_min_messages = error;
+SELECT 'descending' AS physical_order, id, content <@> 'ressources' AS score
+FROM multi_index_test_desc
+WHERE category_id = 1
+ORDER BY score, id
+LIMIT 3;
+RESET client_min_messages;
 
 -- Positive test: explicit index matching the scanned index works
 -- Drop the simple index so french is the only choice
@@ -96,6 +157,8 @@ ORDER BY score
 LIMIT 10;
 
 -- Clean up
+DROP TABLE multi_index_test_asc;
+DROP TABLE multi_index_test_desc;
 DROP TABLE multi_index_test;
 
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/explicit_index.sql
+++ b/test/sql/explicit_index.sql
@@ -53,9 +53,8 @@ CREATE TABLE multi_index_test (
 );
 
 -- Insert test data - enough rows to make planner consider index choices
-INSERT INTO multi_index_test (id, category_id, content)
+INSERT INTO multi_index_test (category_id, content)
 SELECT
-    i,
     (i % 10),
     'Les ressources humaines gèrent les employés et leurs contrats de travail'
 FROM generate_series(1, 1000) i;
@@ -87,63 +86,19 @@ WHERE category_id = 1
 ORDER BY score
 LIMIT 3;
 
+-- All rows contain the same text, so BM25 scores tie and the ids returned
+-- by the index scan are not deterministic. Count the index-ordered rows
+-- instead of printing them; the subquery keeps the BM25 index scan (proved
+-- by the EXPLAIN above) on the query path. Warnings are silenced here
+-- because the EXPLAIN above already asserts both of them.
 SET client_min_messages = error;
-SELECT id, content <@> 'ressources' AS score
-FROM multi_index_test
-WHERE category_id = 1
-ORDER BY score, id
-LIMIT 3;
-RESET client_min_messages;
-
--- Verify the same tie-breaking for ascending and descending physical order
-CREATE TABLE multi_index_test_asc (
-    id SERIAL PRIMARY KEY,
-    category_id INT,
-    content TEXT
-);
-INSERT INTO multi_index_test_asc (id, category_id, content)
-SELECT
-    i,
-    (i % 10),
-    'Les ressources humaines gèrent les employés et leurs contrats de travail'
-FROM generate_series(1, 1000) i;
-CREATE INDEX content_idx_french_asc ON multi_index_test_asc USING bm25 (content)
-    WITH (text_config = 'french');
-CREATE INDEX content_idx_simple_asc ON multi_index_test_asc USING bm25 (content)
-    WITH (text_config = 'simple');
-ANALYZE multi_index_test_asc;
-
-SET client_min_messages = error;
-SELECT 'ascending' AS physical_order, id, content <@> 'ressources' AS score
-FROM multi_index_test_asc
-WHERE category_id = 1
-ORDER BY score, id
-LIMIT 3;
-RESET client_min_messages;
-
-CREATE TABLE multi_index_test_desc (
-    id SERIAL PRIMARY KEY,
-    category_id INT,
-    content TEXT
-);
-INSERT INTO multi_index_test_desc (id, category_id, content)
-SELECT
-    i,
-    (i % 10),
-    'Les ressources humaines gèrent les employés et leurs contrats de travail'
-FROM generate_series(1000, 1, -1) i;
-CREATE INDEX content_idx_french_desc ON multi_index_test_desc USING bm25 (content)
-    WITH (text_config = 'french');
-CREATE INDEX content_idx_simple_desc ON multi_index_test_desc USING bm25 (content)
-    WITH (text_config = 'simple');
-ANALYZE multi_index_test_desc;
-
-SET client_min_messages = error;
-SELECT 'descending' AS physical_order, id, content <@> 'ressources' AS score
-FROM multi_index_test_desc
-WHERE category_id = 1
-ORDER BY score, id
-LIMIT 3;
+SELECT count(*) AS rows_returned FROM (
+    SELECT id
+    FROM multi_index_test
+    WHERE category_id = 1
+    ORDER BY content <@> 'ressources'
+    LIMIT 3
+) sub;
 RESET client_min_messages;
 
 -- Positive test: explicit index matching the scanned index works
@@ -157,8 +112,6 @@ ORDER BY score
 LIMIT 10;
 
 -- Clean up
-DROP TABLE multi_index_test_asc;
-DROP TABLE multi_index_test_desc;
 DROP TABLE multi_index_test;
 
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/explicit_index.sql
+++ b/test/sql/explicit_index.sql
@@ -80,25 +80,23 @@ LIMIT 10;
 -- Positive test: without explicit index, implicit resolution works
 -- (uses first found index, with a warning about multiple indexes)
 EXPLAIN (COSTS OFF)
-SELECT id, content <@> 'ressources' AS score
+SELECT content <@> 'ressources' AS score
 FROM multi_index_test
 WHERE category_id = 1
 ORDER BY score
 LIMIT 3;
 
--- All rows contain the same text, so BM25 scores tie and the ids returned
--- by the index scan are not deterministic. Count the index-ordered rows
--- instead of printing them; the subquery keeps the BM25 index scan (proved
--- by the EXPLAIN above) on the query path. Warnings are silenced here
--- because the EXPLAIN above already asserts both of them.
+-- All matching rows contain the same text, so the score is deterministic
+-- even though the tied tuple ids are not. Re-run the exact statement with
+-- warnings silenced and assert the repeated BM25 score values.
 SET client_min_messages = error;
-SELECT count(*) AS rows_returned FROM (
-    SELECT id
-    FROM multi_index_test
-    WHERE category_id = 1
-    ORDER BY content <@> 'ressources'
-    LIMIT 3
-) sub;
+\pset format unaligned
+SELECT content <@> 'ressources' AS score
+FROM multi_index_test
+WHERE category_id = 1
+ORDER BY score
+LIMIT 3;
+\pset format aligned
 RESET client_min_messages;
 
 -- Positive test: explicit index matching the scanned index works


### PR DESCRIPTION
## Summary
- The `explicit_index` implicit-resolution case inserts 1000 identical documents, so BM25 scores tie and the returned ids are physical-order-dependent (e.g. `{991,981,971}` vs `{1,11,21}` depending on insertion order).
- Replace the nondeterministic id output with a deterministic BM25 score assertion, while keeping the `EXPLAIN` that proves the BM25 Index Scan is used and preserving both planner warnings.

## Context
Reproducible on stock PostgreSQL by varying physical insertion order. No product code change — the test assumption was unstable.

## Verification
- `explicit_index` passes on PostgreSQL 17.9 and 18.4
- EXPLAIN confirms the executed statement plans to `Index Scan using content_idx_simple` with both warnings
- Deterministic score `-0.0004996252828277647` asserted instead of tied ids
