### PR TITLE
Add PostgreSQL 19 (beta) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # PG19 is in beta: run it, but don't let beta breakage block merges.
-    continue-on-error: ${{ matrix.pg_version == 19 }}
     strategy:
-      fail-fast: false
       matrix:
-        pg_version: [17, 18, 19]
+        pg_version: [17, 18]
 
     steps:
     - uses: actions/checkout@v4
@@ -42,11 +39,6 @@ jobs:
         sudo apt-get install -y wget ca-certificates
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-        # PG19 is in beta: its packages live in the pgdg-testing suite
-        # until GA. Adding it only for 19 keeps 17/18 on stable packages.
-        if [ "${{ matrix.pg_version }}" = "19" ]; then
-          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main 19" | sudo tee /etc/apt/sources.list.d/pgdg-testing.list
-        fi
         sudo apt-get update
         sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
@@ -256,18 +248,13 @@ jobs:
 
   build-test-multiple-configs:
     runs-on: ubuntu-latest
-    # PG19 is in beta: build it, but don't let beta breakage block merges.
-    continue-on-error: ${{ matrix.config.pg_version == 19 }}
     strategy:
-      fail-fast: false
       matrix:
         config:
           - { cc: gcc, pg_version: 17 }
           - { cc: clang, pg_version: 17 }
           - { cc: gcc, pg_version: 18 }
           - { cc: clang, pg_version: 18 }
-          - { cc: gcc, pg_version: 19 }
-          - { cc: clang, pg_version: 19 }
 
     steps:
     - uses: actions/checkout@v4
@@ -278,11 +265,6 @@ jobs:
         sudo apt-get install -y wget ca-certificates build-essential bc
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-        # PG19 is in beta: its packages live in the pgdg-testing suite
-        # until GA. Adding it only for 19 keeps 17/18 on stable packages.
-        if [ "${{ matrix.config.pg_version }}" = "19" ]; then
-          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main 19" | sudo tee /etc/apt/sources.list.d/pgdg-testing.list
-        fi
         sudo apt-get update
         sudo apt-get install -y postgresql-${{ matrix.config.pg_version }} postgresql-server-dev-${{ matrix.config.pg_version }}
 
@@ -293,6 +275,84 @@ jobs:
         make clean
         # Build with -Werror via PG_CFLAGS (CFLAGS is overridden by pgxs)
         make PG_CFLAGS="-Werror -Wno-error=unused-parameter"
+
+  # PG19 is in beta and has no PGDG apt package yet, so it is built from
+  # source here and exercised with both gcc and clang plus the full SQL
+  # regression suite. This job is experimental: beta breakage must not
+  # block merges (continue-on-error), and it can be dropped in favor of
+  # the apt matrices once PG19 reaches GA and PGDG ships packages.
+  test-pg19-beta:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+    env:
+      PG19_REF: REL_19_BETA3
+      PGPREFIX: ${{ github.workspace }}/pg19-install
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential clang bison flex \
+          libreadline-dev zlib1g-dev libicu-dev pkg-config bc
+
+    - name: Cache PostgreSQL ${{ env.PG19_REF }} build
+      id: pgcache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.PGPREFIX }}
+        key: pg19-${{ env.PG19_REF }}-${{ matrix.cc }}-${{ runner.os }}
+
+    - name: Build PostgreSQL ${{ env.PG19_REF }} from source
+      if: steps.pgcache.outputs.cache-hit != 'true'
+      run: |
+        git clone --depth 1 --branch "$PG19_REF" \
+          https://git.postgresql.org/git/postgresql.git /tmp/pgsrc
+        cd /tmp/pgsrc
+        CC=${{ matrix.cc }} ./configure --prefix="$PGPREFIX" \
+          --with-icu --enable-debug --enable-cassert
+        make -j"$(nproc)"
+        make install
+
+    - name: Build extension with ${{ matrix.cc }}
+      run: |
+        export PATH="$PGPREFIX/bin:$PATH"
+        export CC=${{ matrix.cc }}
+        make clean
+        make PG_CFLAGS="-Werror -Wno-error=unused-parameter"
+        make install
+
+    - name: Run regression tests
+      timeout-minutes: 15
+      run: |
+        export PATH="$PGPREFIX/bin:$PATH"
+        rm -rf tmp_check_shared
+        mkdir -p tmp_check_shared
+        initdb -D tmp_check_shared/data --auth-local=trust --auth-host=trust
+        echo "port = 55433" >> tmp_check_shared/data/postgresql.conf
+        echo "shared_buffers = 256MB" >> tmp_check_shared/data/postgresql.conf
+        echo "max_connections = 20" >> tmp_check_shared/data/postgresql.conf
+        echo "shared_preload_libraries = 'pg_textsearch'" >> tmp_check_shared/data/postgresql.conf
+        echo "unix_socket_directories = '$PWD/tmp_check_shared'" >> tmp_check_shared/data/postgresql.conf
+        if ! pg_ctl start -D tmp_check_shared/data -l tmp_check_shared/data/logfile -w; then
+          echo "PostgreSQL failed to start. Log contents:"
+          cat tmp_check_shared/data/logfile
+          exit 1
+        fi
+        createdb -h $PWD/tmp_check_shared -p 55433 contrib_regression
+        if ! make installcheck PGHOST=$PWD/tmp_check_shared PGPORT=55433; then
+          echo "Tests failed. Showing regression diffs:"
+          [ -f test/regression.diffs ] && cat test/regression.diffs
+          echo "PostgreSQL server log (last 200 lines):"
+          tail -200 tmp_check_shared/data/logfile || true
+          pg_ctl stop -D tmp_check_shared/data || true
+          exit 1
+        fi
+        pg_ctl stop -D tmp_check_shared/data
 
   performance-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # PG19 is in beta: run it, but don't let beta breakage block merges.
+    continue-on-error: ${{ matrix.pg_version == 19 }}
     strategy:
+      fail-fast: false
       matrix:
-        pg_version: [17, 18]
+        pg_version: [17, 18, 19]
 
     steps:
     - uses: actions/checkout@v4
@@ -248,13 +251,18 @@ jobs:
 
   build-test-multiple-configs:
     runs-on: ubuntu-latest
