### PR TITLE
test: make multiple-index block portable in unsupported

### DIFF
--- a/test/expected/unsupported.out
+++ b/test/expected/unsupported.out
@@ -71,25 +71,58 @@ NOTICE:  BM25 index build started for relation docs_bm25_simple_idx
 NOTICE:  Using text search configuration: simple
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 3 documents, avg_length=3.33
--- Implicit resolution picks first index found
--- Note: Score projection requires explicit index, so just use ORDER BY
-EXPLAIN (COSTS OFF)
-SELECT id
-FROM docs
-ORDER BY content <@> 'database'
-LIMIT 3;
+-- With two equal-cost BM25 indexes on the same column, implicit resolution
+-- warns that multiple indexes match.  The two index paths tie on cost, so
+-- WHICH one the planner scans -- and therefore whether the follow-up
+-- "planner chose index ... instead of ..." warning fires -- depends on index
+-- enumeration order, which is not portable across environments.  Assert only
+-- the portable facts: the resolution warning fires, and the implicit query
+-- still plans as a BM25 index scan rather than falling back to a seq scan.
+-- Portable resolution warning, via standalone scoring (no index-scan path,
+-- so no tie-dependent index choice is asserted).
+SELECT count(*) AS scored_rows
+FROM (SELECT content <@> 'database' AS score FROM docs) q;
 WARNING:  multiple BM25 indexes exist on the same column
 HINT:  Use explicit to_bm25query('query', 'index_name') to specify which index to use.
-WARNING:  planner chose index "docs_bm25_simple_idx" instead of "docs_bm25_idx"
-HINT:  If this is not desired, use a planner hint to force a specific index, or use explicit to_bm25query('query', 'index_name').
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Limit
-   ->  Index Scan using docs_bm25_simple_idx on docs
-         Order By: (content <@> 'docs_bm25_idx:database'::bm25query)
-(3 rows)
+ scored_rows 
+-------------
+           3
+(1 row)
 
--- Explicit index selection gives user control
+-- Portable index-scan assertion: matches the BM25 index family (either tied
+-- index) but not a pkey-scan fallback, so it still fails if the BM25 ordered
+-- scan regresses to a seq/sort plan.  Warnings are silenced because the
+-- tie-dependent "planner chose index" warning is not portable.
+CREATE FUNCTION bm25_query_uses_index_scan(sql text) RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+    ln   text;
+    seen boolean := false;
+BEGIN
+    FOR ln IN EXECUTE 'EXPLAIN (COSTS OFF) ' || sql
+    LOOP
+        IF ln LIKE '%Index Scan using docs_bm25%' THEN
+            seen := true;
+        END IF;
+    END LOOP;
+    RETURN seen;
+END;
+$$;
+SET client_min_messages = error;
+SELECT bm25_query_uses_index_scan(
+    'SELECT id FROM docs ORDER BY content <@> ''database'' LIMIT 3'
+) AS implicit_uses_index_scan;
+ implicit_uses_index_scan 
+--------------------------
+ t
+(1 row)
+
+RESET client_min_messages;
+DROP FUNCTION bm25_query_uses_index_scan(text);
+-- Explicit index selection deterministically pins the scanned index:
+-- fix_bm25_indexpaths rewrites every BM25 path's indexinfo to the named
+-- index, so which tied index the planner enumerated first does not matter.
+-- This holds regardless of environment.
 EXPLAIN (COSTS OFF)
 SELECT id, content <@> to_bm25query('database', 'docs_bm25_simple_idx') as score
 FROM docs

--- a/test/sql/unsupported.sql
+++ b/test/sql/unsupported.sql
@@ -64,15 +64,51 @@ LIMIT 5;
 CREATE INDEX docs_bm25_simple_idx ON docs USING bm25(content)
     WITH (text_config='simple');
 
