### PR TITLE
Fix tpvector_in mutating its input cstring

### DIFF
--- a/src/types/vector.c
+++ b/src/types/vector.c
@@ -388,7 +388,12 @@ tpvector_entry_decode_advance(
 Datum
 tpvector_in(PG_FUNCTION_ARGS)
 {
-	char	 *str = PG_GETARG_CSTRING(0);
+	/*
+	 * Copy the input: parsing below writes NUL terminators into the string
+	 * in place. The argument cstring must not be mutated, or a re-evaluated
+	 * const-folded literal would see a truncated buffer.
+	 */
+	char	 *str = pstrdup(PG_GETARG_CSTRING(0));
 	char	 *colon_pos;
 	char	 *index_name;
 	char	 *entries_str;


### PR DESCRIPTION
`tpvector_in` parsed the input in place, writing NUL terminators over the `PG_GETARG_CSTRING(0)` buffer (notably the trailing `}`). Mutating an argument cstring is unsafe: when a const-folded `bm25vector` literal is evaluated more than once, the second evaluation sees the already-truncated buffer and fails with `invalid tpvector format`.

This is reliably observable on `--enable-cassert` builds (e.g. local pgrx PG17/18), which re-evaluate const-folded expressions. It reproduces on `main`: `SELECT 'idx:{a:1}'::bm25vector` errors, while a runtime-computed `('idx:{a:1' || chr(125))::bm25vector` succeeds. CI's non-cassert builds don't trigger the re-evaluation, so it stayed green.

**Fix:** copy the input with `pstrdup` before parsing so the argument buffer is never modified.

**Testing:** full regression suite passes on pgrx PG17.10 (74/74), including the previously-failing basic, binary_io, vector, and vector_v1_rejected.