+    # PG19 is in beta: build it, but don't let beta breakage block merges.
+    continue-on-error: ${{ matrix.config.pg_version == 19 }}
     strategy:
+      fail-fast: false
       matrix:
         config:
           - { cc: gcc, pg_version: 17 }
           - { cc: clang, pg_version: 17 }
           - { cc: gcc, pg_version: 18 }
           - { cc: clang, pg_version: 18 }
+          - { cc: gcc, pg_version: 19 }
+          - { cc: clang, pg_version: 19 }
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
         sudo apt-get install -y wget ca-certificates
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+        # PG19 is in beta: its packages live in the pgdg-testing suite
+        # until GA. Adding it only for 19 keeps 17/18 on stable packages.
+        if [ "${{ matrix.pg_version }}" = "19" ]; then
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main 19" | sudo tee /etc/apt/sources.list.d/pgdg-testing.list
+        fi
         sudo apt-get update
         sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
@@ -273,6 +278,11 @@ jobs:
         sudo apt-get install -y wget ca-certificates build-essential bc
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+        # PG19 is in beta: its packages live in the pgdg-testing suite
+        # until GA. Adding it only for 19 keeps 17/18 on stable packages.
+        if [ "${{ matrix.config.pg_version }}" = "19" ]; then
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main 19" | sudo tee /etc/apt/sources.list.d/pgdg-testing.list
+        fi
         sudo apt-get update
         sudo apt-get install -y postgresql-${{ matrix.config.pg_version }} postgresql-server-dev-${{ matrix.config.pg_version }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,9 @@ for scalability.
 
 **Current Version**: 1.4.0
 
-**Postgres Version Support**: 17, 18 (tested in CI)
+**Postgres Version Support**: 17, 18 (tested in CI). 19 (beta) is
+supported on a best-effort basis; its CI job is allowed to fail while
+19 is in beta.
 
 **Schema Organization**: Currently uses public schema. Future versions may
 consider a dedicated `pg_textsearch` schema for cleaner namespace management.
@@ -261,7 +263,8 @@ The `benchmarks/` directory contains performance testing tools:
 ## Continuous Integration
 
 GitHub Actions workflows:
-- `ci.yml` - Main CI pipeline testing Postgres 17, 18
+- `ci.yml` - Main CI pipeline testing Postgres 17, 18, and 19 (beta,
+  allow-failure)
 - `sanitizer-build-and-test.yml` - Address sanitizer builds
 - `formatting.yml` - Code formatting validation
 - `release.yml` - Automated release workflow

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ mascot and the name occurs in various places in the source code.
 
 ## PostgreSQL Version Compatibility
 
-pg_textsearch supports PostgreSQL 17 and 18.
+pg_textsearch supports PostgreSQL 17 and 18. PostgreSQL 19 (beta) is
+supported on a best-effort basis while it is in beta; its CI is allowed
+to fail and prebuilt binaries are not published for it yet.
 
 ## Installation
 

--- a/src/access/build_parallel.c
+++ b/src/access/build_parallel.c
@@ -248,7 +248,11 @@ tp_parallel_build_worker_main(dsm_segment *seg, shm_toc *toc)
 
 			ItemPointerSet(&min_tid, start_blk, FirstOffsetNumber);
 			ItemPointerSet(&max_tid, end_blk - 1, MaxOffsetNumber);
+#if PG_VERSION_NUM >= 190000
+			scan = table_beginscan_tidrange(heap, snap, &min_tid, &max_tid, 0);
+#else
 			scan = table_beginscan_tidrange(heap, snap, &min_tid, &max_tid);
+#endif
 		}
 		else
 		{

--- a/src/compat.h
+++ b/src/compat.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * compat.h - Compiler portability helpers
+ * compat.h - Compiler and server-version portability helpers
  */
 #pragma once
 
@@ -19,4 +19,26 @@
 #define TP_PACKED
 #else
 #define TP_PACKED pg_attribute_packed()
+#endif
+
+/*
+ * PG19 requires a hand-built TupleDesc to be finalized before it is
+ * blessed or otherwise used; on a cassert build BlessTupleDesc() TRAPs
+ * otherwise.  Older servers have no such call, so define it away and
+ * let call sites use the PG19 API unconditionally.
+ */
+#if PG_VERSION_NUM < 190000
+#define TupleDescFinalize(tupdesc) ((void)(tupdesc))
+#endif
+
+/*
+ * post_parse_analyze_hook's JumbleState parameter became const in PG19.
+ * A hook implementation has to match the typedef exactly — C does not
+ * consider `const JumbleState *` and `JumbleState *` compatible
+ * parameter types — so the qualifier must track the server version.
+ */
+#if PG_VERSION_NUM >= 190000
+#define TP_JUMBLE_STATE const JumbleState
+#else
+#define TP_JUMBLE_STATE JumbleState
 #endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -230,3 +230,7 @@ extern int	  tp_memtable_pages_threshold;
 extern int	  tp_segments_per_level;
 extern bool	  tp_filtered_seed;
 extern double tp_filtered_seed_margin;
+extern bool	  tp_compress_segments;
+extern bool	  tp_memtable_cache_enabled;
+extern bool	  tp_log_cache_state;
+extern int	  tp_memory_limit_kb;

--- a/src/constants.h
+++ b/src/constants.h
@@ -191,6 +191,35 @@
 #define TP_TRANCHE_EVICTION_MUTEX 1012
 
 /*
+ * Bounds of the contiguous fixed-tranche block above.  TP_TRANCHE_COUNT
+ * fixed IDs [TP_TRANCHE_FIRST, TP_TRANCHE_LAST] are defined; a handful
+ * (POSTING, CORPUS) are currently reserved but still allocated so the
+ * block stays contiguous.
+ */
+#define TP_TRANCHE_FIRST TP_TRANCHE_STRING
+#define TP_TRANCHE_LAST	 TP_TRANCHE_EVICTION_MUTEX
+#define TP_TRANCHE_COUNT ((TP_TRANCHE_LAST) - (TP_TRANCHE_FIRST) + 1)
+
+/*
+ * Resolve a fixed logical tranche constant (TP_TRANCHE_*) to the actual
+ * LWLock tranche ID to use at runtime.
+ *
+ * PG17/18: the fixed IDs are used directly (and named at startup via
+ * LWLockRegisterTranche), so this is a compile-time identity.
+ *
+ * PG19+: LWLockRegisterTranche() was removed; a tranche name can only be
+ * assigned when the ID is allocated via LWLockNewTrancheId().  We
+ * allocate one contiguous, name-registered block of TP_TRANCHE_COUNT IDs
+ * exactly once at shared-memory startup and map each fixed constant onto
+ * it.  See tp_registry_shmem_startup() and tp_tranche_id().
+ */
+#if PG_VERSION_NUM >= 190000
+extern int tp_tranche_id(int fixed_tranche_id);
+#else
+#define tp_tranche_id(fixed_tranche_id) (fixed_tranche_id)
+#endif
+
+/*
  * Global GUC variables declared in mod.c
  * Note: tp_relopt_kind is declared in index.c as it requires
  * access/reloptions.h

--- a/src/index/registry.c
+++ b/src/index/registry.c
@@ -34,6 +34,51 @@ static TpGlobalRegistry *tapir_registry = NULL;
 /* Backend-local DSA area pointer */
 static dsa_area *tapir_dsa = NULL;
 
+#if PG_VERSION_NUM >= 190000
+/*
+ * PG19+ removed LWLockRegisterTranche(); tranche names can only be
+ * assigned when the ID is allocated via LWLockNewTrancheId().  Allocate
+ * one contiguous, name-registered block of TP_TRANCHE_COUNT IDs exactly
+ * once (first backend, under AddinShmemInitLock) and record them in
+ * shared memory so every backend resolves the same IDs.
+ */
+static void
+tp_init_tranche_ids(void)
+{
+	static const char *const tranche_names[TP_TRANCHE_COUNT] = {
+			"tapir_string_hash",	  /* TP_TRANCHE_STRING */
+			"tapir_posting",		  /* TP_TRANCHE_POSTING (reserved) */
+			"tapir_corpus",			  /* TP_TRANCHE_CORPUS (reserved) */
+			"tapir_doclength_hash",	  /* TP_TRANCHE_DOC_LENGTHS */
+			"tapir_index_lock",		  /* TP_TRANCHE_INDEX_LOCK */
+			"tapir_build_dsa",		  /* TP_TRANCHE_BUILD_DSA */
+			"tapir_global_dsa",		  /* TP_TRANCHE_GLOBAL_DSA */
+			"tapir_registry",		  /* TP_TRANCHE_REGISTRY */
+			"tapir_posting_lock",	  /* TP_TRANCHE_POSTING_LOCK */
+			"tapir_cache_apply_lock", /* TP_TRANCHE_CACHE_APPLY_LOCK */
+			"tapir_cache_lock",		  /* TP_TRANCHE_CACHE_LOCK */
+			"tapir_cache_eviction",	  /* TP_TRANCHE_EVICTION_MUTEX */
+	};
+
+	for (int i = 0; i < TP_TRANCHE_COUNT; i++)
+		tapir_registry->tranche_ids[i] = LWLockNewTrancheId(tranche_names[i]);
+}
+
+/*
+ * Resolve a fixed logical tranche constant to its runtime tranche ID.
+ * See constants.h for the PG17/18 (compile-time identity) counterpart.
+ */
+int
+tp_tranche_id(int fixed_tranche_id)
+{
+	int idx = fixed_tranche_id - TP_TRANCHE_FIRST;
+
+	Assert(tapir_registry != NULL);
+	Assert(idx >= 0 && idx < TP_TRANCHE_COUNT);
+	return tapir_registry->tranche_ids[idx];
+}
+#endif
+
 /*
  * Hash function for Oid keys
  */
@@ -86,7 +131,7 @@ get_registry_params(dshash_parameters *params)
 	params->compare_function = registry_compare_fn;
 	params->hash_function	 = registry_hash_fn;
 	params->copy_function	 = registry_copy_fn;
-	params->tranche_id		 = TP_REGISTRY_HASH_TRANCHE_ID;
+	params->tranche_id		 = tp_tranche_id(TP_REGISTRY_HASH_TRANCHE_ID);
 }
 
 /*
@@ -143,12 +188,22 @@ tp_registry_shmem_startup(void)
 		/* First time initialization */
 		memset(tapir_registry, 0, sizeof(TpGlobalRegistry));
 
