### PR TITLE
test: make memtable_reclaim horizon-safe

### DIFF
--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -4,6 +4,22 @@
 -- chain grows again (main fork should not grow by ~one block per dead
 -- page if reuse works).
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+-- Detect whether another same-database client backend is holding an xmin
+-- (which pins the reclaim horizon back).  Sampled around each VACUUM so the
+-- growth bounds below can tolerate deferred reclaim when a concurrent
+-- snapshot -- e.g. autovacuum or a parallel regression session -- keeps
+-- GetOldestNonRemovableTransactionId from advancing.
+CREATE FUNCTION other_backend_holds_xmin() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
+$$;
 CREATE TABLE memtable_reclaim_t (id serial PRIMARY KEY, body text);
 CREATE INDEX memtable_reclaim_idx ON memtable_reclaim_t
     USING bm25(body) WITH (text_config = 'english');
@@ -72,26 +88,12 @@ SELECT false;
 -- Horizon: spill xact is committed (autocommit per statement).
 UPDATE reclaim_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 UPDATE reclaim_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
     SELECT 1 FROM memtable_reclaim_t
@@ -105,6 +107,16 @@ SELECT count(*) >= 1 AS search_after_vacuum FROM (
 
 -- Rebuild chain without auto-spill so pages come from FSM vs extend.
 SET pg_textsearch.memtable_pages_threshold = 0;
+-- Snapshot the DEAD-page count *before* the reuse insert.  Freeing a page
+-- to the FSM does not clear its DEAD stamp -- only reuse via
+-- tp_memtable_alloc_page does -- so the post-rebuild count co-varies with a
+-- reuse regression (pages that should have been reused but were not stay
+-- DEAD and inflate the count by exactly the extra growth).  Bounding the
+-- blocked branch against this pre-rebuild snapshot keeps the check able to
+-- catch a reuse regression even when a concurrent backend forces that branch.
+CREATE TEMP TABLE reclaim_before_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'reclaim2 ' || i || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) i;
@@ -120,7 +132,6 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
  t
 (1 row)
 
-\set QUIET 1
 \pset format unaligned
 SELECT
     CASE
@@ -128,7 +139,7 @@ SELECT
             THEN (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
                   - (SELECT sz_after_spill FROM reclaim_sizes))
                  <= (SELECT deferred_pages
-                     FROM reclaim_after_rebuild)
+                     FROM reclaim_before_rebuild)
                     * current_setting('block_size')::bigint
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_after_spill FROM reclaim_sizes))
@@ -174,14 +185,7 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
 
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 2
 INSERT INTO memtable_reclaim_t (body)
@@ -198,14 +202,7 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
 
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 3
 INSERT INTO memtable_reclaim_t (body)
@@ -222,14 +219,7 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
 
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 4
 INSERT INTO memtable_reclaim_t (body)
@@ -246,14 +236,7 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
 
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 5
 INSERT INTO memtable_reclaim_t (body)
@@ -270,15 +253,15 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
+-- Snapshot the DEAD-page count before the final reuse insert (see the
+-- single-cycle note above): the pre-rebuild count does not co-vary with
+-- whether the subsequent reuse succeeds, so it preserves the blocked
+-- branch's ability to catch a reuse regression.
+CREATE TEMP TABLE multi_cycle_before_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
@@ -298,7 +281,6 @@ FROM multi_cycle_bounds;
 -- one live chain's worth of segment/main-fork growth per cycle
 -- (`num_cycles * max_live_pages`).  Only an external backend_xmin
 -- blocker may add the pages still tracked as DEAD after the rebuild.
-\set QUIET 1
 \pset format unaligned
 SELECT
     CASE
@@ -310,7 +292,7 @@ SELECT
                  <= ((SELECT num_cycles * max_live_pages
                       FROM multi_cycle_bounds)
                      + (SELECT deferred_pages
-                        FROM multi_cycle_after_rebuild))
+                        FROM multi_cycle_before_rebuild))
                     * current_setting('block_size')::bigint
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_start FROM multi_cycle_bounds))
@@ -323,5 +305,6 @@ multi_cycle_growth_valid
 t
 (1 row)
 \pset format aligned
+DROP FUNCTION other_backend_holds_xmin();
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -93,20 +93,19 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
  t
 (1 row)
 
-COPY (
-    SELECT format(
-               'single_cycle_growth_valid=%s',
-               (
-                   (pg_relation_size('memtable_reclaim_idx'::regclass,
-                                     'main')
-                    - (SELECT sz_after_spill FROM reclaim_sizes))
-                   < ((SELECT deferred_pages
-                       FROM reclaim_after_rebuild) + 1)
-                        * current_setting('block_size')::bigint
-               )
-           )
-) TO STDOUT;
-single_cycle_growth_valid=t
+\set QUIET 1
+\pset format unaligned
+SELECT
+    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+     - (SELECT sz_after_spill FROM reclaim_sizes))
+    < ((SELECT deferred_pages FROM reclaim_after_rebuild) + 1)
+         * current_setting('block_size')::bigint
+    AS single_cycle_growth_valid;
+single_cycle_growth_valid
+t
+(1 row)
+\pset format aligned
+\set QUIET 0
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
 -- Rebuilding the chain after repeated spill→VACUUM cycles should keep
 -- cumulative growth bounded by the live memtable work per cycle, with
@@ -114,20 +113,24 @@ single_cycle_growth_valid=t
 -- the final rebuild.
 CREATE TEMP TABLE multi_cycle_bounds (
     sz_start bigint,
-    num_cycles int,
-    max_live_pages int
+    max_live_pages int,
+    num_cycles int
 );
