### PR TITLE
planner: drop non-deterministic implicit multi-index warning

### DIFF
--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -1816,9 +1816,11 @@ validate_indexscan_explicit_index(IndexScan *indexscan, BM25OidCache *oids)
 		scan_name	   = get_rel_name(indexscan->indexid);
 
 		/*
-		 * Check if the index was explicitly specified by the user via
-		 * to_bm25query(text, index_name). If so, error. If it was implicitly
-		 * resolved (e.g., from text <@> text syntax), just warn.
+		 * When the user names an index explicitly via
+		 * to_bm25query(text, index_name), that index must be used for the
+		 * scan to ensure consistent tokenization; error if the planner chose
+		 * a different one. Implicitly resolved indexes (e.g. text <@> text)
+		 * impose no such constraint, so no diagnostic is emitted.
 		 */
 		if (tpquery_is_explicit_index(tpquery))
 		{
@@ -1835,16 +1837,6 @@ validate_indexscan_explicit_index(IndexScan *indexscan, BM25OidCache *oids)
 					 errhint("Use a planner hint to force the specified "
 							 "index, or remove the explicit index name to let "
 							 "the planner choose automatically.")));
-		}
-		else
-		{
-			ereport(WARNING,
-					(errmsg("planner chose index \"%s\" instead of \"%s\"",
-							scan_name ? scan_name : "(unknown)",
-							specified_name ? specified_name : "(unknown)"),
-					 errhint("If this is not desired, use a planner hint to "
-							 "force a specific index, or use explicit "
-							 "to_bm25query('query', 'index_name').")));
 		}
 	}
 }