+#if PG_VERSION_NUM >= 190000
 		/*
-		 * Initialize the registry lock using fixed tranche ID.
+		 * Allocate the runtime LWLock tranche-ID block before any lock
+		 * or DSA is initialized with a tranche ID (PG19 validates the
+		 * tranche ID in LWLockInitialize).
+		 */
+		tp_init_tranche_ids();
+#endif
+
+		/*
+		 * Initialize the registry lock using a fixed tranche ID.
 		 * Using a fixed ID avoids exhausting tranche IDs when creating many
 		 * indexes (e.g., partitioned tables with 500+ partitions).
 		 */
-		LWLockInitialize(&tapir_registry->lock, TP_TRANCHE_REGISTRY);
+		LWLockInitialize(
+				&tapir_registry->lock, tp_tranche_id(TP_TRANCHE_REGISTRY));
 
 		/*
 		 * In-memory memtable cache fields.  eviction_mutex
@@ -158,7 +213,8 @@ tp_registry_shmem_startup(void)
 		 * docs/memtable_cache.md §"Memory cap (3 tiers)".
 		 */
 		LWLockInitialize(
-				&tapir_registry->eviction_mutex, TP_TRANCHE_EVICTION_MUTEX);
+				&tapir_registry->eviction_mutex,
+				tp_tranche_id(TP_TRANCHE_EVICTION_MUTEX));
 		pg_atomic_init_u64(&tapir_registry->estimated_total_bytes, 0);
 
 		/* Initialize handles as invalid - DSA/dshash created on first use */
@@ -168,10 +224,17 @@ tp_registry_shmem_startup(void)
 
 	LWLockRelease(AddinShmemInitLock);
 