-INSERT INTO multi_cycle_bounds (sz_start, num_cycles, max_live_pages)
+CREATE TABLE
+INSERT INTO multi_cycle_bounds (sz_start, max_live_pages, num_cycles)
 SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
-       5,
-       0;
+       0,
+       5;
+INSERT 0 1
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc1 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
+INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
+UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
  mc_spill_1 
 ------------
@@ -135,13 +138,16 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
 (1 row)
 
 VACUUM ANALYZE memtable_reclaim_t;
+VACUUM
 -- Cycle 2
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc2 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
+INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
+UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
  mc_spill_2 
 ------------
@@ -149,13 +155,16 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
 (1 row)
 
 VACUUM ANALYZE memtable_reclaim_t;
+VACUUM
 -- Cycle 3
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc3 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
+INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
+UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
  mc_spill_3 
 ------------
@@ -163,13 +172,16 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
 (1 row)
 
 VACUUM ANALYZE memtable_reclaim_t;
+VACUUM
 -- Cycle 4
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc4 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
+INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
+UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
  mc_spill_4 
 ------------
@@ -177,13 +189,16 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
 (1 row)
 
 VACUUM ANALYZE memtable_reclaim_t;
+VACUUM
 -- Cycle 5
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc5 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
+INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
+UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
  mc_spill_5 
 ------------
@@ -191,12 +206,15 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 (1 row)
 
 VACUUM ANALYZE memtable_reclaim_t;
+VACUUM
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
+INSERT 0 200
 CREATE TEMP TABLE multi_cycle_after_rebuild AS
 SELECT count(*)::int AS deferred_pages
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
+SELECT 1
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
  multi_cycle_chain_multi_page 
@@ -204,21 +222,25 @@ FROM multi_cycle_bounds;
  t
 (1 row)
 
-COPY (
-    SELECT format(
-               'multi_cycle_growth_valid=%s',
-               (
-                   (pg_relation_size('memtable_reclaim_idx'::regclass,
-                                     'main')
-                    - (SELECT sz_start FROM multi_cycle_bounds))
-                   < ((SELECT num_cycles * max_live_pages
-                       FROM multi_cycle_bounds)
-                      + (SELECT deferred_pages
-                         FROM multi_cycle_after_rebuild))
-                        * current_setting('block_size')::bigint
-               )
-           )
-) TO STDOUT;
-multi_cycle_growth_valid=t
+-- Budget one live-chain's worth of segment/main-fork growth per cycle
+-- (`num_cycles * max_live_pages`) plus any pages still tracked as DEAD
+-- after the final rebuild.
+\set QUIET 1
+\pset format unaligned
+SELECT
+    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+     - (SELECT sz_start FROM multi_cycle_bounds))
+    < ((SELECT num_cycles * max_live_pages
+        FROM multi_cycle_bounds)
+       + (SELECT deferred_pages FROM multi_cycle_after_rebuild))
+         * current_setting('block_size')::bigint
+    AS multi_cycle_growth_valid;
+multi_cycle_growth_valid
+t
+(1 row)
+\pset format aligned
+\set QUIET 0
 DROP TABLE memtable_reclaim_t;
+DROP TABLE
 DROP EXTENSION pg_textsearch CASCADE;
+DROP EXTENSION

--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -68,6 +68,9 @@ SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
 VACUUM ANALYZE memtable_reclaim_t;
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 VACUUM ANALYZE memtable_reclaim_t;
+CREATE TEMP TABLE reclaim_after_vacuum AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
     SELECT 1 FROM memtable_reclaim_t
     ORDER BY body <@> to_bm25query('reclaim', 'memtable_reclaim_idx')
@@ -93,7 +96,7 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 SELECT
     (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
      - (SELECT sz_after_spill FROM reclaim_sizes))
-    < (SELECT dead_count FROM reclaim_dead)
+    < ((SELECT deferred_pages FROM reclaim_after_vacuum) + 1)
          * current_setting('block_size')::bigint
     AS main_fork_growth_less_than_dead_bytes;
  main_fork_growth_less_than_dead_bytes 
@@ -102,17 +105,14 @@ SELECT
 (1 row)
 
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
--- Without FSM reuse the main fork would grow by roughly N×K memtable pages;
--- with reclaim each cycle, growth stays below N×K×block_size.
+-- After the final VACUUM, rebuilding the chain should reuse reclaimed
+-- pages from the prior cycles; any extra growth must correspond to
+-- dead pages still explicitly tracked as deferred.
 CREATE TEMP TABLE multi_cycle_bounds (
-    sz_start bigint,
-    max_live_pages int,
-    num_cycles int
+    max_live_pages int
 );
-INSERT INTO multi_cycle_bounds (sz_start, max_live_pages, num_cycles)
-SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
-       0,
-       5;
+INSERT INTO multi_cycle_bounds (max_live_pages)
+SELECT 0;
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc1 doc ' || g || ' ' || repeat('pad ', 6)
@@ -183,7 +183,19 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 (1 row)
 
 VACUUM ANALYZE memtable_reclaim_t;
-SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
+CREATE TEMP TABLE multi_cycle_after_vacuum AS
+SELECT count(*)::int AS deferred_pages,
+       pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
+           AS sz_after_vacuum
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
+INSERT INTO memtable_reclaim_t (body)
+SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
+FROM generate_series(1, 200) g;
+SELECT max_live_pages > 1
+       AND EXISTS (
+           SELECT 1
+           FROM bm25_memtable_chain('memtable_reclaim_idx'))
+       AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
  multi_cycle_chain_multi_page 
 ------------------------------
@@ -192,9 +204,9 @@ FROM multi_cycle_bounds;
 
 SELECT
     (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_start FROM multi_cycle_bounds))
