### PR TITLE
Fix large-corpus index build failures (#431, #432, #433)

### DIFF
--- a/src/access/build.c
+++ b/src/access/build.c
@@ -1481,7 +1481,13 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 				RelationGetRelid(index), RelationGetRelid(heap));
 
 		/* Budget: maintenance_work_mem (in KB) -> bytes */
-		budget	  = (Size)maintenance_work_mem * 1024L;
+		budget = (Size)maintenance_work_mem * 1024L;
+		/*
+		 * Clamp to the arena's addressable capacity so a large
+		 * maintenance_work_mem still spills instead of overrunning
+		 * the 4 GiB arena (issue #433).
+		 */
+		budget	  = tp_arena_clamp_budget(budget);
 		build_ctx = tp_build_context_create(budget);
 
 		/* Initialize callback state */

--- a/src/access/build_context.c
+++ b/src/access/build_context.c
@@ -106,8 +106,10 @@ build_context_grow_docs(TpBuildContext *ctx)
 {
 	uint32 new_capacity = ctx->docs_capacity * 2;
 
-	ctx->fieldnorms = repalloc(ctx->fieldnorms, new_capacity * sizeof(uint8));
-	ctx->ctids = repalloc(ctx->ctids, new_capacity * sizeof(ItemPointerData));
+	ctx->fieldnorms =
+			repalloc_huge(ctx->fieldnorms, new_capacity * sizeof(uint8));
+	ctx->ctids =
+			repalloc_huge(ctx->ctids, new_capacity * sizeof(ItemPointerData));
 	ctx->docs_capacity = new_capacity;
 }
 
@@ -224,7 +226,7 @@ tp_build_context_get_sorted_terms(TpBuildContext *ctx, uint32 *num_terms)
 		return NULL;
 	}
 
-	terms = palloc(count * sizeof(TpBuildTermInfo));
+	terms = palloc_extended(count * sizeof(TpBuildTermInfo), MCXT_ALLOC_HUGE);
 	i	  = 0;
 
 	hash_seq_init(&status, ctx->terms_ht);
@@ -266,7 +268,7 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	TpDictionary	 dict;
 
 	uint32 *string_offsets;
-	uint32	string_pos;
+	uint64	string_pos;
 	uint32	i;
 	Buffer	header_buf;
 	Page	header_page;
@@ -328,12 +330,28 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 			&writer, &dict, offsetof(TpDictionary, string_offsets));
 
 	/* Build string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			num_terms * sizeof(uint32), MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
-		string_offsets[i] = string_pos;
-		string_pos += sizeof(uint32) + terms[i].term_len + sizeof(uint32);
+		/*
+		 * String-pool offsets are stored as uint32 in the segment
+		 * format.  Fail loudly before writing rather than silently
+		 * wrapping (issue #432).
+		 */
+		if (string_pos > PG_UINT32_MAX)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("pg_textsearch: segment string pool exceeds "
+							"the %u-byte format limit",
+							PG_UINT32_MAX),
+					 errhint("The corpus vocabulary is too large for a "
+							 "single segment.")));
+
+		string_offsets[i] = (uint32)string_pos;
+		string_pos += (uint64)sizeof(uint32) + terms[i].term_len +
+					  sizeof(uint32);
 	}
 
 	/* Write string offsets array */