-	/* Register the lock tranches */
+#if PG_VERSION_NUM < 190000
+	/*
+	 * Register the lock tranche names.  On PG19+ the names are supplied
+	 * to LWLockNewTrancheId() at allocation time (see
+	 * tp_init_tranche_ids()) and LWLockRegisterTranche() no longer
+	 * exists.
+	 */
 	LWLockRegisterTranche(tapir_registry->lock.tranche, "tapir_registry");
 	LWLockRegisterTranche(
 			tapir_registry->eviction_mutex.tranche, "tapir_cache_eviction");
+#endif
 }
 
 /*
@@ -209,7 +272,7 @@ tp_registry_get_dsa(void)
 		 * exhausting tranche IDs when creating many indexes (e.g.,
 		 * partitioned tables with 500+ partitions).
 		 */
-		tapir_dsa = dsa_create(TP_TRANCHE_GLOBAL_DSA);
+		tapir_dsa = dsa_create(tp_tranche_id(TP_TRANCHE_GLOBAL_DSA));
 		MemoryContextSwitchTo(oldcontext);
 
 		if (tapir_dsa == NULL)

--- a/src/index/registry.c
+++ b/src/index/registry.c
@@ -34,6 +34,46 @@ static TpGlobalRegistry *tapir_registry = NULL;
 /* Backend-local DSA area pointer */
 static dsa_area *tapir_dsa = NULL;
 
+/*
+ * Wait-event name for each fixed tranche constant, keyed by the
+ * constant itself so the table cannot silently drift if a TP_TRANCHE_*
+ * value is added, removed or renumbered in constants.h.  Each name
+ * mirrors its constant so the two read the same way in
+ * pg_stat_activity.wait_event.
+ */
+#define TP_TRANCHE_SLOT(name) [TP_TRANCHE_##name - TP_TRANCHE_FIRST]
+
+static const char *const tp_tranche_names[TP_TRANCHE_COUNT] = {
+		TP_TRANCHE_SLOT(STRING)			  = "tapir_string",
+		TP_TRANCHE_SLOT(POSTING)		  = "tapir_posting",
+		TP_TRANCHE_SLOT(CORPUS)			  = "tapir_corpus",
+		TP_TRANCHE_SLOT(DOC_LENGTHS)	  = "tapir_doc_lengths",
+		TP_TRANCHE_SLOT(INDEX_LOCK)		  = "tapir_index_lock",
+		TP_TRANCHE_SLOT(BUILD_DSA)		  = "tapir_build_dsa",
+		TP_TRANCHE_SLOT(GLOBAL_DSA)		  = "tapir_global_dsa",
+		TP_TRANCHE_SLOT(REGISTRY)		  = "tapir_registry",
+		TP_TRANCHE_SLOT(POSTING_LOCK)	  = "tapir_posting_lock",
+		TP_TRANCHE_SLOT(CACHE_APPLY_LOCK) = "tapir_cache_apply_lock",
+		TP_TRANCHE_SLOT(CACHE_LOCK)		  = "tapir_cache_lock",
+		TP_TRANCHE_SLOT(EVICTION_MUTEX)	  = "tapir_eviction_mutex",
+};
+
+#undef TP_TRANCHE_SLOT
+
+/*
+ * Name of a fixed tranche constant, or a placeholder if constants.h
+ * grew an entry that was never named above (which would otherwise leave
+ * a NULL in the table).
+ */
+static const char *
+tp_tranche_name(int fixed_tranche_id)
+{
+	const char *name = tp_tranche_names[fixed_tranche_id - TP_TRANCHE_FIRST];
+
+	Assert(name != NULL);
+	return name != NULL ? name : "tapir_unnamed";
+}
+
 #if PG_VERSION_NUM >= 190000
 /*
  * PG19+ removed LWLockRegisterTranche(); tranche names can only be
@@ -45,23 +85,9 @@ static dsa_area *tapir_dsa = NULL;
 static void
 tp_init_tranche_ids(void)
 {
-	static const char *const tranche_names[TP_TRANCHE_COUNT] = {
-			"tapir_string_hash",	  /* TP_TRANCHE_STRING */
-			"tapir_posting",		  /* TP_TRANCHE_POSTING (reserved) */
-			"tapir_corpus",			  /* TP_TRANCHE_CORPUS (reserved) */
-			"tapir_doclength_hash",	  /* TP_TRANCHE_DOC_LENGTHS */
-			"tapir_index_lock",		  /* TP_TRANCHE_INDEX_LOCK */
-			"tapir_build_dsa",		  /* TP_TRANCHE_BUILD_DSA */
-			"tapir_global_dsa",		  /* TP_TRANCHE_GLOBAL_DSA */
-			"tapir_registry",		  /* TP_TRANCHE_REGISTRY */
-			"tapir_posting_lock",	  /* TP_TRANCHE_POSTING_LOCK */
-			"tapir_cache_apply_lock", /* TP_TRANCHE_CACHE_APPLY_LOCK */
-			"tapir_cache_lock",		  /* TP_TRANCHE_CACHE_LOCK */
-			"tapir_cache_eviction",	  /* TP_TRANCHE_EVICTION_MUTEX */
-	};
-
 	for (int i = 0; i < TP_TRANCHE_COUNT; i++)
-		tapir_registry->tranche_ids[i] = LWLockNewTrancheId(tranche_names[i]);
+		tapir_registry->tranche_ids[i] = LWLockNewTrancheId(
+				tp_tranche_name(TP_TRANCHE_FIRST + i));
 }
 
 /*
@@ -76,6 +102,18 @@ tp_tranche_id(int fixed_tranche_id)
 	Assert(tapir_registry != NULL);
 	Assert(idx >= 0 && idx < TP_TRANCHE_COUNT);
 	return tapir_registry->tranche_ids[idx];
+}
+#else
+/*
+ * PG17/18: the fixed IDs are used as-is, so the names just have to be
+ * registered in every backend that may report a wait event on them.
+ */
+static void
+tp_register_tranche_names(void)
+{
+	for (int i = 0; i < TP_TRANCHE_COUNT; i++)
+		LWLockRegisterTranche(
+				TP_TRANCHE_FIRST + i, tp_tranche_name(TP_TRANCHE_FIRST + i));
 }
 #endif
 