-    < (SELECT num_cycles * max_live_pages
-              FROM multi_cycle_bounds)
+     - (SELECT sz_after_vacuum FROM multi_cycle_after_vacuum))
+    < ((SELECT deferred_pages FROM multi_cycle_after_vacuum)
+       + (SELECT max_live_pages FROM multi_cycle_bounds))
          * current_setting('block_size')::bigint
     AS multi_cycle_main_fork_bounded;
  multi_cycle_main_fork_bounded 

--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -68,9 +68,6 @@ SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
 VACUUM ANALYZE memtable_reclaim_t;
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 VACUUM ANALYZE memtable_reclaim_t;
-CREATE TEMP TABLE reclaim_after_vacuum AS
-SELECT count(*)::int AS deferred_pages
-FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
     SELECT 1 FROM memtable_reclaim_t
     ORDER BY body <@> to_bm25query('reclaim', 'memtable_reclaim_idx')
@@ -86,6 +83,9 @@ SET pg_textsearch.memtable_pages_threshold = 0;
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'reclaim2 ' || i || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) i;
+CREATE TEMP TABLE reclaim_after_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT count(*)::int > 0 AS chain_rebuilt
 FROM bm25_memtable_chain('memtable_reclaim_idx');
  chain_rebuilt 
@@ -93,26 +93,34 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
  t
 (1 row)
 
-SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_after_spill FROM reclaim_sizes))
-    < ((SELECT deferred_pages FROM reclaim_after_vacuum) + 1)
-         * current_setting('block_size')::bigint
-    AS main_fork_growth_less_than_dead_bytes;
- main_fork_growth_less_than_dead_bytes 
----------------------------------------
- t
-(1 row)
-
+COPY (
+    SELECT format(
+               'single_cycle_growth_valid=%s',
+               (
+                   (pg_relation_size('memtable_reclaim_idx'::regclass,
+                                     'main')
+                    - (SELECT sz_after_spill FROM reclaim_sizes))
+                   < ((SELECT deferred_pages
+                       FROM reclaim_after_rebuild) + 1)
+                        * current_setting('block_size')::bigint
+               )
+           )
+) TO STDOUT;
+single_cycle_growth_valid=t
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
--- After the final VACUUM, rebuilding the chain should reuse reclaimed
--- pages from the prior cycles; any extra growth must correspond to
--- dead pages still explicitly tracked as deferred.
+-- Rebuilding the chain after repeated spill→VACUUM cycles should keep
+-- cumulative growth bounded by the live memtable work per cycle, with
+-- any extra growth explained only by dead pages still tracked after
+-- the final rebuild.
 CREATE TEMP TABLE multi_cycle_bounds (
+    sz_start bigint,
+    num_cycles int,
     max_live_pages int
 );
-INSERT INTO multi_cycle_bounds (max_live_pages)
-SELECT 0;
+INSERT INTO multi_cycle_bounds (sz_start, num_cycles, max_live_pages)
+SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
+       5,
+       0;
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc1 doc ' || g || ' ' || repeat('pad ', 6)
@@ -183,36 +191,34 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 (1 row)
 
 VACUUM ANALYZE memtable_reclaim_t;
-CREATE TEMP TABLE multi_cycle_after_vacuum AS
-SELECT count(*)::int AS deferred_pages,
-       pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
-           AS sz_after_vacuum
-FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
-SELECT max_live_pages > 1
-       AND EXISTS (
-           SELECT 1
-           FROM bm25_memtable_chain('memtable_reclaim_idx'))
-       AS multi_cycle_chain_multi_page
+CREATE TEMP TABLE multi_cycle_after_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
+SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
  multi_cycle_chain_multi_page 
 ------------------------------
  t
 (1 row)
 
-SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_after_vacuum FROM multi_cycle_after_vacuum))
-    < ((SELECT deferred_pages FROM multi_cycle_after_vacuum)
-       + (SELECT max_live_pages FROM multi_cycle_bounds))
-         * current_setting('block_size')::bigint
-    AS multi_cycle_main_fork_bounded;
- multi_cycle_main_fork_bounded 
--------------------------------
- t
-(1 row)
-
+COPY (
+    SELECT format(
+               'multi_cycle_growth_valid=%s',
+               (
+                   (pg_relation_size('memtable_reclaim_idx'::regclass,
+                                     'main')
+                    - (SELECT sz_start FROM multi_cycle_bounds))
+                   < ((SELECT num_cycles * max_live_pages
+                       FROM multi_cycle_bounds)
+                      + (SELECT deferred_pages
+                         FROM multi_cycle_after_rebuild))
+                        * current_setting('block_size')::bigint
+               )
+           )
+) TO STDOUT;
+multi_cycle_growth_valid=t
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -64,9 +64,34 @@ FROM reclaim_dead r,
 CREATE TEMP TABLE reclaim_sizes AS
 SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
        AS sz_after_spill;
+CREATE TEMP TABLE reclaim_blocker_state (
+    blocked_by_other_backend bool
+);
+INSERT INTO reclaim_blocker_state (blocked_by_other_backend)
+SELECT false;
 -- Horizon: spill xact is committed (autocommit per statement).
+UPDATE reclaim_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
+UPDATE reclaim_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
     SELECT 1 FROM memtable_reclaim_t
@@ -85,12 +110,8 @@ SELECT 'reclaim2 ' || i || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) i;
 CREATE TEMP TABLE reclaim_after_rebuild AS
 SELECT count(*)::int AS deferred_pages,