--- Implicit resolution picks first index found
--- Note: Score projection requires explicit index, so just use ORDER BY
-EXPLAIN (COSTS OFF)
-SELECT id
-FROM docs
-ORDER BY content <@> 'database'
-LIMIT 3;
+-- With two equal-cost BM25 indexes on the same column, implicit resolution
+-- warns that multiple indexes match.  The two index paths tie on cost, so
+-- WHICH one the planner scans -- and therefore whether the follow-up
+-- "planner chose index ... instead of ..." warning fires -- depends on index
+-- enumeration order, which is not portable across environments.  Assert only
+-- the portable facts: the resolution warning fires, and the implicit query
+-- still plans as a BM25 index scan rather than falling back to a seq scan.
 
--- Explicit index selection gives user control
+-- Portable resolution warning, via standalone scoring (no index-scan path,
+-- so no tie-dependent index choice is asserted).
+SELECT count(*) AS scored_rows
+FROM (SELECT content <@> 'database' AS score FROM docs) q;
+
+-- Portable index-scan assertion: matches the BM25 index family (either tied
+-- index) but not a pkey-scan fallback, so it still fails if the BM25 ordered
+-- scan regresses to a seq/sort plan.  Warnings are silenced because the
+-- tie-dependent "planner chose index" warning is not portable.
+CREATE FUNCTION bm25_query_uses_index_scan(sql text) RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+    ln   text;
+    seen boolean := false;
+BEGIN
+    FOR ln IN EXECUTE 'EXPLAIN (COSTS OFF) ' || sql
+    LOOP
+        IF ln LIKE '%Index Scan using docs_bm25%' THEN
+            seen := true;
+        END IF;
+    END LOOP;
+    RETURN seen;
+END;
+$$;
+
+SET client_min_messages = error;
+SELECT bm25_query_uses_index_scan(
+    'SELECT id FROM docs ORDER BY content <@> ''database'' LIMIT 3'
+) AS implicit_uses_index_scan;
+RESET client_min_messages;
+
+DROP FUNCTION bm25_query_uses_index_scan(text);
+
+-- Explicit index selection deterministically pins the scanned index:
+-- fix_bm25_indexpaths rewrites every BM25 path's indexinfo to the named
+-- index, so which tied index the planner enumerated first does not matter.
+-- This holds regardless of environment.
 EXPLAIN (COSTS OFF)
 SELECT id, content <@> to_bm25query('database', 'docs_bm25_simple_idx') as score
 FROM docs


### PR DESCRIPTION
## Problem

The `unsupported` regression test's "LIMITATION 2: Multiple BM25 indexes on
same column" block asserts a tie-dependent planner outcome, so it is fragile
across environments.

When a table has two equal-cost BM25 indexes on the same column, the two index
paths tie on cost — `tp_costestimate` derives cost only from `total_docs`,
which is identical for both indexes. Which tied index the planner scans then
depends on relcache index-enumeration order, which is not portable across
environments.

The expected output hard-coded one environment's tie-break:

- `WARNING: planner chose index "docs_bm25_simple_idx" instead of "docs_bm25_idx"`
  — this warning is emitted (by `validate_indexscan_explicit_index`) only when
  the scanned BM25 index differs from the one the implicit resolver embedded.
- The specific scanned-index name in the `EXPLAIN` plan.

An environment whose enumeration breaks the tie the other way — picking the
same index the implicit resolver embedded — suppresses that warning and shows a
different plan, so the test diverges even though behavior is correct.

## Fix (test-only)

Assert only the portable facts:

1. Implicit resolution warns that multiple indexes match (deterministic —
   demonstrated via standalone scoring, which surfaces the resolution warning
   without depending on a tie-broken index-scan choice).
2. The implicit query still plans as a **BM25** index scan (name-agnostic
   across the two tied indexes, but specific enough to still fail on a
   seq/sort fallback — matches `Index Scan using docs_bm25%`, not a pkey
   fallback).
3. Explicit index naming deterministically pins the scanned index
   (`fix_bm25_indexpaths` rewrites each path's `indexinfo` to the named index,
   independent of enumeration order).

The tie-dependent "planner chose" warning and scanned-index identity are no
longer asserted. No product code changes.

## Verification

- `unsupported` passes on PostgreSQL 17 and 18.