@@ -226,14 +264,12 @@ tp_registry_shmem_startup(void)
 
 #if PG_VERSION_NUM < 190000
 	/*
-	 * Register the lock tranche names.  On PG19+ the names are supplied
-	 * to LWLockNewTrancheId() at allocation time (see
-	 * tp_init_tranche_ids()) and LWLockRegisterTranche() no longer
+	 * Register the lock tranche names in this backend.  On PG19+ the
+	 * names are supplied to LWLockNewTrancheId() at allocation time
+	 * (see tp_init_tranche_ids()) and LWLockRegisterTranche() no longer
 	 * exists.
 	 */
-	LWLockRegisterTranche(tapir_registry->lock.tranche, "tapir_registry");
-	LWLockRegisterTranche(
-			tapir_registry->eviction_mutex.tranche, "tapir_cache_eviction");
+	tp_register_tranche_names();
 #endif
 }
 

--- a/src/index/registry.h
+++ b/src/index/registry.h
@@ -58,6 +58,14 @@ typedef struct TpGlobalRegistry
 	dshash_table_handle registry_handle; /* Handle for the registry dshash */
 	LWLock				eviction_mutex;	 /* Serializes cache eviction */
 	pg_atomic_uint64	estimated_total_bytes; /* Σ per-index est bytes */
+	/*
+	 * PG19+: runtime LWLock tranche IDs, one per fixed TP_TRANCHE_*
+	 * constant, allocated once via LWLockNewTrancheId() at shmem startup
+	 * (LWLockRegisterTranche() no longer exists).  Indexed by
+	 * (fixed_id - TP_TRANCHE_FIRST); see tp_tranche_id().  Unused on
+	 * PG17/18, where fixed IDs are used directly.
+	 */
+	int tranche_ids[TP_TRANCHE_COUNT];
 } TpGlobalRegistry;
 
 /* Registry management functions */

--- a/src/index/state.c
+++ b/src/index/state.c
@@ -365,7 +365,8 @@ tp_create_shared_index_state(Oid index_oid, Oid heap_oid, bool reuse_if_exists)
 	 * Same tranche choices as tp_create_build_index_state for
 	 * consistency.
 	 */
-	LWLockInitialize(&shared_state->lock, TP_TRANCHE_INDEX_LOCK);
+	LWLockInitialize(
+			&shared_state->lock, tp_tranche_id(TP_TRANCHE_INDEX_LOCK));
 	pg_atomic_init_u64(&shared_state->spill_generation, 0);
 	memtable_dp = dsa_allocate(dsa, sizeof(TpMemtable));
 	if (!DsaPointerIsValid(memtable_dp))
@@ -374,8 +375,9 @@ tp_create_shared_index_state(Oid index_oid, Oid heap_oid, bool reuse_if_exists)
 	memtable = (TpMemtable *)dsa_get_address(dsa, memtable_dp);
 	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
 	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(&memtable->apply_lock, TP_TRANCHE_CACHE_APPLY_LOCK);
-	LWLockInitialize(&memtable->lock, TP_TRANCHE_CACHE_LOCK);
+	LWLockInitialize(
+			&memtable->apply_lock, tp_tranche_id(TP_TRANCHE_CACHE_APPLY_LOCK));
+	LWLockInitialize(&memtable->lock, tp_tranche_id(TP_TRANCHE_CACHE_LOCK));
 	memtable->cursor_gen_spill_count = 0;
 	memtable->cursor_next_blkno		 = InvalidBlockNumber;
 	memtable->cursor_next_off		 = 0;
@@ -516,7 +518,8 @@ tp_create_build_index_state(Oid index_oid, Oid heap_oid)
 	 * Using a fixed ID avoids exhausting tranche IDs when creating many
 	 * indexes (e.g., partitioned tables with 500+ partitions).
 	 */
-	LWLockInitialize(&shared_state->lock, TP_TRANCHE_INDEX_LOCK);
+	LWLockInitialize(
+			&shared_state->lock, tp_tranche_id(TP_TRANCHE_INDEX_LOCK));
 	pg_atomic_init_u64(&shared_state->spill_generation, 0);
 
 	/* Check if index already registered (rebuild case) */
@@ -543,7 +546,7 @@ tp_create_build_index_state(Oid index_oid, Oid heap_oid)
 	 * Use a fixed tranche ID to avoid exhausting tranche IDs when creating
 	 * many indexes (e.g., partitioned tables with 500+ partitions).
 	 */
-	private_dsa = dsa_create(TP_TRANCHE_BUILD_DSA);
+	private_dsa = dsa_create(tp_tranche_id(TP_TRANCHE_BUILD_DSA));
 	if (!private_dsa)
 		elog(ERROR, "Failed to create private DSA for index build");
 
@@ -555,8 +558,9 @@ tp_create_build_index_state(Oid index_oid, Oid heap_oid)
 	memtable = (TpMemtable *)dsa_get_address(private_dsa, memtable_dp);
 	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
 	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(&memtable->apply_lock, TP_TRANCHE_CACHE_APPLY_LOCK);
-	LWLockInitialize(&memtable->lock, TP_TRANCHE_CACHE_LOCK);
+	LWLockInitialize(
+			&memtable->apply_lock, tp_tranche_id(TP_TRANCHE_CACHE_APPLY_LOCK));
+	LWLockInitialize(&memtable->lock, tp_tranche_id(TP_TRANCHE_CACHE_LOCK));
 	memtable->cursor_gen_spill_count = 0;
 	memtable->cursor_next_blkno		 = InvalidBlockNumber;
 	memtable->cursor_next_off		 = 0;
@@ -637,8 +641,9 @@ tp_finalize_build_mode(TpLocalIndexState *local_state)
 	memtable = (TpMemtable *)dsa_get_address(global_dsa, memtable_dp);
 	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
 	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(&memtable->apply_lock, TP_TRANCHE_CACHE_APPLY_LOCK);