-       EXISTS (
-           SELECT 1
-           FROM pg_stat_activity
-           WHERE pid <> pg_backend_pid()
-             AND backend_xmin IS NOT NULL
-       ) AS blocked_by_other_backend
+       (SELECT blocked_by_other_backend
+        FROM reclaim_blocker_state) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT count(*)::int > 0 AS chain_rebuilt
 FROM bm25_memtable_chain('memtable_reclaim_idx');
@@ -119,7 +140,6 @@ single_cycle_growth_valid
 t
 (1 row)
 \pset format aligned
-\unset QUIET
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
 -- Rebuilding the chain after repeated spill→VACUUM cycles should keep
 -- cumulative growth bounded by the live memtable work per cycle, with
@@ -130,111 +150,143 @@ CREATE TEMP TABLE multi_cycle_bounds (
     max_live_pages int,
     num_cycles int
 );
-CREATE TABLE
 INSERT INTO multi_cycle_bounds (sz_start, max_live_pages, num_cycles)
 SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
        0,
        5;
-INSERT 0 1
+CREATE TEMP TABLE multi_cycle_blocker_state (
+    blocked_by_other_backend bool
+);
+INSERT INTO multi_cycle_blocker_state (blocked_by_other_backend)
+SELECT false;
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc1 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
-INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
-UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
  mc_spill_1 
 ------------
  t
 (1 row)
 
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
-VACUUM
 -- Cycle 2
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc2 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
-INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
-UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
  mc_spill_2 
 ------------
  t
 (1 row)
 
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
-VACUUM
 -- Cycle 3
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc3 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
-INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
-UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
  mc_spill_3 
 ------------
  t
 (1 row)
 
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
-VACUUM
 -- Cycle 4
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc4 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
-INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
-UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
  mc_spill_4 
 ------------
  t
 (1 row)
 
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
-VACUUM
 -- Cycle 5
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc5 doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
-INSERT 0 200
 UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
-UPDATE 1
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
  mc_spill_5 
 ------------
  t
 (1 row)
 
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
-VACUUM
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
-INSERT 0 200
 CREATE TEMP TABLE multi_cycle_after_rebuild AS
 SELECT count(*)::int AS deferred_pages,
-       EXISTS (
-           SELECT 1
-           FROM pg_stat_activity
-           WHERE pid <> pg_backend_pid()
-             AND backend_xmin IS NOT NULL
-       ) AS blocked_by_other_backend
+       (SELECT blocked_by_other_backend
+        FROM multi_cycle_blocker_state) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
-SELECT 1
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
  multi_cycle_chain_multi_page 
@@ -271,8 +323,5 @@ multi_cycle_growth_valid
 t
 (1 row)
 \pset format aligned
-\unset QUIET
 DROP TABLE memtable_reclaim_t;
-DROP TABLE
 DROP EXTENSION pg_textsearch CASCADE;
-DROP EXTENSION

--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -84,7 +84,13 @@ INSERT INTO memtable_reclaim_t (body)
 SELECT 'reclaim2 ' || i || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) i;
 CREATE TEMP TABLE reclaim_after_rebuild AS
-SELECT count(*)::int AS deferred_pages
+SELECT count(*)::int AS deferred_pages,
+       EXISTS (
+           SELECT 1
+           FROM pg_stat_activity
+           WHERE pid <> pg_backend_pid()
+             AND backend_xmin IS NOT NULL
+       ) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT count(*)::int > 0 AS chain_rebuilt
 FROM bm25_memtable_chain('memtable_reclaim_idx');
@@ -96,16 +102,24 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 \set QUIET 1
 \pset format unaligned
 SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_after_spill FROM reclaim_sizes))
-    < ((SELECT deferred_pages FROM reclaim_after_rebuild) + 1)
-         * current_setting('block_size')::bigint
+    CASE
+        WHEN (SELECT blocked_by_other_backend FROM reclaim_after_rebuild)
+            THEN (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+                  - (SELECT sz_after_spill FROM reclaim_sizes))
+                 <= (SELECT deferred_pages
+                     FROM reclaim_after_rebuild)
+                    * current_setting('block_size')::bigint
+        ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+              - (SELECT sz_after_spill FROM reclaim_sizes))
+             = 0
+             AND (SELECT deferred_pages FROM reclaim_after_rebuild) = 0
+    END
     AS single_cycle_growth_valid;
 single_cycle_growth_valid
 t
 (1 row)
 \pset format aligned
-\set QUIET 0
+\unset QUIET
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
 -- Rebuilding the chain after repeated spill→VACUUM cycles should keep
 -- cumulative growth bounded by the live memtable work per cycle, with
@@ -212,7 +226,13 @@ SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
 INSERT 0 200
 CREATE TEMP TABLE multi_cycle_after_rebuild AS
-SELECT count(*)::int AS deferred_pages
+SELECT count(*)::int AS deferred_pages,
+       EXISTS (
+           SELECT 1
+           FROM pg_stat_activity
+           WHERE pid <> pg_backend_pid()
+             AND backend_xmin IS NOT NULL
+       ) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT 1
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
@@ -222,24 +242,36 @@ FROM multi_cycle_bounds;
  t
 (1 row)
 
--- Budget one live-chain's worth of segment/main-fork growth per cycle
--- (`num_cycles * max_live_pages`) plus any pages still tracked as DEAD
--- after the final rebuild.
+-- Unblocked runs must fit within the cumulative live-work budget:
+-- one live chain's worth of segment/main-fork growth per cycle
+-- (`num_cycles * max_live_pages`).  Only an external backend_xmin
+-- blocker may add the pages still tracked as DEAD after the rebuild.
 \set QUIET 1
 \pset format unaligned
 SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_start FROM multi_cycle_bounds))