@@ -369,7 +387,9 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	header.postings_offset = writer.current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(TermBlockInfo));
+	term_blocks = palloc_extended(
+			num_terms * sizeof(TermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;
@@ -470,7 +490,7 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 			if (skip_entries_count >= skip_entries_capacity)
 			{
 				skip_entries_capacity *= 2;
-				all_skip_entries = repalloc(
+				all_skip_entries = repalloc_huge(
 						all_skip_entries,
 						skip_entries_capacity * sizeof(TpSkipEntry));
 			}
@@ -495,7 +515,8 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	/* Write CTID pages array (BlockNumber per doc) */
 	header.ctid_pages_offset = writer.current_offset;
 	{
-		uint32 *ctid_pages = palloc(ctx->num_docs * sizeof(uint32));
+		uint32 *ctid_pages = palloc_extended(
+				ctx->num_docs * sizeof(uint32), MCXT_ALLOC_HUGE);
 
 		for (i = 0; i < ctx->num_docs; i++)
 			ctid_pages[i] = ItemPointerGetBlockNumber(&ctx->ctids[i]);
@@ -507,7 +528,8 @@ tp_write_segment_from_build_ctx(TpBuildContext *ctx, Relation index)
 	/* Write CTID offsets array (OffsetNumber per doc) */
 	header.ctid_offsets_offset = writer.current_offset;
 	{
-		uint16 *ctid_offsets = palloc(ctx->num_docs * sizeof(uint16));
+		uint16 *ctid_offsets = palloc_extended(
+				ctx->num_docs * sizeof(uint16), MCXT_ALLOC_HUGE);
 
 		for (i = 0; i < ctx->num_docs; i++)
 			ctid_offsets[i] = ItemPointerGetOffsetNumber(&ctx->ctids[i]);
@@ -733,7 +755,7 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	off_t base_file_offset;
 
 	uint32 *string_offsets;
-	uint32	string_pos;
+	uint64	string_pos;
 	uint32	i;
 
 	/* Current write position in the flat stream */
@@ -791,12 +813,28 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	current_offset += offsetof(TpDictionary, string_offsets);
 
 	/* Build string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			num_terms * sizeof(uint32), MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
-		string_offsets[i] = string_pos;
-		string_pos += sizeof(uint32) + terms[i].term_len + sizeof(uint32);
+		/*
+		 * String-pool offsets are stored as uint32 in the segment
+		 * format.  Fail loudly before writing rather than silently
+		 * wrapping (issue #432).
+		 */
+		if (string_pos > PG_UINT32_MAX)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("pg_textsearch: segment string pool exceeds "
+							"the %u-byte format limit",
+							PG_UINT32_MAX),
+					 errhint("The corpus vocabulary is too large for a "
+							 "single segment.")));
+
+		string_offsets[i] = (uint32)string_pos;
+		string_pos += (uint64)sizeof(uint32) + terms[i].term_len +
+					  sizeof(uint32);
 	}
 
 	/* Write string offsets array */
@@ -835,7 +873,9 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	header.postings_offset = current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(TermBlockInfo));
+	term_blocks = palloc_extended(
+			num_terms * sizeof(TermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;
@@ -924,7 +964,7 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 			if (skip_entries_count >= skip_entries_capacity)
 			{
 				skip_entries_capacity *= 2;
-				all_skip_entries = repalloc(
+				all_skip_entries = repalloc_huge(
 						all_skip_entries,
 						skip_entries_capacity * sizeof(TpSkipEntry));
 			}
@@ -954,7 +994,8 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	/* Write CTID pages array */
 	header.ctid_pages_offset = current_offset;
 	{
-		uint32 *ctid_pages = palloc(ctx->num_docs * sizeof(uint32));
+		uint32 *ctid_pages = palloc_extended(
+				ctx->num_docs * sizeof(uint32), MCXT_ALLOC_HUGE);
 
 		for (i = 0; i < ctx->num_docs; i++)
 			ctid_pages[i] = ItemPointerGetBlockNumber(&ctx->ctids[i]);
@@ -966,7 +1007,8 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 	/* Write CTID offsets array */
 	header.ctid_offsets_offset = current_offset;
 	{
-		uint16 *ctid_offsets = palloc(ctx->num_docs * sizeof(uint16));
+		uint16 *ctid_offsets = palloc_extended(
+				ctx->num_docs * sizeof(uint16), MCXT_ALLOC_HUGE);
 
 		for (i = 0; i < ctx->num_docs; i++)
 			ctid_offsets[i] = ItemPointerGetOffsetNumber(&ctx->ctids[i]);
@@ -995,7 +1037,8 @@ tp_write_segment_to_buffile(TpBuildContext *ctx, BufFile *file)
 		/* Save end position */
 		BufFileTell(file, &end_fileno, &end_file_offset);
 
-		dict_entries = palloc(num_terms * sizeof(TpDictEntry));
+		dict_entries = palloc_extended(
+				num_terms * sizeof(TpDictEntry), MCXT_ALLOC_HUGE);
 		for (i = 0; i < num_terms; i++)
 		{
 			dict_entries[i].skip_index_offset =

--- a/src/access/build_parallel.c
+++ b/src/access/build_parallel.c
@@ -265,6 +265,14 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 	if (budget < 64L * 1024 * 1024)
 		budget = 64L * 1024 * 1024;
 
+	/*
+	 * Clamp to the arena's addressable capacity: with few workers
+	 * launched, maintenance_work_mem / nworkers can still exceed the
+	 * 4 GiB arena, so the worker would overrun instead of spilling
+	 * (issue #433).
+	 */
+	budget = tp_arena_clamp_budget(budget);
+
 	build_ctx = tp_build_context_create(budget);
 	tracker_init(&tracker);
 
@@ -423,9 +431,13 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 							worker_id,
 							tracker.count,
 							TP_MAX_WORKER_SEGMENTS),
-					 errhint("Increase maintenance_work_mem or "
-							 "reduce "
-							 "max_parallel_maintenance_workers.")));
+					 errhint("Increase maintenance_work_mem so each "
+							 "worker flushes fewer, larger segments "
+							 "(the per-worker budget is bounded by the "
+							 "arena's ~4 GiB capacity). Reducing "
+							 "max_parallel_maintenance_workers makes this "
+							 "worse, as each remaining worker then scans a "
+							 "larger share of the table.")));
 
 		for (i = 0; i < tracker.count; i++)
 		{

--- a/src/memtable/arena.h
+++ b/src/memtable/arena.h
@@ -34,6 +34,16 @@ typedef uint32 ArenaAddr;
 #define ARENA_MAX_PAGES 4096
 
 /*
+ * Maximum bytes an arena can address: ARENA_MAX_PAGES * ARENA_PAGE_SIZE
+ * = 4096 * 1MB = 4GB = 2^32.  Computed in 64-bit on purpose: the product
+ * is exactly 2^32 and wraps to zero in a 32-bit size_t.  Used to clamp
+ * the flush budget so a maintenance_work_mem larger than the arena can
+ * still trigger a spill instead of hitting the arena's hard ceiling
+ * (issue #433).
+ */
+#define ARENA_MAX_BYTES ((uint64)ARENA_MAX_PAGES * ARENA_PAGE_SIZE)
+
+/*
  * Build an ArenaAddr from page index and offset.
  */
 static inline ArenaAddr
@@ -73,6 +83,25 @@ typedef struct TpArena
 	uint32 current_offset; /* Write position in current page */
 	Size   total_bytes;	   /* Total bytes allocated (for budget) */
 } TpArena;
+
+/*
+ * Clamp a requested flush budget to what a single arena can actually
+ * hold.  The arena is capped at ARENA_MAX_BYTES by construction, so a
+ * budget at or above that can never fire the flush check and the arena
+ * dies with "exceeded maximum capacity" instead of spilling.  We clamp
+ * to 3/4 of capacity, leaving headroom for per-document overshoot
+ * between budget checks (a document may add many terms before the next
+ * check).  See issue #433.
+ */
+static inline Size
+tp_arena_clamp_budget(Size budget)
+{
+	Size cap = (Size)(ARENA_MAX_BYTES - ARENA_MAX_BYTES / 4);
+
+	if (budget == 0 || budget > cap)
+		return cap;
+	return budget;
+}
 
 /*
  * Create a new arena.

--- a/src/memtable/chain_source.c
+++ b/src/memtable/chain_source.c
@@ -760,8 +760,9 @@ tp_memtable_chain_source_extract(
 		return;
 	}
 
-	terms = (TermInfo *)palloc0(num_terms * sizeof(TermInfo));
-	i	  = 0;
+	terms = (TermInfo *)palloc_extended(
+			num_terms * sizeof(TermInfo), MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	i = 0;
 	hash_seq_init(&seq, src->term_ht);
 	while ((te = (ChainTermEntry *)hash_seq_search(&seq)) != NULL)
 	{

--- a/src/segment/docmap.c
+++ b/src/segment/docmap.c
@@ -181,10 +181,13 @@ tp_docmap_finalize(TpDocMapBuilder *builder)
 		  docmap_entry_cmp_by_ctid);
 
 	/* Allocate output arrays (split CTID storage for better cache locality) */
-	builder->capacity	  = builder->num_docs;
-	builder->ctid_pages	  = palloc(sizeof(BlockNumber) * builder->num_docs);
-	builder->ctid_offsets = palloc(sizeof(OffsetNumber) * builder->num_docs);
-	builder->fieldnorms	  = palloc(sizeof(uint8) * builder->num_docs);
+	builder->capacity	= builder->num_docs;
+	builder->ctid_pages = palloc_extended(
+			sizeof(BlockNumber) * builder->num_docs, MCXT_ALLOC_HUGE);
+	builder->ctid_offsets = palloc_extended(
+			sizeof(OffsetNumber) * builder->num_docs, MCXT_ALLOC_HUGE);
+	builder->fieldnorms = palloc_extended(
+			sizeof(uint8) * builder->num_docs, MCXT_ALLOC_HUGE);
 
 	/*
 	 * Fill arrays and reassign doc_ids in CTID order.

--- a/src/segment/io.h
+++ b/src/segment/io.h
@@ -86,7 +86,7 @@ extern BlockNumber tp_write_segment(
 		struct TpDocMapBuilder *docmap);
 extern void tp_segment_writer_init(TpSegmentWriter *writer, Relation index);
 extern void
-tp_segment_writer_write(TpSegmentWriter *writer, const void *data, uint32 len);
+tp_segment_writer_write(TpSegmentWriter *writer, const void *data, Size len);
 extern void tp_segment_writer_flush(TpSegmentWriter *writer);
 extern void tp_segment_writer_finish(TpSegmentWriter *writer);
 

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -60,7 +60,7 @@ merge_sink_init_pages(TpMergeSink *sink, Relation index)
  * Sequential append to sink.
  */
 static void
-merge_sink_write(TpMergeSink *sink, const void *data, uint32 size)
+merge_sink_write(TpMergeSink *sink, const void *data, Size size)
 {
 	tp_segment_writer_write(&sink->writer, data, size);
 	sink->current_offset = sink->writer.current_offset;
@@ -198,7 +198,8 @@ merge_source_init(TpMergeSource *source, Relation index, BlockNumber root)
 			sizeof(dict_header.num_terms));
 
 	/* Cache all string offsets for this segment */
-	source->string_offsets = palloc(sizeof(uint32) * source->num_terms);
+	source->string_offsets = palloc_extended(
+			sizeof(uint32) * source->num_terms, MCXT_ALLOC_HUGE);
 	tp_segment_read(
 			source->reader,
 			header->dictionary_offset + sizeof(dict_header.num_terms),
@@ -256,7 +257,8 @@ merge_source_init_from_reader(TpMergeSource *source, TpSegmentReader *reader)
 			sizeof(dict_header.num_terms));
 
 	/* Cache all string offsets for this segment */
-	source->string_offsets = palloc(sizeof(uint32) * source->num_terms);
+	source->string_offsets = palloc_extended(
+			sizeof(uint32) * source->num_terms, MCXT_ALLOC_HUGE);
 	tp_segment_read(
 			source->reader,
 			header->dictionary_offset + sizeof(dict_header.num_terms),
@@ -696,7 +698,8 @@ build_merged_docmap(
 		}
 
 		total_docs += ms->num_docs;
-		mapping->old_to_new[i] = palloc(ms->num_docs * sizeof(uint32));
+		mapping->old_to_new[i] = palloc_extended(
+				ms->num_docs * sizeof(uint32), MCXT_ALLOC_HUGE);
 
 		/* CTID arrays: use cached if available, else bulk-read */
 		if (sources[i].reader->cached_ctid_pages != NULL)
@@ -707,14 +710,16 @@ build_merged_docmap(
 		}
 		else
 		{
-			ms->ctid_pages = palloc(ms->num_docs * sizeof(BlockNumber));
+			ms->ctid_pages = palloc_extended(
+					ms->num_docs * sizeof(BlockNumber), MCXT_ALLOC_HUGE);
 			tp_segment_read(
 					sources[i].reader,
 					header->ctid_pages_offset,
 					ms->ctid_pages,
 					ms->num_docs * sizeof(BlockNumber));
 
-			ms->ctid_offsets = palloc(ms->num_docs * sizeof(OffsetNumber));
+			ms->ctid_offsets = palloc_extended(
+					ms->num_docs * sizeof(OffsetNumber), MCXT_ALLOC_HUGE);
 			tp_segment_read(
 					sources[i].reader,
 					header->ctid_offsets_offset,
@@ -724,7 +729,8 @@ build_merged_docmap(
 		}
 
 		/* Fieldnorms: always bulk-read (not cached by reader) */
-		ms->fieldnorms = palloc(ms->num_docs * sizeof(uint8));
+		ms->fieldnorms =
+				palloc_extended(ms->num_docs * sizeof(uint8), MCXT_ALLOC_HUGE);
 		tp_segment_read(
 				sources[i].reader,
 				header->fieldnorm_offset,
@@ -733,9 +739,12 @@ build_merged_docmap(
 	}
 
 	/* Step 2: Allocate output arrays (palloc(0) is valid in PG) */
-	out_pages	   = palloc(total_docs * sizeof(BlockNumber));
-	out_offsets	   = palloc(total_docs * sizeof(OffsetNumber));
-	out_fieldnorms = palloc(total_docs * sizeof(uint8));
+	out_pages =
+			palloc_extended(total_docs * sizeof(BlockNumber), MCXT_ALLOC_HUGE);
+	out_offsets = palloc_extended(
+			total_docs * sizeof(OffsetNumber), MCXT_ALLOC_HUGE);
+	out_fieldnorms =
+			palloc_extended(total_docs * sizeof(uint8), MCXT_ALLOC_HUGE);
 
 	/*
 	 * Step 3: Merge docmaps.
@@ -992,7 +1001,7 @@ write_merged_segment_to_sink(
 	TpMergeDocMapping	doc_mapping;
 	MergeTermBlockInfo *term_blocks;
 	uint32			   *string_offsets;
-	uint32				string_pos;
+	uint64				string_pos;
 	uint32				i;
 
 	/* Accumulated skip entries for all terms */
@@ -1050,12 +1059,29 @@ write_merged_segment_to_sink(
 	merge_sink_write(sink, &dict, offsetof(TpDictionary, string_offsets));
 
 	/* Calculate string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			num_terms * sizeof(uint32), MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
-		string_offsets[i] = string_pos;
-		string_pos += sizeof(uint32) + terms[i].term_len + sizeof(uint32);
+		/*
+		 * String-pool offsets are stored as uint32 in the segment
+		 * format.  Fail loudly before writing rather than silently
+		 * wrapping and producing a segment that reads from the wrong
+		 * place (issue #432).
+		 */
+		if (string_pos > PG_UINT32_MAX)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("pg_textsearch: merged segment string pool "
+							"exceeds the %u-byte format limit",
+							PG_UINT32_MAX),
+					 errhint("The corpus vocabulary is too large for a "
+							 "single segment.")));
+
+		string_offsets[i] = (uint32)string_pos;
+		string_pos += (uint64)sizeof(uint32) + terms[i].term_len +
+					  sizeof(uint32);
 	}
 
 	/* Write string offsets array */
@@ -1088,7 +1114,9 @@ write_merged_segment_to_sink(
 	header.postings_offset = sink->current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(MergeTermBlockInfo));
+	term_blocks = palloc_extended(
+			num_terms * sizeof(MergeTermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;

--- a/src/segment/merge.c
+++ b/src/segment/merge.c
@@ -1392,7 +1392,8 @@ write_merged_segment_to_sink(
 	{
 		TpDictEntry *dict_entries;
 
-		dict_entries = palloc(num_terms * sizeof(TpDictEntry));
+		dict_entries = palloc_extended(
+				num_terms * sizeof(TpDictEntry), MCXT_ALLOC_HUGE);
 		for (i = 0; i < num_terms; i++)
 		{
 			dict_entries[i].skip_index_offset =

--- a/src/segment/scan.c
+++ b/src/segment/scan.c
@@ -106,7 +106,7 @@ tp_segment_posting_iterator_init(
 		TpStringEntry string_entry;
 		int			  cmp;
 		uint32		  string_offset_value;
-		uint32		  string_offset;
+		uint64		  string_offset;
 
 		mid = left + (right - left) / 2;
 
@@ -618,7 +618,7 @@ tp_segment_get_doc_freq(
 			TpStringEntry string_entry;
 			int			  cmp;
 			uint32		  string_offset_value;
-			uint32		  string_offset;
+			uint64		  string_offset;
 			int			  mid = left + (right - left) / 2;
 
 			tp_segment_read(
@@ -747,7 +747,7 @@ tp_batch_get_segment_doc_freq(
 			{
 				int	   mid = left + (right - left) / 2;
 				uint32 string_offset_value;
-				uint32 string_offset;
+				uint64 string_offset;
 				uint32 string_length;
 				int	   cmp;
 

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -975,7 +975,7 @@ tp_write_segment(
 	TpDictionary	dict;
 
 	uint32			*string_offsets;
-	uint32			 string_pos;
+	uint64			 string_pos;
 	uint32			 i;
 	Buffer			 header_buf;
 	Page			 header_page;
@@ -1039,12 +1039,28 @@ tp_write_segment(
 			&writer, &dict, offsetof(TpDictionary, string_offsets));
 
 	/* Build string offsets */
-	string_offsets = palloc0(num_terms * sizeof(uint32));
-	string_pos	   = 0;
+	string_offsets = palloc_extended(
+			num_terms * sizeof(uint32), MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
+	string_pos = 0;
 	for (i = 0; i < num_terms; i++)
 	{
-		string_offsets[i] = string_pos;
-		string_pos += sizeof(uint32) + terms[i].term_len + sizeof(uint32);
+		/*
+		 * String-pool offsets are stored as uint32 in the segment
+		 * format.  Fail loudly before writing rather than silently
+		 * wrapping (issue #432).
+		 */
+		if (string_pos > PG_UINT32_MAX)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("pg_textsearch: segment string pool exceeds "
+							"the %u-byte format limit",
+							PG_UINT32_MAX),
+					 errhint("The corpus vocabulary is too large for a "
+							 "single segment.")));
+
+		string_offsets[i] = (uint32)string_pos;
+		string_pos += (uint64)sizeof(uint32) + terms[i].term_len +
+					  sizeof(uint32);
 	}
 
 	/* Write string offsets array */
@@ -1079,7 +1095,9 @@ tp_write_segment(
 	header.postings_offset = writer.current_offset;
 
 	/* Initialize per-term tracking and skip entry accumulator */
-	term_blocks = palloc0(num_terms * sizeof(TermBlockInfo));
+	term_blocks = palloc_extended(
+			num_terms * sizeof(TermBlockInfo),
+			MCXT_ALLOC_HUGE | MCXT_ALLOC_ZERO);
 
 	skip_entries_capacity = 1024;
 	skip_entries_count	  = 0;

--- a/src/segment/segment.c
+++ b/src/segment/segment.c
@@ -2052,16 +2052,16 @@ tp_segment_writer_init(TpSegmentWriter *writer, Relation index)
 }
 
 void
-tp_segment_writer_write(TpSegmentWriter *writer, const void *data, uint32 len)
+tp_segment_writer_write(TpSegmentWriter *writer, const void *data, Size len)
 {
 	const char *src			  = (const char *)data;
-	uint32		bytes_written = 0;
+	Size		bytes_written = 0;
 
 	while (bytes_written < len)
 	{
 		/* Calculate how much we can write to current page */
 		uint32 page_space = BLCKSZ - writer->buffer_pos;
-		uint32 to_write	  = Min(page_space, len - bytes_written);
+		uint32 to_write	  = (uint32)Min((Size)page_space, len - bytes_written);
 
 		/* Copy data to buffer */
 		memcpy(writer->buffer + writer->buffer_pos,


### PR DESCRIPTION
Fixes three independent bugs that break index build on very large corpora
(tens of millions of terms, hundreds of millions of docs, multi-GB
`maintenance_work_mem`): #431, #432, #433. Covers every corpus-/doc-scaled
allocation on the build, memtable-spill, and merge paths.

## #431 — `MaxAllocSize` overruns
Corpus-/doc-scaled arrays used plain `palloc`/`repalloc` and cross Postgres'
1 GB `MaxAllocSize`, aborting the build mid-way (e.g. 24 B/term structs fail
~44.7 M terms; 32 B/term ~33.5 M; doc-scaled `BlockNumber` arrays ~256 M
docs). Converted them to the huge variants (`palloc_extended(MCXT_ALLOC_HUGE)`,
`repalloc_huge`) across the serial/parallel segment writers
(`build_context.c`), the memtable-spill writer (`segment.c`), the N-way merge
(`merge.c`), the term extractor (`chain_source.c`), and docmap finalize
(`docmap.c`).

## #432 — silent 32-bit truncation
- `tp_segment_writer_write()` / `merge_sink_write()` took a `uint32` length;
  the skip-index write passes a `Size` that truncates past 4 GiB → corrupt
  segment. Widened to `Size`.
- `string_offset` scan locals were `uint32` but assigned a `uint64` read
  offset. Widened to `uint64`.
- String-pool offsets are genuinely `uint32` on disk: every segment writer
  now raises `ERRCODE_PROGRAM_LIMIT_EXCEEDED` before writing rather than
  wrapping silently.

## #433 — flush budget can exceed the 4 GiB arena
The build arena addresses at most 4 GiB (`ArenaAddr` packs page+offset in 32
bits). The flush budget came straight from `maintenance_work_mem`, unclamped,
so a budget ≥ 4 GiB meant the spill check never fired and the arena hit its
hard ceiling ("exceeded maximum capacity"). Added `ARENA_MAX_BYTES` and
`tp_arena_clamp_budget()` (clamps to ¾ of capacity, leaving headroom for
per-document overshoot) on the serial (`build.c`) and per-worker
(`build_parallel.c`) budgets, and corrected the `TP_MAX_WORKER_SEGMENTS`
errhint (lowering `max_parallel_maintenance_workers` makes it worse).

Order matters: fixing #431/#433 without the #432 width fix would turn a loud
abort into silent corruption on multi-GB skip indexes, so all three ship
together.

## Testing
Worst-case triggers (40 M+ terms / multi-GB budgets) aren't reproducible in
CI; confirmed locally on PostgreSQL 17.9 beyond build + inspection:

- Clean build (no new warnings); `make installcheck` **74/74**, no
  `regression.diffs`.
- **#433 clamp (unit):** a harness on the real `tp_arena_clamp_budget()` /
  `ARENA_MAX_BYTES` confirms `ARENA_MAX_BYTES == 4 GiB` (not wrapped to 0),
  cap == 3 GiB, sub-cap budgets pass through, and `0`/`4 GiB`/`64 GiB` clamp
  to 3 GiB.
- **#433 end-to-end (A/B):** the ceiling scales with `ARENA_MAX_PAGES`, so it
  reproduces in seconds with the arena shrunk to 16 pages and
  `maintenance_work_mem = 64 MB` on a 400k-doc corpus — same corpus/settings,
  only the clamp toggled:
  - clamp **off** → `ERROR: arena: exceeded maximum capacity (16 pages, 16 MB)`
  - clamp **on** → clamped to 12 MB, spills to 6 L0 segments, all 400k docs
    indexed, top-k query correct.

Closes #431
Closes #432
Closes #433