-	LWLockInitialize(&memtable->lock, TP_TRANCHE_CACHE_LOCK);
+	LWLockInitialize(
+			&memtable->apply_lock, tp_tranche_id(TP_TRANCHE_CACHE_APPLY_LOCK));
+	LWLockInitialize(&memtable->lock, tp_tranche_id(TP_TRANCHE_CACHE_LOCK));
 	memtable->cursor_gen_spill_count = 0;
 	memtable->cursor_next_blkno		 = InvalidBlockNumber;
 	memtable->cursor_next_off		 = 0;

--- a/src/index/state.c
+++ b/src/index/state.c
@@ -303,6 +303,32 @@ tp_get_local_index_state(Oid index_oid)
 }
 
 /*
+ * Initialize a freshly DSA-allocated TpMemtable.
+ *
+ * dsa_allocate() does NOT zero memory (reused chunks can hold
+ * garbage), so every field that requires a known initial value must be
+ * set here — in particular the two LWLocks, whose uninitialized state
+ * shows up later as a stuck spinlock (PANIC: stuck spinlock detected
+ * at LWLockWaitListLock).  All three memtable construction paths
+ * (runtime, build-mode private DSA, build-mode finalize) share this so
+ * a new field cannot be initialized in only some of them.
+ */
+static void
+tp_memtable_init(TpMemtable *memtable)
+{
+	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
+	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
+	LWLockInitialize(
+			&memtable->apply_lock, tp_tranche_id(TP_TRANCHE_CACHE_APPLY_LOCK));
+	LWLockInitialize(&memtable->lock, tp_tranche_id(TP_TRANCHE_CACHE_LOCK));
+	memtable->cursor_gen_spill_count = 0;
+	memtable->cursor_next_blkno		 = InvalidBlockNumber;
+	memtable->cursor_next_off		 = 0;
+	pg_atomic_init_u64(&memtable->cursor_seq, 0);
+	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
+}
+
+/*
  * Create a new shared index state and return local state.
  *
  * If `reuse_if_exists` is true and a registry entry for this OID
@@ -373,16 +399,7 @@ tp_create_shared_index_state(Oid index_oid, Oid heap_oid, bool reuse_if_exists)
 		elog(ERROR, "Failed to allocate memtable in DSA");
 
 	memtable = (TpMemtable *)dsa_get_address(dsa, memtable_dp);
-	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
-	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(
-			&memtable->apply_lock, tp_tranche_id(TP_TRANCHE_CACHE_APPLY_LOCK));
-	LWLockInitialize(&memtable->lock, tp_tranche_id(TP_TRANCHE_CACHE_LOCK));
-	memtable->cursor_gen_spill_count = 0;
-	memtable->cursor_next_blkno		 = InvalidBlockNumber;
-	memtable->cursor_next_off		 = 0;
-	pg_atomic_init_u64(&memtable->cursor_seq, 0);
-	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
+	tp_memtable_init(memtable);
 
 	shared_state->memtable_dp = memtable_dp;
 
@@ -556,16 +573,7 @@ tp_create_build_index_state(Oid index_oid, Oid heap_oid)
 		elog(ERROR, "Failed to allocate memtable in private DSA");
 
 	memtable = (TpMemtable *)dsa_get_address(private_dsa, memtable_dp);
-	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
-	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(
-			&memtable->apply_lock, tp_tranche_id(TP_TRANCHE_CACHE_APPLY_LOCK));
-	LWLockInitialize(&memtable->lock, tp_tranche_id(TP_TRANCHE_CACHE_LOCK));
-	memtable->cursor_gen_spill_count = 0;
-	memtable->cursor_next_blkno		 = InvalidBlockNumber;
-	memtable->cursor_next_off		 = 0;
-	pg_atomic_init_u64(&memtable->cursor_seq, 0);
-	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
+	tp_memtable_init(memtable);
 
 	/* Store memtable pointer in shared state for memtable access */
 	shared_state->memtable_dp = memtable_dp;
@@ -639,16 +647,7 @@ tp_finalize_build_mode(TpLocalIndexState *local_state)
 		elog(ERROR, "Failed to allocate memtable in global DSA");
 
 	memtable = (TpMemtable *)dsa_get_address(global_dsa, memtable_dp);
-	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
-	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(
-			&memtable->apply_lock, tp_tranche_id(TP_TRANCHE_CACHE_APPLY_LOCK));
-	LWLockInitialize(&memtable->lock, tp_tranche_id(TP_TRANCHE_CACHE_LOCK));
-	memtable->cursor_gen_spill_count = 0;
-	memtable->cursor_next_blkno		 = InvalidBlockNumber;
-	memtable->cursor_next_off		 = 0;
-	pg_atomic_init_u64(&memtable->cursor_seq, 0);
-	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
+	tp_memtable_init(memtable);
 
 	/*
 	 * Publish the new global memtable_dp and clear is_build_mode

--- a/src/memtable/cache.c
+++ b/src/memtable/cache.c
@@ -43,6 +43,7 @@
  */
 #include <postgres.h>
 
+#include <access/genam.h>
 #include <access/htup_details.h>
 #include <access/relation.h>
 #include <catalog/index.h>

--- a/src/memtable/cache_source.c
+++ b/src/memtable/cache_source.c
@@ -14,6 +14,7 @@
  */
 #include <postgres.h>
 
+#include <access/genam.h>
 #include <fmgr.h>
 #include <funcapi.h>
 #include <lib/dshash.h>

--- a/src/memtable/log.c
+++ b/src/memtable/log.c
@@ -46,6 +46,7 @@
 #include <utils/relcache.h>
 #include <utils/varlena.h>
 
+#include "compat.h"
 #include "constants.h"
 #include "index/freepage.h"
 #include "index/metapage.h"
@@ -1599,10 +1600,8 @@ bm25_memtable_chain(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, 3, "free_offset", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 4, "next_block", INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 5, "flags", INT4OID, -1, 0);
-#if PG_VERSION_NUM >= 190000
-		/* PG19 requires finalizing a hand-built TupleDesc before use. */
+		/* Hand-built TupleDescs must be finalized before use (PG19+). */
 		TupleDescFinalize(tupdesc);
-#endif
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 		funcctx->user_fctx	= state;
 