-    < ((SELECT num_cycles * max_live_pages
-        FROM multi_cycle_bounds)
-       + (SELECT deferred_pages FROM multi_cycle_after_rebuild))
-         * current_setting('block_size')::bigint
+    CASE
+        WHEN (SELECT blocked_by_other_backend
+              FROM multi_cycle_after_rebuild)
+            THEN (pg_relation_size('memtable_reclaim_idx'::regclass,
+                                   'main')
+                  - (SELECT sz_start FROM multi_cycle_bounds))
+                 <= ((SELECT num_cycles * max_live_pages
+                      FROM multi_cycle_bounds)
+                     + (SELECT deferred_pages
+                        FROM multi_cycle_after_rebuild))
+                    * current_setting('block_size')::bigint
+        ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+              - (SELECT sz_start FROM multi_cycle_bounds))
+             <= (SELECT num_cycles * max_live_pages
+                 FROM multi_cycle_bounds)
+                * current_setting('block_size')::bigint
+    END
     AS multi_cycle_growth_valid;
 multi_cycle_growth_valid
 t
 (1 row)
 \pset format aligned
-\set QUIET 0
+\unset QUIET
 DROP TABLE memtable_reclaim_t;
 DROP TABLE
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -6,6 +6,23 @@
 
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 
+-- Detect whether another same-database client backend is holding an xmin
+-- (which pins the reclaim horizon back).  Sampled around each VACUUM so the
+-- growth bounds below can tolerate deferred reclaim when a concurrent
+-- snapshot -- e.g. autovacuum or a parallel regression session -- keeps
+-- GetOldestNonRemovableTransactionId from advancing.
+CREATE FUNCTION other_backend_holds_xmin() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
+$$;
+
 CREATE TABLE memtable_reclaim_t (id serial PRIMARY KEY, body text);
 CREATE INDEX memtable_reclaim_idx ON memtable_reclaim_t
     USING bm25(body) WITH (text_config = 'english');
@@ -53,27 +70,13 @@ SELECT false;
 -- Horizon: spill xact is committed (autocommit per statement).
 UPDATE reclaim_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 UPDATE reclaim_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
@@ -84,6 +87,17 @@ SELECT count(*) >= 1 AS search_after_vacuum FROM (
 
 -- Rebuild chain without auto-spill so pages come from FSM vs extend.
 SET pg_textsearch.memtable_pages_threshold = 0;
+
+-- Snapshot the DEAD-page count *before* the reuse insert.  Freeing a page
+-- to the FSM does not clear its DEAD stamp -- only reuse via
+-- tp_memtable_alloc_page does -- so the post-rebuild count co-varies with a
+-- reuse regression (pages that should have been reused but were not stay
+-- DEAD and inflate the count by exactly the extra growth).  Bounding the
+-- blocked branch against this pre-rebuild snapshot keeps the check able to
+-- catch a reuse regression even when a concurrent backend forces that branch.
+CREATE TEMP TABLE reclaim_before_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'reclaim2 ' || i || ' ' || repeat('pad ', 6)
@@ -98,7 +112,6 @@ FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT count(*)::int > 0 AS chain_rebuilt
 FROM bm25_memtable_chain('memtable_reclaim_idx');
 
-\set QUIET 1
 \pset format unaligned
 SELECT
     CASE
@@ -106,7 +119,7 @@ SELECT
             THEN (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
                   - (SELECT sz_after_spill FROM reclaim_sizes))
                  <= (SELECT deferred_pages
-                     FROM reclaim_after_rebuild)
+                     FROM reclaim_before_rebuild)
                     * current_setting('block_size')::bigint
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_after_spill FROM reclaim_sizes))
@@ -149,14 +162,7 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 2
@@ -169,14 +175,7 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 3
@@ -189,14 +188,7 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 4
@@ -209,14 +201,7 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 5
@@ -229,15 +214,16 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 UPDATE multi_cycle_blocker_state
 SET blocked_by_other_backend = blocked_by_other_backend
-    OR EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+    OR other_backend_holds_xmin();
 VACUUM ANALYZE memtable_reclaim_t;
+
+-- Snapshot the DEAD-page count before the final reuse insert (see the
+-- single-cycle note above): the pre-rebuild count does not co-vary with
+-- whether the subsequent reuse succeeds, so it preserves the blocked
+-- branch's ability to catch a reuse regression.
+CREATE TEMP TABLE multi_cycle_before_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
@@ -256,7 +242,6 @@ FROM multi_cycle_bounds;
 -- one live chain's worth of segment/main-fork growth per cycle
 -- (`num_cycles * max_live_pages`).  Only an external backend_xmin
 -- blocker may add the pages still tracked as DEAD after the rebuild.
-\set QUIET 1
 \pset format unaligned
 SELECT
     CASE
@@ -268,7 +253,7 @@ SELECT
                  <= ((SELECT num_cycles * max_live_pages
                       FROM multi_cycle_bounds)
                      + (SELECT deferred_pages
-                        FROM multi_cycle_after_rebuild))
+                        FROM multi_cycle_before_rebuild))
                     * current_setting('block_size')::bigint
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_start FROM multi_cycle_bounds))
@@ -279,5 +264,6 @@ SELECT
     AS multi_cycle_growth_valid;
 \pset format aligned
 
+DROP FUNCTION other_backend_holds_xmin();
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -63,7 +63,13 @@ SELECT 'reclaim2 ' || i || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) i;
 
 CREATE TEMP TABLE reclaim_after_rebuild AS
-SELECT count(*)::int AS deferred_pages
+SELECT count(*)::int AS deferred_pages,
+       EXISTS (
+           SELECT 1
+           FROM pg_stat_activity
+           WHERE pid <> pg_backend_pid()
+             AND backend_xmin IS NOT NULL
+       ) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 
 SELECT count(*)::int > 0 AS chain_rebuilt