--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -1803,17 +1803,11 @@ validate_indexscan_explicit_index(IndexScan *indexscan, BM25OidCache *oids)
 	/* Validate they match */
 	if (specified_index_oid != indexscan->indexid)
 	{
-		char *specified_name;
-		char *scan_name;
-
 		/*
 		 * Allow partitioned indexes: if specified is parent and scan is child
 		 */
 		if (is_child_partition_index(specified_index_oid, indexscan->indexid))
 			return; /* Child partition index - allowed */
-
-		specified_name = get_rel_name(specified_index_oid);
-		scan_name	   = get_rel_name(indexscan->indexid);
 
 		/*
 		 * When the user names an index explicitly via
@@ -1824,6 +1818,9 @@ validate_indexscan_explicit_index(IndexScan *indexscan, BM25OidCache *oids)
 		 */
 		if (tpquery_is_explicit_index(tpquery))
 		{
+			char *specified_name = get_rel_name(specified_index_oid);
+			char *scan_name		 = get_rel_name(indexscan->indexid);
+
 			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 					 errmsg("query specifies index \"%s\" but planner chose "
@@ -1998,8 +1995,9 @@ tp_planner_hook(
 		/*
 		 * Validate implicit index resolution - for explicit indexes, the
 		 * set_rel_pathlist_hook should have already forced the correct index.
-		 * This validation catches cases where implicit resolution picked a
-		 * different index than the planner chose.
+		 * This validation errors when an explicitly named index differs from
+		 * the one the planner scanned; implicit resolution mismatches are
+		 * allowed and emit no diagnostic.
 		 */
 		validate_explicit_index_usage(result->planTree, &oid_cache);
 

--- a/test/expected/explicit_index.out
+++ b/test/expected/explicit_index.out
@@ -92,29 +92,10 @@ LIMIT 10;
          Filter: (category_id = 1)
 (4 rows)
 
--- Positive test: without explicit index, implicit resolution works
--- (uses first found index, with a warning about multiple indexes)
-EXPLAIN (COSTS OFF)
-SELECT content <@> 'ressources' AS score
-FROM multi_index_test
-WHERE category_id = 1
-ORDER BY score
-LIMIT 3;
-WARNING:  multiple BM25 indexes exist on the same column
-HINT:  Use explicit to_bm25query('query', 'index_name') to specify which index to use.
-WARNING:  planner chose index "content_idx_simple" instead of "content_idx_french"
-HINT:  If this is not desired, use a planner hint to force a specific index, or use explicit to_bm25query('query', 'index_name').
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Limit
-   ->  Index Scan using content_idx_simple on multi_index_test
-         Order By: (content <@> 'content_idx_french:ressources'::bm25query)
-         Filter: (category_id = 1)
-(4 rows)
-
--- All matching rows contain the same text, so the score is deterministic
--- even though the tied tuple ids are not. Re-run the exact statement with
--- warnings silenced and assert the repeated BM25 score values.
+-- Positive test: without an explicit index, implicit resolution still
+-- works. All matching rows share the same text, so the BM25 scores are
+-- deterministic even though the tied tuple ids (and which tied index is
+-- scanned) are not.
 SET client_min_messages = error;
 \pset format unaligned
 SELECT content <@> 'ressources' AS score

--- a/test/expected/expression_index.out
+++ b/test/expected/expression_index.out
@@ -229,21 +229,15 @@ DROP TABLE expr_part CASCADE;
 -- ============================================================
 -- Multiple expression indexes trigger warning
 -- ============================================================
--- Suppress build-progress NOTICEs for this index: its reported
--- document count is not deterministic here.  expr_jsonb had rows
--- deleted and vacuumed above, but if a concurrent backend holds
--- back OldestXmin (autovacuum or a parallel session), VACUUM leaves
--- the deleted tuples "recently dead" and this fresh build indexes
--- them -- table_index_build_scan passes recently-dead tuples to the
--- build callback, as any access method does.  The exact count is
--- irrelevant to what this section tests (the multiple-index
--- resolution warning), so suppress it.
+-- Suppress build NOTICEs: the reported doc count is non-deterministic
+-- here (recently-dead tuples from the earlier delete/vacuum may be
+-- indexed) and irrelevant to this multi-index test.
 SET client_min_messages = warning;
 CREATE INDEX expr_jsonb_idx2 ON expr_jsonb
     USING bm25 ((data->>'content'))
     WITH (text_config='simple');
 RESET client_min_messages;
--- Implicit resolution should warn about multiple indexes
+-- Implicit resolution warns about multiple matching indexes.
 SELECT id,
        ROUND(((data->>'content') <@>
               to_bm25query('database'))::numeric, 4)
@@ -255,15 +249,11 @@ WARNING:  multiple BM25 indexes match the expression
 HINT:  Use explicit to_bm25query('query', 'index_name') to specify which index.
 WARNING:  multiple BM25 indexes match the expression
 HINT:  Use explicit to_bm25query('query', 'index_name') to specify which index.
-WARNING:  planner chose index "expr_jsonb_idx2" instead of "expr_jsonb_idx"
-HINT:  If this is not desired, use a planner hint to force a specific index, or use explicit to_bm25query('query', 'index_name').
  id | score 
 ----+-------
 (0 rows)
 
--- Explicit naming with multiple expression indexes exercises
--- the expression branch in collect_explicit_indexes_walker,
--- find_explicit_requirement, and fix_bm25_indexpaths.
+-- Explicit naming with multiple expression indexes.
 SELECT id,
        ROUND(((data->>'content') <@>
               to_bm25query('database',

--- a/test/expected/unsupported.out
+++ b/test/expected/unsupported.out
@@ -60,8 +60,8 @@ LIMIT 5;
 
 -- =============================================================================
 -- LIMITATION 2: Multiple BM25 indexes on same column
--- The planner hook picks the first matching index. Use explicit to_bm25query()
--- for control over which index is used.
+-- Implicit resolution warns and uses one of the indexes; name one
+-- explicitly with to_bm25query() for control.
 -- =============================================================================
 \echo 'Test: Multiple BM25 indexes on same column'
 Test: Multiple BM25 indexes on same column
@@ -71,25 +71,17 @@ NOTICE:  BM25 index build started for relation docs_bm25_simple_idx
 NOTICE:  Using text search configuration: simple
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 3 documents, avg_length=3.33
--- Implicit resolution picks first index found
--- Note: Score projection requires explicit index, so just use ORDER BY
-EXPLAIN (COSTS OFF)
-SELECT id
-FROM docs
-ORDER BY content <@> 'database'
-LIMIT 3;
+-- Implicit resolution warns; the matched row is the same whichever tied
+-- index the planner picks.
+SELECT id FROM docs ORDER BY content <@> 'database' LIMIT 3;
 WARNING:  multiple BM25 indexes exist on the same column
 HINT:  Use explicit to_bm25query('query', 'index_name') to specify which index to use.
-WARNING:  planner chose index "docs_bm25_simple_idx" instead of "docs_bm25_idx"
-HINT:  If this is not desired, use a planner hint to force a specific index, or use explicit to_bm25query('query', 'index_name').
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Limit
-   ->  Index Scan using docs_bm25_simple_idx on docs
-         Order By: (content <@> 'docs_bm25_idx:database'::bm25query)
-(3 rows)
+ id 
+----
+  1
+(1 row)
 
--- Explicit index selection gives user control
+-- Explicit naming pins a specific index.
 EXPLAIN (COSTS OFF)
 SELECT id, content <@> to_bm25query('database', 'docs_bm25_simple_idx') as score
 FROM docs

--- a/test/sql/explicit_index.sql
+++ b/test/sql/explicit_index.sql
@@ -77,18 +77,10 @@ WHERE category_id = 1
 ORDER BY score
 LIMIT 10;
 
--- Positive test: without explicit index, implicit resolution works
--- (uses first found index, with a warning about multiple indexes)
-EXPLAIN (COSTS OFF)
-SELECT content <@> 'ressources' AS score
-FROM multi_index_test
-WHERE category_id = 1
-ORDER BY score
-LIMIT 3;
-
--- All matching rows contain the same text, so the score is deterministic
--- even though the tied tuple ids are not. Re-run the exact statement with
--- warnings silenced and assert the repeated BM25 score values.
+-- Positive test: without an explicit index, implicit resolution still
+-- works. All matching rows share the same text, so the BM25 scores are
+-- deterministic even though the tied tuple ids (and which tied index is
+-- scanned) are not.
 SET client_min_messages = error;
 \pset format unaligned
 SELECT content <@> 'ressources' AS score

--- a/test/sql/expression_index.sql
+++ b/test/sql/expression_index.sql
@@ -205,22 +205,16 @@ DROP TABLE expr_part CASCADE;
 -- Multiple expression indexes trigger warning
 -- ============================================================
 
--- Suppress build-progress NOTICEs for this index: its reported
--- document count is not deterministic here.  expr_jsonb had rows
--- deleted and vacuumed above, but if a concurrent backend holds
--- back OldestXmin (autovacuum or a parallel session), VACUUM leaves
--- the deleted tuples "recently dead" and this fresh build indexes
--- them -- table_index_build_scan passes recently-dead tuples to the
--- build callback, as any access method does.  The exact count is
--- irrelevant to what this section tests (the multiple-index
--- resolution warning), so suppress it.
+-- Suppress build NOTICEs: the reported doc count is non-deterministic
+-- here (recently-dead tuples from the earlier delete/vacuum may be
+-- indexed) and irrelevant to this multi-index test.
 SET client_min_messages = warning;
 CREATE INDEX expr_jsonb_idx2 ON expr_jsonb
     USING bm25 ((data->>'content'))
     WITH (text_config='simple');
 RESET client_min_messages;
 
--- Implicit resolution should warn about multiple indexes
+-- Implicit resolution warns about multiple matching indexes.
 SELECT id,
        ROUND(((data->>'content') <@>
               to_bm25query('database'))::numeric, 4)
@@ -229,9 +223,7 @@ FROM expr_jsonb
 ORDER BY (data->>'content') <@> to_bm25query('database')
 LIMIT 3;
 
--- Explicit naming with multiple expression indexes exercises
--- the expression branch in collect_explicit_indexes_walker,
--- find_explicit_requirement, and fix_bm25_indexpaths.
+-- Explicit naming with multiple expression indexes.
 SELECT id,
        ROUND(((data->>'content') <@>
               to_bm25query('database',

--- a/test/sql/unsupported.sql
+++ b/test/sql/unsupported.sql
@@ -55,8 +55,8 @@ LIMIT 5;
 
 -- =============================================================================
 -- LIMITATION 2: Multiple BM25 indexes on same column
--- The planner hook picks the first matching index. Use explicit to_bm25query()
--- for control over which index is used.
+-- Implicit resolution warns and uses one of the indexes; name one
+-- explicitly with to_bm25query() for control.
 -- =============================================================================
 
 \echo 'Test: Multiple BM25 indexes on same column'
@@ -64,15 +64,11 @@ LIMIT 5;
 CREATE INDEX docs_bm25_simple_idx ON docs USING bm25(content)
     WITH (text_config='simple');
 
--- Implicit resolution picks first index found
--- Note: Score projection requires explicit index, so just use ORDER BY
-EXPLAIN (COSTS OFF)
-SELECT id
-FROM docs
-ORDER BY content <@> 'database'
-LIMIT 3;
+-- Implicit resolution warns; the matched row is the same whichever tied
+-- index the planner picks.
+SELECT id FROM docs ORDER BY content <@> 'database' LIMIT 3;
 
--- Explicit index selection gives user control
+-- Explicit naming pins a specific index.
 EXPLAIN (COSTS OFF)
 SELECT id, content <@> to_bm25query('database', 'docs_bm25_simple_idx') as score
 FROM docs


### PR DESCRIPTION
## Summary

When two BM25 indexes exist on the same column (or two expression
indexes match the same expression), the planner faces a genuine cost
tie — `tp_costestimate` derives cost only from `total_docs`, which is
identical for indexes on the same column. Which tied index the planner
scans then depends on relcache `indexlist` enumeration order, which is
not guaranteed stable across environments.

`validate_indexscan_explicit_index()` emitted a per-scan
`WARNING: planner chose index "X" instead of "Y"` in the *implicit*
resolution case. Because X/Y depend on that enumeration order, the
warning text was non-deterministic across environments, making the
multi-index regression tests fragile. It was also non-actionable: the
generic `multiple BM25 indexes ...` warning already advises naming an
index explicitly, and the returned rows are identical regardless of
which tied index is scanned.

This PR removes the implicit-case WARNING/HINT. The explicit-case
`ERROR` (raised when `to_bm25query()` names an index the planner did
not use) is a real tokenization-correctness guarantee and is kept
unchanged, as are the generic multiple-index warnings.

## Test changes

The multi-index test sections are updated to use portable index-scan
queries that don't print the tie-dependent chosen index, and their
comments are trimmed:

- **unsupported**: the implicit query returns rows instead of
  `EXPLAIN` (only doc 1 matches, so the result is stable); the
  explicit `EXPLAIN` pins a deterministic index.
- **explicit_index**: drops the implicit `EXPLAIN` whose plan line
  named the tied index, keeping the existing deterministic-score
  assertion that already covers the implicit path.
- **expression_index**: no query change (the implicit query returns 0
  rows); expected output regenerated without the removed warning.

## Verification

Full regression suite green on PostgreSQL 17 and 18 (72/72). Code
formatting checked with `clang-format`.