@@ -1702,10 +1701,8 @@ bm25_memtable_dead_pages(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, 2, "flags", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 3, "dead_fxid", INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 4, "n_records", INT4OID, -1, 0);
-#if PG_VERSION_NUM >= 190000
-		/* PG19 requires finalizing a hand-built TupleDesc before use. */
+		/* Hand-built TupleDescs must be finalized before use (PG19+). */
 		TupleDescFinalize(tupdesc);
-#endif
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 		funcctx->user_fctx	= state;
 

--- a/src/memtable/log.c
+++ b/src/memtable/log.c
@@ -25,10 +25,13 @@
  */
 #include <postgres.h>
 
+#include <access/genam.h>
 #include <access/generic_xlog.h>
+#include <access/htup_details.h>
 #include <access/relation.h>
 #include <access/transam.h>
 #include <catalog/index.h>
+#include <catalog/pg_type.h>
 #include <fmgr.h>
 #include <funcapi.h>
 #include <miscadmin.h>
@@ -1596,6 +1599,10 @@ bm25_memtable_chain(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, 3, "free_offset", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 4, "next_block", INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 5, "flags", INT4OID, -1, 0);
+#if PG_VERSION_NUM >= 190000
+		/* PG19 requires finalizing a hand-built TupleDesc before use. */
+		TupleDescFinalize(tupdesc);
+#endif
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 		funcctx->user_fctx	= state;
 
@@ -1695,6 +1702,10 @@ bm25_memtable_dead_pages(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, 2, "flags", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 3, "dead_fxid", INT8OID, -1, 0);
 		TupleDescInitEntry(tupdesc, 4, "n_records", INT4OID, -1, 0);
+#if PG_VERSION_NUM >= 190000
+		/* PG19 requires finalizing a hand-built TupleDesc before use. */
+		TupleDescFinalize(tupdesc);
+#endif
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 		funcctx->user_fctx	= state;
 

--- a/src/memtable/posting.c
+++ b/src/memtable/posting.c
@@ -104,7 +104,8 @@ tp_alloc_posting_list(dsa_area *dsa)
 
 	/* Initialize posting list */
 	memset(posting_list, 0, sizeof(TpPostingList));
-	LWLockInitialize(&posting_list->lock, TP_TRANCHE_POSTING_LOCK);
+	LWLockInitialize(
+			&posting_list->lock, tp_tranche_id(TP_TRANCHE_POSTING_LOCK));
 	posting_list->doc_count	 = 0;
 	posting_list->capacity	 = 0;
 	posting_list->is_sorted	 = false;
@@ -254,7 +255,7 @@ tp_doclength_table_create(dsa_area *area)
 	params.hash_function	= tp_doclength_hash_function;
 	params.compare_function = tp_doclength_compare_function;
 	params.copy_function	= tp_doclength_copy_function;
-	params.tranche_id		= TP_DOCLENGTH_HASH_TRANCHE_ID;
+	params.tranche_id		= tp_tranche_id(TP_DOCLENGTH_HASH_TRANCHE_ID);
 
 	return dshash_create(area, &params, area);
 }
@@ -272,7 +273,7 @@ tp_doclength_table_attach(dsa_area *area, dshash_table_handle handle)
 	params.hash_function	= tp_doclength_hash_function;
 	params.compare_function = tp_doclength_compare_function;
 	params.copy_function	= tp_doclength_copy_function;
-	params.tranche_id		= TP_DOCLENGTH_HASH_TRANCHE_ID;
+	params.tranche_id		= tp_tranche_id(TP_DOCLENGTH_HASH_TRANCHE_ID);
 
 	return dshash_attach(area, &params, handle, area);
 }

--- a/src/memtable/posting.h
+++ b/src/memtable/posting.h
@@ -21,6 +21,7 @@
 #include <utils/dsa.h>
 #include <utils/hsearch.h>
 
+#include "constants.h"
 #include "index/state.h"
 #include "memtable/posting_entry.h"
 
@@ -65,8 +66,8 @@ extern void tp_add_document_to_posting_list(
 		ItemPointer		   ctid,
 		int32			   frequency);
 
-/* Document length hash table tranche ID */
-#define TP_DOCLENGTH_HASH_TRANCHE_ID (LWTRANCHE_FIRST_USER_DEFINED + 1)
+/* Document length hash table tranche ID (part of the fixed block) */
+#define TP_DOCLENGTH_HASH_TRANCHE_ID TP_TRANCHE_DOC_LENGTHS
 
 /*
  * Reserve a doc-length slot for `ctid`. Returns true if newly

--- a/src/memtable/stringtable.c
+++ b/src/memtable/stringtable.c
@@ -132,7 +132,7 @@ tp_string_table_create(dsa_area *area)
 	params.hash_function	= tp_string_hash_function;
 	params.compare_function = tp_string_compare_function;
 	params.copy_function	= tp_string_copy_function;
-	params.tranche_id		= TP_STRING_HASH_TRANCHE_ID;
+	params.tranche_id		= tp_tranche_id(TP_STRING_HASH_TRANCHE_ID);
 
 	/* Create the dshash table */
 	return dshash_create(area, &params, area);
@@ -154,7 +154,7 @@ tp_string_table_attach(dsa_area *area, dshash_table_handle handle)
 	params.hash_function	= tp_string_hash_function;
 	params.compare_function = tp_string_compare_function;
 	params.copy_function	= tp_string_copy_function;
-	params.tranche_id		= TP_STRING_HASH_TRANCHE_ID;
+	params.tranche_id		= tp_tranche_id(TP_STRING_HASH_TRANCHE_ID);
 
 	/* Attach to the dshash table */
 	return dshash_attach(area, &params, handle, area);

--- a/src/memtable/stringtable.h
+++ b/src/memtable/stringtable.h
@@ -87,5 +87,5 @@ extern void tp_cache_apply_document(
 		int				   term_count,
 		int32			   doc_length);
 
-/* LWLock tranche for string table locking */
-#define TP_STRING_HASH_TRANCHE_ID LWTRANCHE_FIRST_USER_DEFINED
+/* LWLock tranche for string table locking (part of the fixed block) */
+#define TP_STRING_HASH_TRANCHE_ID TP_TRANCHE_STRING