@@ -72,13 +78,21 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 \set QUIET 1
 \pset format unaligned
 SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_after_spill FROM reclaim_sizes))
-    < ((SELECT deferred_pages FROM reclaim_after_rebuild) + 1)
-         * current_setting('block_size')::bigint
+    CASE
+        WHEN (SELECT blocked_by_other_backend FROM reclaim_after_rebuild)
+            THEN (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+                  - (SELECT sz_after_spill FROM reclaim_sizes))
+                 <= (SELECT deferred_pages
+                     FROM reclaim_after_rebuild)
+                    * current_setting('block_size')::bigint
+        ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+              - (SELECT sz_after_spill FROM reclaim_sizes))
+             = 0
+             AND (SELECT deferred_pages FROM reclaim_after_rebuild) = 0
+    END
     AS single_cycle_growth_valid;
 \pset format aligned
-\set QUIET 0
+\unset QUIET
 
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
 -- Rebuilding the chain after repeated spill→VACUUM cycles should keep
@@ -151,27 +165,45 @@ SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
 
 CREATE TEMP TABLE multi_cycle_after_rebuild AS
-SELECT count(*)::int AS deferred_pages
+SELECT count(*)::int AS deferred_pages,
+       EXISTS (
+           SELECT 1
+           FROM pg_stat_activity
+           WHERE pid <> pg_backend_pid()
+             AND backend_xmin IS NOT NULL
+       ) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
 
--- Budget one live-chain's worth of segment/main-fork growth per cycle
--- (`num_cycles * max_live_pages`) plus any pages still tracked as DEAD
--- after the final rebuild.
+-- Unblocked runs must fit within the cumulative live-work budget:
+-- one live chain's worth of segment/main-fork growth per cycle
+-- (`num_cycles * max_live_pages`).  Only an external backend_xmin
+-- blocker may add the pages still tracked as DEAD after the rebuild.
 \set QUIET 1
 \pset format unaligned
 SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_start FROM multi_cycle_bounds))
-    < ((SELECT num_cycles * max_live_pages
-        FROM multi_cycle_bounds)
-       + (SELECT deferred_pages FROM multi_cycle_after_rebuild))
-         * current_setting('block_size')::bigint
+    CASE
+        WHEN (SELECT blocked_by_other_backend
+              FROM multi_cycle_after_rebuild)
+            THEN (pg_relation_size('memtable_reclaim_idx'::regclass,
+                                   'main')
+                  - (SELECT sz_start FROM multi_cycle_bounds))
+                 <= ((SELECT num_cycles * max_live_pages
+                      FROM multi_cycle_bounds)
+                     + (SELECT deferred_pages
+                        FROM multi_cycle_after_rebuild))
+                    * current_setting('block_size')::bigint
+        ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+              - (SELECT sz_start FROM multi_cycle_bounds))
+             <= (SELECT num_cycles * max_live_pages
+                 FROM multi_cycle_bounds)
+                * current_setting('block_size')::bigint
+    END
     AS multi_cycle_growth_valid;
 \pset format aligned
-\set QUIET 0
+\unset QUIET
 
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -49,10 +49,6 @@ VACUUM ANALYZE memtable_reclaim_t;
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 VACUUM ANALYZE memtable_reclaim_t;
 
-CREATE TEMP TABLE reclaim_after_vacuum AS
-SELECT count(*)::int AS deferred_pages
-FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
-
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
     SELECT 1 FROM memtable_reclaim_t
     ORDER BY body <@> to_bm25query('reclaim', 'memtable_reclaim_idx')
@@ -66,26 +62,42 @@ INSERT INTO memtable_reclaim_t (body)
 SELECT 'reclaim2 ' || i || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) i;
 
+CREATE TEMP TABLE reclaim_after_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
+
 SELECT count(*)::int > 0 AS chain_rebuilt
 FROM bm25_memtable_chain('memtable_reclaim_idx');
 
-SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_after_spill FROM reclaim_sizes))
-    < ((SELECT deferred_pages FROM reclaim_after_vacuum) + 1)
-         * current_setting('block_size')::bigint
-    AS main_fork_growth_less_than_dead_bytes;
+COPY (
+    SELECT format(
+               'single_cycle_growth_valid=%s',
+               (
+                   (pg_relation_size('memtable_reclaim_idx'::regclass,
+                                     'main')
+                    - (SELECT sz_after_spill FROM reclaim_sizes))
+                   < ((SELECT deferred_pages
+                       FROM reclaim_after_rebuild) + 1)
+                        * current_setting('block_size')::bigint
+               )
+           )
+) TO STDOUT;
 
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
--- After the final VACUUM, rebuilding the chain should reuse reclaimed
--- pages from the prior cycles; any extra growth must correspond to
--- dead pages still explicitly tracked as deferred.
+-- Rebuilding the chain after repeated spill→VACUUM cycles should keep
+-- cumulative growth bounded by the live memtable work per cycle, with
+-- any extra growth explained only by dead pages still tracked after
+-- the final rebuild.
 CREATE TEMP TABLE multi_cycle_bounds (
+    sz_start bigint,
+    num_cycles int,
     max_live_pages int
 );
 
-INSERT INTO multi_cycle_bounds (max_live_pages)
-SELECT 0;
+INSERT INTO multi_cycle_bounds (sz_start, num_cycles, max_live_pages)
+SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
+       5,
+       0;
 
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
@@ -137,30 +149,32 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 VACUUM ANALYZE memtable_reclaim_t;
 
-CREATE TEMP TABLE multi_cycle_after_vacuum AS
-SELECT count(*)::int AS deferred_pages,
-       pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
-           AS sz_after_vacuum
-FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
-
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
 FROM generate_series(1, 200) g;
 
-SELECT max_live_pages > 1
-       AND EXISTS (
-           SELECT 1
-           FROM bm25_memtable_chain('memtable_reclaim_idx'))
-       AS multi_cycle_chain_multi_page
+CREATE TEMP TABLE multi_cycle_after_rebuild AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
+
+SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
 
-SELECT
-    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_after_vacuum FROM multi_cycle_after_vacuum))
-    < ((SELECT deferred_pages FROM multi_cycle_after_vacuum)
-       + (SELECT max_live_pages FROM multi_cycle_bounds))
-         * current_setting('block_size')::bigint
-    AS multi_cycle_main_fork_bounded;
+COPY (
+    SELECT format(
+               'multi_cycle_growth_valid=%s',
+               (
+                   (pg_relation_size('memtable_reclaim_idx'::regclass,
+                                     'main')
+                    - (SELECT sz_start FROM multi_cycle_bounds))
+                   < ((SELECT num_cycles * max_live_pages
+                       FROM multi_cycle_bounds)
+                      + (SELECT deferred_pages
+                         FROM multi_cycle_after_rebuild))
+                        * current_setting('block_size')::bigint
+               )
+           )
+) TO STDOUT;
 
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -43,10 +43,37 @@ CREATE TEMP TABLE reclaim_sizes AS
 SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
        AS sz_after_spill;
 
+CREATE TEMP TABLE reclaim_blocker_state (
+    blocked_by_other_backend bool
+);
+
+INSERT INTO reclaim_blocker_state (blocked_by_other_backend)
+SELECT false;
+
 -- Horizon: spill xact is committed (autocommit per statement).
+UPDATE reclaim_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
+UPDATE reclaim_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
@@ -64,12 +91,8 @@ FROM generate_series(1, 200) i;
 
 CREATE TEMP TABLE reclaim_after_rebuild AS
 SELECT count(*)::int AS deferred_pages,
-       EXISTS (
-           SELECT 1
-           FROM pg_stat_activity
-           WHERE pid <> pg_backend_pid()
-             AND backend_xmin IS NOT NULL
-       ) AS blocked_by_other_backend
+       (SELECT blocked_by_other_backend
+        FROM reclaim_blocker_state) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 
 SELECT count(*)::int > 0 AS chain_rebuilt
@@ -92,7 +115,6 @@ SELECT
     END
     AS single_cycle_growth_valid;
 \pset format aligned
-\unset QUIET
 
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
 -- Rebuilding the chain after repeated spill→VACUUM cycles should keep
@@ -110,6 +132,13 @@ SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
        0,
        5;
 
+CREATE TEMP TABLE multi_cycle_blocker_state (
+    blocked_by_other_backend bool
+);
+
+INSERT INTO multi_cycle_blocker_state (blocked_by_other_backend)
+SELECT false;
+
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
 SELECT 'mc1 doc ' || g || ' ' || repeat('pad ', 6)
@@ -118,6 +147,16 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 2
@@ -128,6 +167,16 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 3
@@ -138,6 +187,16 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 4
@@ -148,6 +207,16 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 5
@@ -158,6 +227,16 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     max_live_pages,
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
+UPDATE multi_cycle_blocker_state
+SET blocked_by_other_backend = blocked_by_other_backend
+    OR EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname = current_database()
+          AND backend_type = 'client backend'
+          AND backend_xmin IS NOT NULL
+    );
 VACUUM ANALYZE memtable_reclaim_t;
 
 INSERT INTO memtable_reclaim_t (body)
@@ -166,12 +245,8 @@ FROM generate_series(1, 200) g;
 
 CREATE TEMP TABLE multi_cycle_after_rebuild AS
 SELECT count(*)::int AS deferred_pages,
-       EXISTS (
-           SELECT 1
-           FROM pg_stat_activity
-           WHERE pid <> pg_backend_pid()
-             AND backend_xmin IS NOT NULL
-       ) AS blocked_by_other_backend
+       (SELECT blocked_by_other_backend
+        FROM multi_cycle_blocker_state) AS blocked_by_other_backend
 FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
@@ -203,7 +278,6 @@ SELECT
     END
     AS multi_cycle_growth_valid;
 \pset format aligned
-\unset QUIET
 
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -49,6 +49,10 @@ VACUUM ANALYZE memtable_reclaim_t;
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 VACUUM ANALYZE memtable_reclaim_t;
 
+CREATE TEMP TABLE reclaim_after_vacuum AS
+SELECT count(*)::int AS deferred_pages
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
+
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
     SELECT 1 FROM memtable_reclaim_t
     ORDER BY body <@> to_bm25query('reclaim', 'memtable_reclaim_idx')
@@ -68,23 +72,20 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 SELECT
     (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
      - (SELECT sz_after_spill FROM reclaim_sizes))
-    < (SELECT dead_count FROM reclaim_dead)
+    < ((SELECT deferred_pages FROM reclaim_after_vacuum) + 1)
          * current_setting('block_size')::bigint
     AS main_fork_growth_less_than_dead_bytes;
 
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
--- Without FSM reuse the main fork would grow by roughly N×K memtable pages;
--- with reclaim each cycle, growth stays below N×K×block_size.
+-- After the final VACUUM, rebuilding the chain should reuse reclaimed
+-- pages from the prior cycles; any extra growth must correspond to
+-- dead pages still explicitly tracked as deferred.
 CREATE TEMP TABLE multi_cycle_bounds (
-    sz_start bigint,
-    max_live_pages int,
-    num_cycles int
+    max_live_pages int
 );
 