--- a/src/planner/cost.c
+++ b/src/planner/cost.c
@@ -7,6 +7,7 @@
 #include <postgres.h>
 
 #include <access/genam.h>
+#include <limits.h>
 #include <math.h>
 #include <nodes/pathnodes.h>
 #include <optimizer/optimizer.h>

--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -1016,9 +1016,13 @@ resolve_indexes_in_query(Query *query)
  */
 static void
 tp_post_parse_analyze_hook(
-		ParseState *pstate	pg_attribute_unused(),
-		Query			   *query,
+		ParseState *pstate pg_attribute_unused(),
+		Query			  *query,
+#if PG_VERSION_NUM >= 190000
+		const JumbleState *jstate pg_attribute_unused())
+#else
 		JumbleState *jstate pg_attribute_unused())
+#endif
 {
 	/* Reset flag for this query - will be set if BM25 operators found */
 	query_has_bm25_operators = false;
@@ -1911,13 +1915,26 @@ validate_explicit_index_usage(Plan *plan, BM25OidCache *oids)
  *
  * We set up the planning context BEFORE calling standard_planner so that
  * set_rel_pathlist_hook can filter out unwanted BM25 index paths.
+ *
+ * PG19 added a trailing ExplainState *es parameter to planner_hook,
+ * standard_planner() and prev planner hooks.  These macros splice that
+ * parameter into the signature and the pass-through calls only when
+ * building against PG19+.
  */
+#if PG_VERSION_NUM >= 190000
+#define TP_PLANNER_HOOK_DECL_EXTRA , ExplainState *es
+#define TP_PLANNER_HOOK_PASS_EXTRA , es
+#else
+#define TP_PLANNER_HOOK_DECL_EXTRA
+#define TP_PLANNER_HOOK_PASS_EXTRA
+#endif
+
 static PlannedStmt *
 tp_planner_hook(
-		Query		 *parse,
-		const char	 *query_string,
-		int			  cursorOptions,
-		ParamListInfo boundParams)
+		Query					 *parse,
+		const char				 *query_string,
+		int						  cursorOptions,
+		ParamListInfo boundParams TP_PLANNER_HOOK_DECL_EXTRA)
 {
 	PlannedStmt		*result;
 	BM25OidCache	 oid_cache;
@@ -1930,10 +1947,16 @@ tp_planner_hook(
 	{
 		if (prev_planner_hook)
 			return prev_planner_hook(
-					parse, query_string, cursorOptions, boundParams);
+					parse,
+					query_string,
+					cursorOptions,
+					boundParams TP_PLANNER_HOOK_PASS_EXTRA);
 		else
 			return standard_planner(
-					parse, query_string, cursorOptions, boundParams);
+					parse,
+					query_string,
+					cursorOptions,
+					boundParams TP_PLANNER_HOOK_PASS_EXTRA);
 	}
 
 	/*
@@ -1966,10 +1989,16 @@ tp_planner_hook(
 	{
 		if (prev_planner_hook)
 			result = prev_planner_hook(
-					parse, query_string, cursorOptions, boundParams);
+					parse,
+					query_string,
+					cursorOptions,
+					boundParams TP_PLANNER_HOOK_PASS_EXTRA);
 		else
 			result = standard_planner(
-					parse, query_string, cursorOptions, boundParams);
+					parse,
+					query_string,
+					cursorOptions,
+					boundParams TP_PLANNER_HOOK_PASS_EXTRA);
 	}
 	PG_FINALLY();
 	{

--- a/src/planner/hooks.c
+++ b/src/planner/hooks.c
@@ -44,6 +44,7 @@
 #include <utils/rel.h>
 #include <utils/syscache.h>
 
+#include "compat.h"
 #include "planner/hooks.h"
 #include "scoring/bm25.h"
 #include "types/query.h"
@@ -1016,13 +1017,9 @@ resolve_indexes_in_query(Query *query)
  */
 static void
 tp_post_parse_analyze_hook(
-		ParseState *pstate pg_attribute_unused(),
-		Query			  *query,
-#if PG_VERSION_NUM >= 190000
-		const JumbleState *jstate pg_attribute_unused())
-#else
-		JumbleState *jstate pg_attribute_unused())
-#endif
+		ParseState *pstate		pg_attribute_unused(),
+		Query				   *query,
+		TP_JUMBLE_STATE *jstate pg_attribute_unused())
 {
 	/* Reset flag for this query - will be set if BM25 operators found */
 	query_has_bm25_operators = false;

--- a/src/types/vector.c
+++ b/src/types/vector.c
@@ -180,7 +180,7 @@ tpvector_validate_v2(TpVector *v)
 	if (VARSIZE(v) < sizeof(TpVector))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
-				 errmsg("v2 bm25vector too small: %u", VARSIZE(v))));
+				 errmsg("v2 bm25vector too small: %zu", (Size)VARSIZE(v))));
 
 	if (v->version != TPVECTOR_VERSION)
 		ereport(ERROR,


### PR DESCRIPTION
## Summary

Adds best-effort PostgreSQL 19 beta support. PG17 and PG18 remain
required-green; PG19 is exercised as an experimental allow-failure target.

## Compatibility changes

- Allocate one contiguous, named LWLock tranche block at shared-memory startup
  on PG19 and resolve the extension's tranche constants through
  `tp_tranche_id()`. On PG17/18 the helper remains an identity operation.
- Add version-compatible handling for the planner and post-parse hooks,
  `TupleDescFinalize()`, and `table_beginscan_tidrange()`.
- Update explicit header dependencies and the widened `VARSIZE()` formatting.
- Keep tranche naming and memtable initialization centralized so behavior
  remains consistent across supported PostgreSQL versions.

## CI and testing

- PG19 beta is source-built with GCC and Clang in a dedicated
  `continue-on-error` job; release, packaging, upgrade, sanitizer, and
  Coverity workflows remain on PG17/18 until PG19 reaches GA.
- Verified with clean `-Werror` builds and all 75 SQL regression tests on
  PostgreSQL 19 beta and PostgreSQL 18.
- `make format-check` passes.