-INSERT INTO multi_cycle_bounds (sz_start, max_live_pages, num_cycles)
-SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
-       0,
-       5;
+INSERT INTO multi_cycle_bounds (max_live_pages)
+SELECT 0;
 
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
@@ -136,14 +137,28 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 VACUUM ANALYZE memtable_reclaim_t;
 
-SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
+CREATE TEMP TABLE multi_cycle_after_vacuum AS
+SELECT count(*)::int AS deferred_pages,
+       pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
+           AS sz_after_vacuum
+FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
+
+INSERT INTO memtable_reclaim_t (body)
+SELECT 'mc_reuse doc ' || g || ' ' || repeat('pad ', 6)
+FROM generate_series(1, 200) g;
+
+SELECT max_live_pages > 1
+       AND EXISTS (
+           SELECT 1
+           FROM bm25_memtable_chain('memtable_reclaim_idx'))
+       AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
 
 SELECT
     (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
-     - (SELECT sz_start FROM multi_cycle_bounds))
-    < (SELECT num_cycles * max_live_pages
-              FROM multi_cycle_bounds)
+     - (SELECT sz_after_vacuum FROM multi_cycle_after_vacuum))
+    < ((SELECT deferred_pages FROM multi_cycle_after_vacuum)
+       + (SELECT max_live_pages FROM multi_cycle_bounds))
          * current_setting('block_size')::bigint
     AS multi_cycle_main_fork_bounded;
 

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -69,19 +69,16 @@ FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT count(*)::int > 0 AS chain_rebuilt
 FROM bm25_memtable_chain('memtable_reclaim_idx');
 
-COPY (
-    SELECT format(
-               'single_cycle_growth_valid=%s',
-               (
-                   (pg_relation_size('memtable_reclaim_idx'::regclass,
-                                     'main')
-                    - (SELECT sz_after_spill FROM reclaim_sizes))
-                   < ((SELECT deferred_pages
-                       FROM reclaim_after_rebuild) + 1)
-                        * current_setting('block_size')::bigint
-               )
-           )
-) TO STDOUT;
+\set QUIET 1
+\pset format unaligned
+SELECT
+    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+     - (SELECT sz_after_spill FROM reclaim_sizes))
+    < ((SELECT deferred_pages FROM reclaim_after_rebuild) + 1)
+         * current_setting('block_size')::bigint
+    AS single_cycle_growth_valid;
+\pset format aligned
+\set QUIET 0
 
 -- Multi-cycle: five spill→VACUUM cycles (VACUUM cannot run inside DO).
 -- Rebuilding the chain after repeated spill→VACUUM cycles should keep
@@ -90,14 +87,14 @@ COPY (
 -- the final rebuild.
 CREATE TEMP TABLE multi_cycle_bounds (
     sz_start bigint,
-    num_cycles int,
-    max_live_pages int
+    max_live_pages int,
+    num_cycles int
 );
 
-INSERT INTO multi_cycle_bounds (sz_start, num_cycles, max_live_pages)
+INSERT INTO multi_cycle_bounds (sz_start, max_live_pages, num_cycles)
 SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
-       5,
-       0;
+       0,
+       5;
 
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
@@ -160,21 +157,21 @@ FROM bm25_memtable_dead_pages('memtable_reclaim_idx');
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
 
-COPY (
-    SELECT format(
-               'multi_cycle_growth_valid=%s',
-               (
-                   (pg_relation_size('memtable_reclaim_idx'::regclass,
-                                     'main')
-                    - (SELECT sz_start FROM multi_cycle_bounds))
-                   < ((SELECT num_cycles * max_live_pages
-                       FROM multi_cycle_bounds)
-                      + (SELECT deferred_pages
-                         FROM multi_cycle_after_rebuild))
-                        * current_setting('block_size')::bigint
-               )
-           )
-) TO STDOUT;
+-- Budget one live-chain's worth of segment/main-fork growth per cycle
+-- (`num_cycles * max_live_pages`) plus any pages still tracked as DEAD
+-- after the final rebuild.
+\set QUIET 1
+\pset format unaligned
+SELECT
+    (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
+     - (SELECT sz_start FROM multi_cycle_bounds))
+    < ((SELECT num_cycles * max_live_pages
+        FROM multi_cycle_bounds)
+       + (SELECT deferred_pages FROM multi_cycle_after_rebuild))
+         * current_setting('block_size')::bigint
+    AS multi_cycle_growth_valid;
+\pset format aligned
+\set QUIET 0
 
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Summary
- `memtable_reclaim` asserts dead memtable pages become reclaimable before its size checks. That assumption fails whenever another backend holds back `GetOldestNonRemovableTransactionId` (a long-lived reclaim horizon), so the test fails on both reclaim bounds.
- Sample whether a same-database client backend holds an xmin *across the reclaim/VACUUM windows*. When unblocked, keep the strict bound (reuse must occur, no unexplained deferred pages). When a real external blocker exists, permit only growth explicitly accounted by post-rebuild DEAD pages. Cumulative multi-cycle coverage is retained.

## Context
Reproducible on stock PostgreSQL by holding a `REPEATABLE READ` snapshot. No product code change — deferred reclaim is correct behavior; the test needed to account for it without masking a genuine reuse regression.

## Verification
- `memtable_reclaim` passes on PostgreSQL 17.9 and 18.4
- Passes with a persistent same-DB held snapshot and with a transient holder that leaves after VACUUM
- Unrelated-database / vacuum-worker backends do not relax the strict check
- The strict no-blocker branch still fails when reuse is broken (verified via pinned-horizon mutation)
