### PR TITLE
test: make reclaim-dependent assertions horizon-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,17 @@ jobs:
           echo "✗ WAL audit tests failed"
           exit 1
         fi
+        # Reruns the SQL suite against a primary whose reclaim horizon is
+        # pinned by a hot-standby-feedback standby. Catches assertions on
+        # counts taken after DELETE/VACUUM/REINDEX that a single-node
+        # installcheck cannot, since it never pins the horizon.
+        echo "Running pinned-horizon regression tests..."
+        if (cd test/scripts && ./pinned_horizon.sh); then
+          echo "✓ Pinned-horizon tests passed"
+        else
+          echo "✗ Pinned-horizon tests failed"
+          exit 1
+        fi
 
         # hypertable.sh needs a PostgreSQL instance with TimescaleDB preloaded
         echo "Running hypertable tests..."

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,16 @@ test-reindex:
 	@echo "Running multi-backend reindex regression tests (issue #390)..."
 	@cd test/scripts && ./multi_backend_reindex.sh
 
-test-shell: test-concurrency test-recovery test-segment test-cic test-multi-index test-reindex
+test-pinned-horizon:
+	@echo "Running pinned-horizon regression tests..."
+	@cd test/scripts && ./pinned_horizon.sh
+
+# Print the REGRESS list so shell tests can drive pg_regress without
+# duplicating it.
+print-regress:
+	@echo $(REGRESS)
+
+test-shell: test-concurrency test-recovery test-segment test-cic test-multi-index test-reindex test-pinned-horizon
 	@echo "All shell-based tests completed"
 
 test-all: test test-shell
@@ -377,4 +386,4 @@ help:
 	@echo "  make test-all"
 	@echo "  make format"
 
-.PHONY: test clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help
+.PHONY: test clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-pinned-horizon print-regress test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help

--- a/test/expected/catalog_stats.out
+++ b/test/expected/catalog_stats.out
@@ -1,21 +1,6 @@
 -- Test that BM25 indexes report correct catalog statistics
 -- (pg_class.reltuples, pg_class.relpages, pg_stat_user_indexes)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
--- True when the reclaim horizon may be pinned, leaving deleted tuples
--- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
-CREATE FUNCTION horizon_pinned() RETURNS boolean
-LANGUAGE sql STABLE AS $$
-    SELECT EXISTS (
-               SELECT 1
-               FROM pg_stat_activity
-               WHERE pid <> pg_backend_pid()
-                 AND backend_xmin IS NOT NULL
-                 AND (datname = current_database()
-                      OR backend_type = 'walsender')
-           )
-        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
-        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
-$$;
 -- ============================================================
 -- heap_tuples vs index_tuples for partial indexes
 --
@@ -209,16 +194,19 @@ NOTICE:  BM25 index build started for relation stats_vacuum_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 100 documents, avg_length=3.00
--- Latch: the horizon may unpin partway through the window below.
-CREATE TEMP TABLE stats_vacuum_horizon AS SELECT horizon_pinned() AS pinned;
+-- A core btree over the same rows acts as the oracle.  One VACUUM
+-- processes every index on the table under a single reclaim horizon, so
+-- bm25's reltuples must equal btree's exactly.  The absolute counts move
+-- when the horizon is pinned -- deleted tuples stay RECENTLY_DEAD and
+-- must remain indexed -- but this equality does not.
+CREATE INDEX stats_vacuum_btree ON stats_vacuum (content);
 -- Delete half the rows and vacuum
 DELETE FROM stats_vacuum WHERE id > 50;
-UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
--- Index reltuples should reflect roughly 50 after vacuum.
-SELECT (SELECT pinned FROM stats_vacuum_horizon)
-       OR reltuples BETWEEN 40 AND 60 AS index_tuples_after_vacuum
-FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_after_vacuum
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_vacuum_idx'::regclass
+  AND btree.oid = 'stats_vacuum_btree'::regclass;
  index_tuples_after_vacuum 
 ---------------------------
  t
@@ -229,11 +217,11 @@ FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 -- this-round deaths would leave reltuples stuck at the first
 -- round's value).
 DELETE FROM stats_vacuum WHERE id > 25;
-UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
-SELECT (SELECT pinned FROM stats_vacuum_horizon)
-       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
-FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_after_second_vacuum
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_vacuum_idx'::regclass
+  AND btree.oid = 'stats_vacuum_btree'::regclass;
  index_tuples_after_second_vacuum 
 ----------------------------------
  t
@@ -241,11 +229,11 @@ FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 
 -- No-deletes maintenance round; reltuples must stay at the live
 -- count, not reset to the cumulative insert count.
-UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
-SELECT (SELECT pinned FROM stats_vacuum_horizon)
-       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
-FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_after_noop_vacuum
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_vacuum_idx'::regclass
+  AND btree.oid = 'stats_vacuum_btree'::regclass;
  index_tuples_after_noop_vacuum 
 --------------------------------
  t
@@ -271,15 +259,16 @@ NOTICE:  BM25 index build started for relation stats_reindex_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 30 documents, avg_length=3.00
--- Latch across the delete/REINDEX window.
-CREATE TEMP TABLE stats_reindex_horizon AS SELECT horizon_pinned() AS pinned;
+-- Same oracle, with an identical predicate.  REINDEX TABLE rebuilds
+-- both in one command.
+CREATE INDEX stats_reindex_btree ON stats_reindex (content)
+    WHERE category = 'tech';
 -- Delete some matching rows
 DELETE FROM stats_reindex WHERE category = 'tech' AND id > 20;
-UPDATE stats_reindex_horizon SET pinned = pinned OR horizon_pinned();
 -- The build NOTICE reports the document count, which varies with the
 -- horizon.  Silence it; the count is asserted below instead.
 SET client_min_messages = warning;
-REINDEX INDEX stats_reindex_idx;
+REINDEX TABLE stats_reindex;
 RESET client_min_messages;
 -- heap reltuples should still be ~90; core excludes recently-dead here,
 -- so this is horizon-independent.
@@ -290,18 +279,14 @@ FROM pg_class WHERE oid = 'stats_reindex'::regclass;
  t
 (1 row)
 
--- index reltuples should reflect ~20 remaining tech rows.
-SELECT (SELECT pinned FROM stats_reindex_horizon)
-       OR reltuples BETWEEN 15 AND 25 AS index_tuples_ok
-FROM pg_class WHERE oid = 'stats_reindex_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_ok
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_reindex_idx'::regclass
+  AND btree.oid = 'stats_reindex_btree'::regclass;
  index_tuples_ok 
 -----------------
  t
 (1 row)
 
 DROP TABLE stats_reindex CASCADE;
--- ============================================================
--- Cleanup
--- ============================================================
-DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/catalog_stats.out
+++ b/test/expected/catalog_stats.out
@@ -1,6 +1,21 @@
 -- Test that BM25 indexes report correct catalog statistics
 -- (pg_class.reltuples, pg_class.relpages, pg_stat_user_indexes)
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+-- True when the reclaim horizon may be pinned, leaving deleted tuples
+-- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
+$$;
 -- ============================================================
 -- heap_tuples vs index_tuples for partial indexes
 --
@@ -194,11 +209,15 @@ NOTICE:  BM25 index build started for relation stats_vacuum_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 100 documents, avg_length=3.00
+-- Latch: the horizon may unpin partway through the window below.
+CREATE TEMP TABLE stats_vacuum_horizon AS SELECT horizon_pinned() AS pinned;
 -- Delete half the rows and vacuum
 DELETE FROM stats_vacuum WHERE id > 50;
+UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
--- Index reltuples should reflect roughly 50 after vacuum
-SELECT reltuples BETWEEN 40 AND 60 AS index_tuples_after_vacuum
+-- Index reltuples should reflect roughly 50 after vacuum.
+SELECT (SELECT pinned FROM stats_vacuum_horizon)
+       OR reltuples BETWEEN 40 AND 60 AS index_tuples_after_vacuum
 FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
  index_tuples_after_vacuum 
 ---------------------------
@@ -210,8 +229,10 @@ FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 -- this-round deaths would leave reltuples stuck at the first
 -- round's value).
 DELETE FROM stats_vacuum WHERE id > 25;
+UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
-SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
+SELECT (SELECT pinned FROM stats_vacuum_horizon)
+       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
 FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
  index_tuples_after_second_vacuum 
 ----------------------------------
@@ -220,8 +241,10 @@ FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 
 -- No-deletes maintenance round; reltuples must stay at the live
 -- count, not reset to the cumulative insert count.
+UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
-SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
+SELECT (SELECT pinned FROM stats_vacuum_horizon)
+       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
 FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
  index_tuples_after_noop_vacuum 
 --------------------------------
@@ -248,14 +271,18 @@ NOTICE:  BM25 index build started for relation stats_reindex_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 30 documents, avg_length=3.00
+-- Latch across the delete/REINDEX window.
+CREATE TEMP TABLE stats_reindex_horizon AS SELECT horizon_pinned() AS pinned;
 -- Delete some matching rows
 DELETE FROM stats_reindex WHERE category = 'tech' AND id > 20;
+UPDATE stats_reindex_horizon SET pinned = pinned OR horizon_pinned();
+-- The build NOTICE reports the document count, which varies with the
+-- horizon.  Silence it; the count is asserted below instead.
+SET client_min_messages = warning;
 REINDEX INDEX stats_reindex_idx;
-NOTICE:  BM25 index build started for relation stats_reindex_idx
-NOTICE:  Using text search configuration: english
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 20 documents, avg_length=3.00
--- heap reltuples should still be ~90 (100 - 10 deleted)
+RESET client_min_messages;
+-- heap reltuples should still be ~90; core excludes recently-dead here,
+-- so this is horizon-independent.
 SELECT reltuples >= 80 AS heap_tuples_ok
 FROM pg_class WHERE oid = 'stats_reindex'::regclass;
  heap_tuples_ok 
@@ -263,8 +290,9 @@ FROM pg_class WHERE oid = 'stats_reindex'::regclass;
  t
 (1 row)
 
--- index reltuples should reflect ~20 remaining tech rows
-SELECT reltuples BETWEEN 15 AND 25 AS index_tuples_ok
+-- index reltuples should reflect ~20 remaining tech rows.
+SELECT (SELECT pinned FROM stats_reindex_horizon)
+       OR reltuples BETWEEN 15 AND 25 AS index_tuples_ok
 FROM pg_class WHERE oid = 'stats_reindex_idx'::regclass;
  index_tuples_ok 
 -----------------
@@ -275,4 +303,5 @@ DROP TABLE stats_reindex CASCADE;
 -- ============================================================
 -- Cleanup
 -- ============================================================
+DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -4,18 +4,29 @@
 -- chain grows again (main fork should not grow by ~one block per dead
 -- page if reuse works).
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
--- True when another same-database client backend holds an xmin, which
--- pins the reclaim horizon back and can defer FSM reclaim.
-CREATE FUNCTION other_backend_holds_xmin() RETURNS boolean
+-- True when the cluster's reclaim horizon may be pinned, which defers FSM
+-- reclaim.  GetOldestNonRemovableTransactionId() is held back by anything
+-- ComputeXidHorizons() folds into data_oldest_nonremovable (procarray.c):
+-- an xmin-holding backend in our database, a backend flagged
+-- PROC_AFFECTS_ALL_HORIZONS, a replication slot xmin, or a prepared xact.
+-- A standby with hot_standby_feedback = on publishes its xmin through the
+-- slot, not pg_stat_activity, so checking only client backends misses it.
+-- While pinned, deleted tuples stay HEAPTUPLE_RECENTLY_DEAD: VACUUM must
+-- retain them, and index builds must still index them to preserve MVCC.
+-- Counts taken after a DELETE are then meaningless, so dependent
+-- assertions are skipped rather than relaxed.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
 LANGUAGE sql STABLE AS $$
     SELECT EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
 $$;
 CREATE TABLE memtable_reclaim_t (id serial PRIMARY KEY, body text);
 CREATE INDEX memtable_reclaim_idx ON memtable_reclaim_t
@@ -78,19 +89,19 @@ CREATE TEMP TABLE reclaim_sizes AS
 SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
        AS sz_after_spill;
 CREATE TEMP TABLE reclaim_blocker_state (
-    blocked_by_other_backend bool
+    pinned bool
 );
-INSERT INTO reclaim_blocker_state (blocked_by_other_backend)
+INSERT INTO reclaim_blocker_state (pinned)
 SELECT false;
 -- Horizon: spill xact is committed (autocommit per statement).
 UPDATE reclaim_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 UPDATE reclaim_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
     SELECT 1 FROM memtable_reclaim_t
@@ -119,7 +130,7 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 -- is legitimately deferred, so skip the check rather than relax it.
 SELECT
     CASE
-        WHEN (SELECT blocked_by_other_backend FROM reclaim_blocker_state)
+        WHEN (SELECT pinned FROM reclaim_blocker_state)
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_after_spill FROM reclaim_sizes)) = 0
@@ -145,9 +156,9 @@ SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
        0,
        5;
 CREATE TEMP TABLE multi_cycle_blocker_state (
-    blocked_by_other_backend bool
+    pinned bool
 );
-INSERT INTO multi_cycle_blocker_state (blocked_by_other_backend)
+INSERT INTO multi_cycle_blocker_state (pinned)
 SELECT false;
 -- Cycle 1
 INSERT INTO memtable_reclaim_t (body)
@@ -163,8 +174,8 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
 (1 row)
 
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 2
 INSERT INTO memtable_reclaim_t (body)
@@ -180,8 +191,8 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
 (1 row)
 
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 3
 INSERT INTO memtable_reclaim_t (body)
@@ -197,8 +208,8 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
 (1 row)
 
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 4
 INSERT INTO memtable_reclaim_t (body)
@@ -214,8 +225,8 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
 (1 row)
 
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 -- Cycle 5
 INSERT INTO memtable_reclaim_t (body)
@@ -231,8 +242,8 @@ SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 (1 row)
 
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
 FROM multi_cycle_bounds;
@@ -246,7 +257,7 @@ FROM multi_cycle_bounds;
 -- horizon.
 SELECT
     CASE
-        WHEN (SELECT blocked_by_other_backend FROM multi_cycle_blocker_state)
+        WHEN (SELECT pinned FROM multi_cycle_blocker_state)
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_start FROM multi_cycle_bounds))
@@ -259,6 +270,6 @@ SELECT
  t
 (1 row)
 
-DROP FUNCTION other_backend_holds_xmin();
+DROP FUNCTION horizon_pinned();
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/memtable_reclaim.out
+++ b/test/expected/memtable_reclaim.out
@@ -15,6 +15,12 @@ CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 -- retain them, and index builds must still index them to preserve MVCC.
 -- Counts taken after a DELETE are then meaningless, so dependent
 -- assertions are skipped rather than relaxed.
+--
+-- FSM reclaim is horizon-defined, so there is no horizon-independent way
+-- to assert it (contrast catalog_stats.sql, which compares against a core
+-- btree instead).  The pin is sampled both before the operation, into a
+-- latch, and again inline in the assertion, so a pin appearing or
+-- clearing mid-window is still caught.
 CREATE FUNCTION horizon_pinned() RETURNS boolean
 LANGUAGE sql STABLE AS $$
     SELECT EXISTS (
@@ -130,7 +136,7 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 -- is legitimately deferred, so skip the check rather than relax it.
 SELECT
     CASE
-        WHEN (SELECT pinned FROM reclaim_blocker_state)
+        WHEN (SELECT pinned FROM reclaim_blocker_state) OR horizon_pinned()
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_after_spill FROM reclaim_sizes)) = 0
@@ -257,7 +263,7 @@ FROM multi_cycle_bounds;
 -- horizon.
 SELECT
     CASE
-        WHEN (SELECT pinned FROM multi_cycle_blocker_state)
+        WHEN (SELECT pinned FROM multi_cycle_blocker_state) OR horizon_pinned()
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_start FROM multi_cycle_bounds))

--- a/test/expected/segment_reclaim.out
+++ b/test/expected/segment_reclaim.out
@@ -22,6 +22,9 @@ LANGUAGE sql STABLE AS $$
         OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
         OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
 $$;
+-- Deferred reclaim is horizon-defined, so it cannot be asserted without
+-- reference to the horizon.  Latch the pin before each operation and
+-- sample it again inline in the assertion; see memtable_reclaim.sql.
 CREATE TEMP TABLE reclaim_horizon AS SELECT horizon_pinned() AS pinned;
 CREATE TABLE reclaim_docs (id int, body text)
     WITH (autovacuum_enabled = false);
@@ -77,7 +80,8 @@ SELECT txid_current() IS NOT NULL AS t2;
 UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
 -- All parked pages reclaimed (skipped while the horizon is pinned).
-SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon)
+                 OR horizon_pinned() THEN 0
             ELSE bm25_pending_free_pages('reclaim_idx') END
     AS parked_after_vacuum;
  parked_after_vacuum 
@@ -116,7 +120,7 @@ SELECT bm25_spill_index('reclaim_idx') > 0 AS reuse_spilled;
  t
 (1 row)
 
-SELECT (SELECT pinned FROM reclaim_horizon)
+SELECT (SELECT pinned FROM reclaim_horizon) OR horizon_pinned()
        OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
           <= :blocks_before_reuse AS reused_freed_pages_no_extension;
  reused_freed_pages_no_extension 
@@ -165,7 +169,8 @@ t
 (1 row)
 UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon)
+                 OR horizon_pinned() THEN 0
             ELSE bm25_pending_free_pages('reclaim_idx') END
     AS pool_after_vacuum;
 pool_after_vacuum
@@ -183,7 +188,7 @@ SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
 DELETE FROM reclaim_docs WHERE id BETWEEN 3001 AND 3020;
 UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT (SELECT pinned FROM reclaim_horizon)
+SELECT (SELECT pinned FROM reclaim_horizon) OR horizon_pinned()
        OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
           > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
 vacuum_tombstone_extended
@@ -205,7 +210,8 @@ t
 (1 row)
 UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon)
+                 OR horizon_pinned() THEN 0
             ELSE bm25_pending_free_pages('reclaim_idx') END
     AS parked_after_vacuum_drain;
 parked_after_vacuum_drain
@@ -222,7 +228,7 @@ SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
 vacuum_reuse_spilled
 t
 (1 row)
-SELECT (SELECT pinned FROM reclaim_horizon)
+SELECT (SELECT pinned FROM reclaim_horizon) OR horizon_pinned()
        OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
           <= :blocks_before_vacuum_reuse
     AS vacuum_reused_freed_pages_no_extension;

--- a/test/expected/segment_reclaim.out
+++ b/test/expected/segment_reclaim.out
@@ -6,6 +6,23 @@
 -- autovacuum is disabled on the table so the only drain is the explicit
 -- VACUUM below, keeping the parked-page observations deterministic.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+-- The txid_current() calls below advance the latest xid, but cannot advance
+-- the *oldest* horizon while something pins it back; deferring the drain is
+-- then the design (#380).  See memtable_reclaim.sql for the rationale.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
+$$;
+CREATE TEMP TABLE reclaim_horizon AS SELECT horizon_pinned() AS pinned;
 CREATE TABLE reclaim_docs (id int, body text)
     WITH (autovacuum_enabled = false);
 INSERT INTO reclaim_docs
@@ -57,9 +74,12 @@ SELECT txid_current() IS NOT NULL AS t2;
  t
 (1 row)
 
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
--- All parked pages reclaimed.
-SELECT bm25_pending_free_pages('reclaim_idx') AS parked_after_vacuum;
+-- All parked pages reclaimed (skipped while the horizon is pinned).
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+            ELSE bm25_pending_free_pages('reclaim_idx') END
+    AS parked_after_vacuum;
  parked_after_vacuum 
 ---------------------
                    0
@@ -96,8 +116,9 @@ SELECT bm25_spill_index('reclaim_idx') > 0 AS reuse_spilled;
  t
 (1 row)
 
-SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
-    <= :blocks_before_reuse AS reused_freed_pages_no_extension;
+SELECT (SELECT pinned FROM reclaim_horizon)
+       OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+          <= :blocks_before_reuse AS reused_freed_pages_no_extension;
  reused_freed_pages_no_extension 
 ---------------------------------
  t
@@ -142,8 +163,11 @@ SELECT txid_current() IS NOT NULL AS vp2;
 vp2
 t
 (1 row)
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT bm25_pending_free_pages('reclaim_idx') AS pool_after_vacuum;
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+            ELSE bm25_pending_free_pages('reclaim_idx') END
+    AS pool_after_vacuum;
 pool_after_vacuum
 0
 (1 row)
@@ -157,9 +181,11 @@ t
 SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
     AS blocks_before_vacuum_drop \gset
 DELETE FROM reclaim_docs WHERE id BETWEEN 3001 AND 3020;
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
-    > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
+SELECT (SELECT pinned FROM reclaim_horizon)
+       OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+          > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
 vacuum_tombstone_extended
 t
 (1 row)
@@ -177,8 +203,11 @@ SELECT txid_current() IS NOT NULL AS vt2;
 vt2
 t
 (1 row)
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT bm25_pending_free_pages('reclaim_idx') AS parked_after_vacuum_drain;
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+            ELSE bm25_pending_free_pages('reclaim_idx') END
+    AS parked_after_vacuum_drain;
 parked_after_vacuum_drain
 0
 (1 row)
@@ -193,11 +222,14 @@ SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
 vacuum_reuse_spilled
 t
 (1 row)
-SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
-    <= :blocks_before_vacuum_reuse AS vacuum_reused_freed_pages_no_extension;
+SELECT (SELECT pinned FROM reclaim_horizon)
+       OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+          <= :blocks_before_vacuum_reuse
+    AS vacuum_reused_freed_pages_no_extension;
 vacuum_reused_freed_pages_no_extension
 t
 (1 row)
 \pset format aligned
 DROP TABLE reclaim_docs;
+DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -1,21 +1,6 @@
 -- Test VACUUM behavior with BM25 indexes
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
--- True when the reclaim horizon may be pinned, leaving deleted tuples
--- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
-CREATE FUNCTION horizon_pinned() RETURNS boolean
-LANGUAGE sql STABLE AS $$
-    SELECT EXISTS (
-               SELECT 1
-               FROM pg_stat_activity
-               WHERE pid <> pg_backend_pid()
-                 AND backend_xmin IS NOT NULL
-                 AND (datname = current_database()
-                      OR backend_type = 'walsender')
-           )
-        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
-        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
-$$;
 -- Create test table
 CREATE TABLE vacuum_test (
     id SERIAL PRIMARY KEY,
@@ -88,9 +73,7 @@ LIMIT 5;
 
 -- Test VACUUM FULL (more aggressive cleanup)
 -- VACUUM FULL rebuilds indexes
-CREATE TEMP TABLE vacuum_full_horizon AS SELECT horizon_pinned() AS pinned;
 DELETE FROM vacuum_test WHERE content NOT LIKE '%test%';
-UPDATE vacuum_full_horizon SET pinned = pinned OR horizon_pinned();
 -- We use \set VERBOSITY terse to avoid OID-specific error messages
 \set VERBOSITY terse
 -- The rebuild NOTICE reports the document count, which varies with the
@@ -99,17 +82,20 @@ SET client_min_messages = warning;
 VACUUM FULL vacuum_test;
 RESET client_min_messages;
 \set VERBOSITY default
--- Check statistics after VACUUM FULL.
-SELECT CASE
-           WHEN (SELECT pinned FROM vacuum_full_horizon) THEN '1'
-           ELSE split_part(
-                    split_part(bm25_dump_index('vacuum_idx')::text,
-                               'total_docs: ', 2),
-                    E'\n', 1)
-       END AS total_docs_after_vacuum_full;
- total_docs_after_vacuum_full 
-------------------------------
- 1
+-- VACUUM FULL rewrites the heap and rebuilds every index in one
+-- command, so the bm25 doc count must match what core's primary key
+-- btree retains.  That holds whether or not the horizon is pinned; the
+-- absolute count does not, since a pinned horizon forces the rewrite to
+-- carry recently-dead tuples over.
+SELECT split_part(
+           split_part(bm25_dump_index('vacuum_idx')::text, 'total_docs: ', 2),
+           E'\n', 1)::int
+       = (SELECT reltuples::int FROM pg_class
+           WHERE oid = 'vacuum_test_pkey'::regclass)
+       AS total_docs_matches_btree;
+ total_docs_matches_btree 
+--------------------------
+ t
 (1 row)
 
 -- Verify search still works
@@ -123,5 +109,4 @@ ORDER BY content <@> to_bm25query('test', 'vacuum_idx');
 
 -- Clean up
 DROP TABLE vacuum_test;
-DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch;

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -1,6 +1,21 @@
 -- Test VACUUM behavior with BM25 indexes
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+-- True when the reclaim horizon may be pinned, leaving deleted tuples
+-- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
+$$;
 -- Create test table
 CREATE TABLE vacuum_test (
     id SERIAL PRIMARY KEY,
@@ -73,20 +88,25 @@ LIMIT 5;
 
 -- Test VACUUM FULL (more aggressive cleanup)
 -- VACUUM FULL rebuilds indexes
+CREATE TEMP TABLE vacuum_full_horizon AS SELECT horizon_pinned() AS pinned;
 DELETE FROM vacuum_test WHERE content NOT LIKE '%test%';
+UPDATE vacuum_full_horizon SET pinned = pinned OR horizon_pinned();
 -- We use \set VERBOSITY terse to avoid OID-specific error messages
 \set VERBOSITY terse
+-- The rebuild NOTICE reports the document count, which varies with the
+-- horizon (VACUUM FULL copies recently-dead tuples too).  Silence it.
+SET client_min_messages = warning;
 VACUUM FULL vacuum_test;
-NOTICE:  BM25 index build started for relation vacuum_idx
-NOTICE:  Using text search configuration: english
-NOTICE:  Using index options: k1=1.20, b=0.75
-NOTICE:  BM25 index build completed: 1 documents, avg_length=3.00
+RESET client_min_messages;
 \set VERBOSITY default
--- Check statistics after VACUUM FULL
-SELECT split_part(
-    split_part(bm25_dump_index('vacuum_idx')::text, 'total_docs: ', 2),
-    E'\n', 1
-) AS total_docs_after_vacuum_full;
+-- Check statistics after VACUUM FULL.
+SELECT CASE
+           WHEN (SELECT pinned FROM vacuum_full_horizon) THEN '1'
+           ELSE split_part(
+                    split_part(bm25_dump_index('vacuum_idx')::text,
+                               'total_docs: ', 2),
+                    E'\n', 1)
+       END AS total_docs_after_vacuum_full;
  total_docs_after_vacuum_full 
 ------------------------------
  1
@@ -103,4 +123,5 @@ ORDER BY content <@> to_bm25query('test', 'vacuum_idx');
 
 -- Clean up
 DROP TABLE vacuum_test;
+DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch;

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -121,15 +121,18 @@ VACUUM vb_reuse;
 INSERT INTO vb_reuse (content)
 SELECT 'beta keyword document ' || i
 FROM generate_series(1, 50) i;
--- alpha should return nothing
-SELECT count(*) FROM (
-    SELECT id FROM vb_reuse
+-- No alpha content may resurface, whether or not CTIDs were reused.
+-- Counting returned rows instead would be horizon-dependent, since
+-- ORDER BY ... LIMIT does not filter.
+SELECT count(*) FILTER (WHERE content LIKE 'alpha%') AS stale_alpha_rows
+FROM (
+    SELECT id, content FROM vb_reuse
     ORDER BY content <@> to_bm25query('alpha', 'vb_reuse_idx')
     LIMIT 1000
 ) q;
- count 
--------
-     0
+ stale_alpha_rows 
+------------------
+                0
 (1 row)
 
 -- beta should return results

--- a/test/scripts/pinned_horizon.sh
+++ b/test/scripts/pinned_horizon.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+#
+# pinned_horizon.sh — rerun the SQL regression suite against a primary
+# whose reclaim horizon is pinned by a hot-standby-feedback standby
+# holding an open snapshot.
+#
+# A single-node `make installcheck` never pins the horizon, so it cannot
+# catch an assertion on counts taken after a DELETE, VACUUM or REINDEX
+# that is missing a horizon_pinned() guard.  See the docblock in
+# test/sql/memtable_reclaim.sql for why those counts move.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PRIMARY_PORT=55470
+STANDBY_PORT=55471
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_pinned_horizon_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_pinned_horizon_standby"
+TEST_DB=pinned_horizon_probe
+REGRESS_DB=contrib_regression
+SLOT_NAME=pinned_horizon_slot
+
+# pg_regress runs the tests, which CREATE and DROP the extension
+# themselves, so the probe database must not have it pre-created.
+SETUP_CREATE_EXTENSION=0
+
+# shellcheck source=test/scripts/replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+main() {
+    check_required_tools
+
+    setup_primary
+
+    log "Creating physical replication slot '${SLOT_NAME}'..."
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c \
+        "SELECT pg_create_physical_replication_slot('${SLOT_NAME}');" \
+        >/dev/null || error "could not create replication slot"
+
+    setup_standby
+
+    log "Enabling hot_standby_feedback on the standby..."
+    cat >> "${STANDBY_DIR}/postgresql.conf" <<EOF
+hot_standby_feedback = on
+primary_slot_name = '${SLOT_NAME}'
+EOF
+    # Both settings are PGC_SIGHUP, so a reload is enough.
+    pg_ctl reload -D "${STANDBY_DIR}" >/dev/null ||
+        error "could not reload standby"
+
+    pin_horizon
+    assert_horizon_pinned
+    run_regression_suite
+}
+
+# Current xmin held by the standby's replication slot, if any.
+slot_xmin() {
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c \
+        "SELECT xmin::text::bigint FROM pg_replication_slots
+          WHERE slot_name = '${SLOT_NAME}';" 2>/dev/null
+}
+
+# Hold a REPEATABLE READ snapshot open on the standby for the rest of the
+# run; feedback propagates its xmin to the primary's slot.
+pin_horizon() {
+    log "Opening a long-lived standby snapshot..."
+    long_lived_open "${STANDBY_PORT}"
+    long_lived_query "BEGIN ISOLATION LEVEL REPEATABLE READ;" >/dev/null
+    # Force the snapshot to be taken and registered now.
+    long_lived_query "SELECT count(*) FROM pg_class;" >/dev/null
+
+    log "Waiting for feedback to reach the primary's slot..."
+    local waited=0
+    while [ "${waited}" -lt 60 ]; do
+        local xmin
+        xmin=$(psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c \
+            "SELECT xmin FROM pg_replication_slots
+              WHERE slot_name = '${SLOT_NAME}';" 2>/dev/null)
+        if [ -n "${xmin}" ]; then
+            log "Slot xmin is ${xmin} after ${waited}s"
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    error "standby feedback never set an xmin on the slot"
+}
+
+# Fail loudly if the horizon is not actually held back; otherwise this
+# script silently degrades into a slower duplicate of installcheck.
+assert_horizon_pinned() {
+    log "Asserting the primary's reclaim horizon is pinned..."
+
+    # Burn a couple of xids, then confirm the horizon did not follow.
+    # Comparing against the current snapshot would be wrong: the frozen
+    # xmin equals the next unassigned xid, which the first probe takes.
+    local slot_xmin_before slot_xmin_after new_xid
+    slot_xmin_before=$(slot_xmin)
+    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c \
+        "SELECT pg_current_xact_id();" >/dev/null
+    new_xid=$(psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c \
+        "SELECT pg_current_xact_id()::text::bigint;")
+    slot_xmin_after=$(slot_xmin)
+
+    if [ -z "${slot_xmin_before}" ] || [ -z "${slot_xmin_after}" ] ||
+       [ -z "${new_xid}" ]; then
+        error "could not read slot xmin / current xid"
+    fi
+    if [ "${slot_xmin_after}" != "${slot_xmin_before}" ]; then
+        error "horizon advanced from ${slot_xmin_before} to \
+${slot_xmin_after} while the standby snapshot was open"
+    fi
+    if [ "${slot_xmin_after}" -ge "${new_xid}" ]; then
+        error "slot xmin ${slot_xmin_after} does not trail new xid \
+${new_xid} -- horizon is not pinned"
+    fi
+    log "Horizon held at ${slot_xmin_after} while xids advanced to ${new_xid}."
+
+    # If horizon_pinned() stops detecting this topology, every guard
+    # silently stops working -- so assert the predicate itself.
+    local detected
+    detected=$(psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" -tA -c \
+        "SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_stat_activity
+                    WHERE pid <> pg_backend_pid()
+                      AND backend_xmin IS NOT NULL
+                      AND (datname = current_database()
+                           OR backend_type = 'walsender')
+                )
+             OR EXISTS (SELECT 1 FROM pg_replication_slots
+                         WHERE xmin IS NOT NULL)
+             OR EXISTS (SELECT 1 FROM pg_prepared_xacts);")
+    if [ "${detected}" != "t" ]; then
+        error "horizon_pinned() would return false in this pinned \
+topology -- the test guards are no longer effective"
+    fi
+
+    log "Horizon confirmed pinned and detectable."
+}
+
+run_regression_suite() {
+    local pg_regress regress_list regress_dir
+    regress_dir="$(dirname "$(pg_config --pgxs)")/../../src/test/regress"
+    pg_regress="${regress_dir}/pg_regress"
+    [ -x "${pg_regress}" ] || error "pg_regress not found at ${pg_regress}"
+
+    regress_list=$(make -C "${SRC_DIR}" -s --no-print-directory \
+        print-regress) || error "could not read REGRESS list"
+    [ -n "${regress_list}" ] || error "REGRESS list is empty"
+
+    createdb -p "${PRIMARY_PORT}" "${REGRESS_DB}" ||
+        error "could not create ${REGRESS_DB}"
+
+    log "Running regression suite against the pinned primary..."
+    # Tests include files by repo-root-relative path (\i test/sql/...),
+    # so pg_regress must run from the repo root, as installcheck does.
+    cd "${SRC_DIR}" || error "could not cd to ${SRC_DIR}"
+    # shellcheck disable=SC2086
+    if "${pg_regress}" --use-existing --host=/tmp \
+        --port="${PRIMARY_PORT}" --dbname="${REGRESS_DB}" \
+        --inputdir="${SRC_DIR}/test" --outputdir="${SRC_DIR}/test" \
+        ${regress_list}; then
+        log "All regression tests passed with the horizon pinned."
+        return 0
+    fi
+
+    warn "Regression failures under a pinned horizon."
+    warn "An assertion on counts taken after a DELETE, VACUUM or"
+    warn "REINDEX likely needs a horizon_pinned() guard; see"
+    warn "test/sql/memtable_reclaim.sql for the pattern."
+    if [ -f "${SRC_DIR}/test/regression.diffs" ]; then
+        echo "=== regression.diffs ==="
+        cat "${SRC_DIR}/test/regression.diffs"
+    fi
+    error "pinned-horizon regression run failed"
+}
+
+main "$@"

--- a/test/scripts/replication_lib.sh
+++ b/test/scripts/replication_lib.sh
@@ -202,8 +202,13 @@ EOF
     pg_ctl start -D "${PRIMARY_DIR}" \
         -l "${PRIMARY_DIR}/postgres.log" -w
     createdb -p "${PRIMARY_PORT}" "${TEST_DB}"
-    psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" \
-        -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+    # Set SETUP_CREATE_EXTENSION=0 when the caller needs a bare
+    # database -- pinned_horizon.sh hands it to pg_regress, whose
+    # tests create and drop the extension themselves.
+    if [ "${SETUP_CREATE_EXTENSION:-1}" = "1" ]; then
+        psql -p "${PRIMARY_PORT}" -d "${TEST_DB}" \
+            -c "CREATE EXTENSION pg_textsearch;" >/dev/null
+    fi
 }
 
 # Standby is built from primary via pg_basebackup. Caller must

--- a/test/sql/catalog_stats.sql
+++ b/test/sql/catalog_stats.sql
@@ -3,22 +3,6 @@
 
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 
--- True when the reclaim horizon may be pinned, leaving deleted tuples
--- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
-CREATE FUNCTION horizon_pinned() RETURNS boolean
-LANGUAGE sql STABLE AS $$
-    SELECT EXISTS (
-               SELECT 1
-               FROM pg_stat_activity
-               WHERE pid <> pg_backend_pid()
-                 AND backend_xmin IS NOT NULL
-                 AND (datname = current_database()
-                      OR backend_type = 'walsender')
-           )
-        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
-        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
-$$;
-
 -- ============================================================
 -- heap_tuples vs index_tuples for partial indexes
 --
@@ -177,39 +161,42 @@ FROM generate_series(1, 100) i;
 CREATE INDEX stats_vacuum_idx ON stats_vacuum
     USING bm25 (content) WITH (text_config='english');
 
--- Latch: the horizon may unpin partway through the window below.
-CREATE TEMP TABLE stats_vacuum_horizon AS SELECT horizon_pinned() AS pinned;
+-- A core btree over the same rows acts as the oracle.  One VACUUM
+-- processes every index on the table under a single reclaim horizon, so
+-- bm25's reltuples must equal btree's exactly.  The absolute counts move
+-- when the horizon is pinned -- deleted tuples stay RECENTLY_DEAD and
+-- must remain indexed -- but this equality does not.
+CREATE INDEX stats_vacuum_btree ON stats_vacuum (content);
 
 -- Delete half the rows and vacuum
 DELETE FROM stats_vacuum WHERE id > 50;
-UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
 
--- Index reltuples should reflect roughly 50 after vacuum.
-SELECT (SELECT pinned FROM stats_vacuum_horizon)
-       OR reltuples BETWEEN 40 AND 60 AS index_tuples_after_vacuum
-FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_after_vacuum
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_vacuum_idx'::regclass
+  AND btree.oid = 'stats_vacuum_btree'::regclass;
 
 -- Second delete + vacuum; reltuples must continue tracking the
 -- live count (regression test: reporting metap->total_docs - only
 -- this-round deaths would leave reltuples stuck at the first
 -- round's value).
 DELETE FROM stats_vacuum WHERE id > 25;
-UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
 
-SELECT (SELECT pinned FROM stats_vacuum_horizon)
-       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
-FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_after_second_vacuum
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_vacuum_idx'::regclass
+  AND btree.oid = 'stats_vacuum_btree'::regclass;
 
 -- No-deletes maintenance round; reltuples must stay at the live
 -- count, not reset to the cumulative insert count.
-UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
 
-SELECT (SELECT pinned FROM stats_vacuum_horizon)
-       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
-FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_after_noop_vacuum
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_vacuum_idx'::regclass
+  AND btree.oid = 'stats_vacuum_btree'::regclass;
 
 DROP TABLE stats_vacuum CASCADE;
 
@@ -232,17 +219,18 @@ CREATE INDEX stats_reindex_idx ON stats_reindex
     USING bm25 (content) WITH (text_config='english')
     WHERE category = 'tech';
 
--- Latch across the delete/REINDEX window.
-CREATE TEMP TABLE stats_reindex_horizon AS SELECT horizon_pinned() AS pinned;
+-- Same oracle, with an identical predicate.  REINDEX TABLE rebuilds
+-- both in one command.
+CREATE INDEX stats_reindex_btree ON stats_reindex (content)
+    WHERE category = 'tech';
 
 -- Delete some matching rows
 DELETE FROM stats_reindex WHERE category = 'tech' AND id > 20;
-UPDATE stats_reindex_horizon SET pinned = pinned OR horizon_pinned();
 
 -- The build NOTICE reports the document count, which varies with the
 -- horizon.  Silence it; the count is asserted below instead.
 SET client_min_messages = warning;
-REINDEX INDEX stats_reindex_idx;
+REINDEX TABLE stats_reindex;
 RESET client_min_messages;
 
 -- heap reltuples should still be ~90; core excludes recently-dead here,
@@ -250,17 +238,11 @@ RESET client_min_messages;
 SELECT reltuples >= 80 AS heap_tuples_ok
 FROM pg_class WHERE oid = 'stats_reindex'::regclass;
 
--- index reltuples should reflect ~20 remaining tech rows.
-SELECT (SELECT pinned FROM stats_reindex_horizon)
-       OR reltuples BETWEEN 15 AND 25 AS index_tuples_ok
-FROM pg_class WHERE oid = 'stats_reindex_idx'::regclass;
+SELECT bm25.reltuples = btree.reltuples AS index_tuples_ok
+FROM pg_class bm25, pg_class btree
+WHERE bm25.oid = 'stats_reindex_idx'::regclass
+  AND btree.oid = 'stats_reindex_btree'::regclass;
 
 DROP TABLE stats_reindex CASCADE;
-
--- ============================================================
--- Cleanup
--- ============================================================
-
-DROP FUNCTION horizon_pinned();
 
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/catalog_stats.sql
+++ b/test/sql/catalog_stats.sql
@@ -3,6 +3,22 @@
 
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 
+-- True when the reclaim horizon may be pinned, leaving deleted tuples
+-- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
+$$;
+
 -- ============================================================
 -- heap_tuples vs index_tuples for partial indexes
 --
@@ -161,12 +177,17 @@ FROM generate_series(1, 100) i;
 CREATE INDEX stats_vacuum_idx ON stats_vacuum
     USING bm25 (content) WITH (text_config='english');
 
+-- Latch: the horizon may unpin partway through the window below.
+CREATE TEMP TABLE stats_vacuum_horizon AS SELECT horizon_pinned() AS pinned;
+
 -- Delete half the rows and vacuum
 DELETE FROM stats_vacuum WHERE id > 50;
+UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
 
--- Index reltuples should reflect roughly 50 after vacuum
-SELECT reltuples BETWEEN 40 AND 60 AS index_tuples_after_vacuum
+-- Index reltuples should reflect roughly 50 after vacuum.
+SELECT (SELECT pinned FROM stats_vacuum_horizon)
+       OR reltuples BETWEEN 40 AND 60 AS index_tuples_after_vacuum
 FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 
 -- Second delete + vacuum; reltuples must continue tracking the
@@ -174,16 +195,20 @@ FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 -- this-round deaths would leave reltuples stuck at the first
 -- round's value).
 DELETE FROM stats_vacuum WHERE id > 25;
+UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
 
-SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
+SELECT (SELECT pinned FROM stats_vacuum_horizon)
+       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_second_vacuum
 FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 
 -- No-deletes maintenance round; reltuples must stay at the live
 -- count, not reset to the cumulative insert count.
+UPDATE stats_vacuum_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM stats_vacuum;
 
-SELECT reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
+SELECT (SELECT pinned FROM stats_vacuum_horizon)
+       OR reltuples BETWEEN 15 AND 35 AS index_tuples_after_noop_vacuum
 FROM pg_class WHERE oid = 'stats_vacuum_idx'::regclass;
 
 DROP TABLE stats_vacuum CASCADE;
@@ -207,17 +232,27 @@ CREATE INDEX stats_reindex_idx ON stats_reindex
     USING bm25 (content) WITH (text_config='english')
     WHERE category = 'tech';
 
+-- Latch across the delete/REINDEX window.
+CREATE TEMP TABLE stats_reindex_horizon AS SELECT horizon_pinned() AS pinned;
+
 -- Delete some matching rows
 DELETE FROM stats_reindex WHERE category = 'tech' AND id > 20;
+UPDATE stats_reindex_horizon SET pinned = pinned OR horizon_pinned();
 
+-- The build NOTICE reports the document count, which varies with the
+-- horizon.  Silence it; the count is asserted below instead.
+SET client_min_messages = warning;
 REINDEX INDEX stats_reindex_idx;
+RESET client_min_messages;
 
--- heap reltuples should still be ~90 (100 - 10 deleted)
+-- heap reltuples should still be ~90; core excludes recently-dead here,
+-- so this is horizon-independent.
 SELECT reltuples >= 80 AS heap_tuples_ok
 FROM pg_class WHERE oid = 'stats_reindex'::regclass;
 
--- index reltuples should reflect ~20 remaining tech rows
-SELECT reltuples BETWEEN 15 AND 25 AS index_tuples_ok
+-- index reltuples should reflect ~20 remaining tech rows.
+SELECT (SELECT pinned FROM stats_reindex_horizon)
+       OR reltuples BETWEEN 15 AND 25 AS index_tuples_ok
 FROM pg_class WHERE oid = 'stats_reindex_idx'::regclass;
 
 DROP TABLE stats_reindex CASCADE;
@@ -225,5 +260,7 @@ DROP TABLE stats_reindex CASCADE;
 -- ============================================================
 -- Cleanup
 -- ============================================================
+
+DROP FUNCTION horizon_pinned();
 
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -6,18 +6,29 @@
 
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 
--- True when another same-database client backend holds an xmin, which
--- pins the reclaim horizon back and can defer FSM reclaim.
-CREATE FUNCTION other_backend_holds_xmin() RETURNS boolean
+-- True when the cluster's reclaim horizon may be pinned, which defers FSM
+-- reclaim.  GetOldestNonRemovableTransactionId() is held back by anything
+-- ComputeXidHorizons() folds into data_oldest_nonremovable (procarray.c):
+-- an xmin-holding backend in our database, a backend flagged
+-- PROC_AFFECTS_ALL_HORIZONS, a replication slot xmin, or a prepared xact.
+-- A standby with hot_standby_feedback = on publishes its xmin through the
+-- slot, not pg_stat_activity, so checking only client backends misses it.
+-- While pinned, deleted tuples stay HEAPTUPLE_RECENTLY_DEAD: VACUUM must
+-- retain them, and index builds must still index them to preserve MVCC.
+-- Counts taken after a DELETE are then meaningless, so dependent
+-- assertions are skipped rather than relaxed.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
 LANGUAGE sql STABLE AS $$
     SELECT EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND datname = current_database()
-          AND backend_type = 'client backend'
-          AND backend_xmin IS NOT NULL
-    );
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
 $$;
 
 CREATE TABLE memtable_reclaim_t (id serial PRIMARY KEY, body text);
@@ -58,22 +69,22 @@ SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint
        AS sz_after_spill;
 
 CREATE TEMP TABLE reclaim_blocker_state (
-    blocked_by_other_backend bool
+    pinned bool
 );
 
-INSERT INTO reclaim_blocker_state (blocked_by_other_backend)
+INSERT INTO reclaim_blocker_state (pinned)
 SELECT false;
 
 -- Horizon: spill xact is committed (autocommit per statement).
 UPDATE reclaim_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Idempotent second pass (RecordFreeIndexPage on same blocks is safe).
 UPDATE reclaim_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 
 SELECT count(*) >= 1 AS search_after_vacuum FROM (
@@ -97,7 +108,7 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 -- is legitimately deferred, so skip the check rather than relax it.
 SELECT
     CASE
-        WHEN (SELECT blocked_by_other_backend FROM reclaim_blocker_state)
+        WHEN (SELECT pinned FROM reclaim_blocker_state)
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_after_spill FROM reclaim_sizes)) = 0
@@ -121,10 +132,10 @@ SELECT pg_relation_size('memtable_reclaim_idx'::regclass, 'main')::bigint,
        5;
 
 CREATE TEMP TABLE multi_cycle_blocker_state (
-    blocked_by_other_backend bool
+    pinned bool
 );
 
-INSERT INTO multi_cycle_blocker_state (blocked_by_other_backend)
+INSERT INTO multi_cycle_blocker_state (pinned)
 SELECT false;
 
 -- Cycle 1
@@ -136,8 +147,8 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_1;
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 2
@@ -149,8 +160,8 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_2;
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 3
@@ -162,8 +173,8 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_3;
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 4
@@ -175,8 +186,8 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_4;
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 
 -- Cycle 5
@@ -188,8 +199,8 @@ UPDATE multi_cycle_bounds SET max_live_pages = GREATEST(
     (SELECT count(*)::int FROM bm25_memtable_chain('memtable_reclaim_idx')));
 SELECT bm25_spill_index('memtable_reclaim_idx') IS NOT NULL AS mc_spill_5;
 UPDATE multi_cycle_blocker_state
-SET blocked_by_other_backend = blocked_by_other_backend
-    OR other_backend_holds_xmin();
+SET pinned = pinned
+    OR horizon_pinned();
 VACUUM ANALYZE memtable_reclaim_t;
 
 SELECT max_live_pages > 1 AS multi_cycle_chain_multi_page
@@ -200,7 +211,7 @@ FROM multi_cycle_bounds;
 -- horizon.
 SELECT
     CASE
-        WHEN (SELECT blocked_by_other_backend FROM multi_cycle_blocker_state)
+        WHEN (SELECT pinned FROM multi_cycle_blocker_state)
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_start FROM multi_cycle_bounds))
@@ -209,6 +220,6 @@ SELECT
     END
     AS multi_cycle_growth_valid;
 
-DROP FUNCTION other_backend_holds_xmin();
+DROP FUNCTION horizon_pinned();
 DROP TABLE memtable_reclaim_t;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/memtable_reclaim.sql
+++ b/test/sql/memtable_reclaim.sql
@@ -17,6 +17,12 @@ CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 -- retain them, and index builds must still index them to preserve MVCC.
 -- Counts taken after a DELETE are then meaningless, so dependent
 -- assertions are skipped rather than relaxed.
+--
+-- FSM reclaim is horizon-defined, so there is no horizon-independent way
+-- to assert it (contrast catalog_stats.sql, which compares against a core
+-- btree instead).  The pin is sampled both before the operation, into a
+-- latch, and again inline in the assertion, so a pin appearing or
+-- clearing mid-window is still caught.
 CREATE FUNCTION horizon_pinned() RETURNS boolean
 LANGUAGE sql STABLE AS $$
     SELECT EXISTS (
@@ -108,7 +114,7 @@ FROM bm25_memtable_chain('memtable_reclaim_idx');
 -- is legitimately deferred, so skip the check rather than relax it.
 SELECT
     CASE
-        WHEN (SELECT pinned FROM reclaim_blocker_state)
+        WHEN (SELECT pinned FROM reclaim_blocker_state) OR horizon_pinned()
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_after_spill FROM reclaim_sizes)) = 0
@@ -211,7 +217,7 @@ FROM multi_cycle_bounds;
 -- horizon.
 SELECT
     CASE
-        WHEN (SELECT pinned FROM multi_cycle_blocker_state)
+        WHEN (SELECT pinned FROM multi_cycle_blocker_state) OR horizon_pinned()
             THEN true
         ELSE (pg_relation_size('memtable_reclaim_idx'::regclass, 'main')
               - (SELECT sz_start FROM multi_cycle_bounds))

--- a/test/sql/segment_reclaim.sql
+++ b/test/sql/segment_reclaim.sql
@@ -24,6 +24,9 @@ LANGUAGE sql STABLE AS $$
         OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
 $$;
 
+-- Deferred reclaim is horizon-defined, so it cannot be asserted without
+-- reference to the horizon.  Latch the pin before each operation and
+-- sample it again inline in the assertion; see memtable_reclaim.sql.
 CREATE TEMP TABLE reclaim_horizon AS SELECT horizon_pinned() AS pinned;
 
 CREATE TABLE reclaim_docs (id int, body text)
@@ -57,7 +60,8 @@ UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
 
 -- All parked pages reclaimed (skipped while the horizon is pinned).
-SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon)
+                 OR horizon_pinned() THEN 0
             ELSE bm25_pending_free_pages('reclaim_idx') END
     AS parked_after_vacuum;
 
@@ -83,7 +87,7 @@ INSERT INTO reclaim_docs
 SELECT g, 'alpha beta term' || (g % 50)
 FROM generate_series(4001, 5000) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS reuse_spilled;
-SELECT (SELECT pinned FROM reclaim_horizon)
+SELECT (SELECT pinned FROM reclaim_horizon) OR horizon_pinned()
        OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
           <= :blocks_before_reuse AS reused_freed_pages_no_extension;
 
@@ -113,7 +117,8 @@ SELECT txid_current() IS NOT NULL AS vp1;
 SELECT txid_current() IS NOT NULL AS vp2;
 UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon)
+                 OR horizon_pinned() THEN 0
             ELSE bm25_pending_free_pages('reclaim_idx') END
     AS pool_after_vacuum;
 
@@ -126,7 +131,7 @@ SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
 DELETE FROM reclaim_docs WHERE id BETWEEN 3001 AND 3020;
 UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT (SELECT pinned FROM reclaim_horizon)
+SELECT (SELECT pinned FROM reclaim_horizon) OR horizon_pinned()
        OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
           > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
 
@@ -138,7 +143,8 @@ SELECT txid_current() IS NOT NULL AS vt1;
 SELECT txid_current() IS NOT NULL AS vt2;
 UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon)
+                 OR horizon_pinned() THEN 0
             ELSE bm25_pending_free_pages('reclaim_idx') END
     AS parked_after_vacuum_drain;
 
@@ -150,7 +156,7 @@ INSERT INTO reclaim_docs
 SELECT g, 'vacuum reuse beta term' || (g % 50)
 FROM generate_series(3021, 3720) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
-SELECT (SELECT pinned FROM reclaim_horizon)
+SELECT (SELECT pinned FROM reclaim_horizon) OR horizon_pinned()
        OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
           <= :blocks_before_vacuum_reuse
     AS vacuum_reused_freed_pages_no_extension;

--- a/test/sql/segment_reclaim.sql
+++ b/test/sql/segment_reclaim.sql
@@ -6,6 +6,26 @@
 -- autovacuum is disabled on the table so the only drain is the explicit
 -- VACUUM below, keeping the parked-page observations deterministic.
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+-- The txid_current() calls below advance the latest xid, but cannot advance
+-- the *oldest* horizon while something pins it back; deferring the drain is
+-- then the design (#380).  See memtable_reclaim.sql for the rationale.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
+$$;
+
+CREATE TEMP TABLE reclaim_horizon AS SELECT horizon_pinned() AS pinned;
+
 CREATE TABLE reclaim_docs (id int, body text)
     WITH (autovacuum_enabled = false);
 INSERT INTO reclaim_docs
@@ -33,10 +53,13 @@ SELECT bm25_pending_free_pages('reclaim_idx') > 0 AS parked_after_merge;
 -- pages become reclaimable, then VACUUM to drain them.
 SELECT txid_current() IS NOT NULL AS t1;
 SELECT txid_current() IS NOT NULL AS t2;
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
 
--- All parked pages reclaimed.
-SELECT bm25_pending_free_pages('reclaim_idx') AS parked_after_vacuum;
+-- All parked pages reclaimed (skipped while the horizon is pinned).
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+            ELSE bm25_pending_free_pages('reclaim_idx') END
+    AS parked_after_vacuum;
 
 -- Sanity: queries still work after reclaim.
 SELECT count(*) > 0 AS has_hits
@@ -60,8 +83,9 @@ INSERT INTO reclaim_docs
 SELECT g, 'alpha beta term' || (g % 50)
 FROM generate_series(4001, 5000) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS reuse_spilled;
-SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
-    <= :blocks_before_reuse AS reused_freed_pages_no_extension;
+SELECT (SELECT pinned FROM reclaim_horizon)
+       OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+          <= :blocks_before_reuse AS reused_freed_pages_no_extension;
 
 -- VACUUM's own segment replacement/drop path must also park displaced
 -- pages instead of returning them to the FSM immediately (#413). Build a
@@ -87,8 +111,11 @@ SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_pool_spilled;
 SELECT bm25_force_merge('reclaim_idx');
 SELECT txid_current() IS NOT NULL AS vp1;
 SELECT txid_current() IS NOT NULL AS vp2;
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT bm25_pending_free_pages('reclaim_idx') AS pool_after_vacuum;
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+            ELSE bm25_pending_free_pages('reclaim_idx') END
+    AS pool_after_vacuum;
 
 INSERT INTO reclaim_docs
 SELECT g, 'vacuum dropped beta term' || (g % 50)
@@ -97,9 +124,11 @@ SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_spilled;
 SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
     AS blocks_before_vacuum_drop \gset
 DELETE FROM reclaim_docs WHERE id BETWEEN 3001 AND 3020;
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
-    > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
+SELECT (SELECT pinned FROM reclaim_horizon)
+       OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+          > :blocks_before_vacuum_drop AS vacuum_tombstone_extended;
 
 -- VACUUM should park the dropped segment's pages, not recycle them yet.
 SELECT bm25_pending_free_pages('reclaim_idx') > 0 AS parked_after_vacuum_drop;
@@ -107,8 +136,11 @@ SELECT bm25_pending_free_pages('reclaim_idx') > 0 AS parked_after_vacuum_drop;
 -- Once the xid horizon advances, a later VACUUM drains the parked pages.
 SELECT txid_current() IS NOT NULL AS vt1;
 SELECT txid_current() IS NOT NULL AS vt2;
+UPDATE reclaim_horizon SET pinned = pinned OR horizon_pinned();
 VACUUM reclaim_docs;
-SELECT bm25_pending_free_pages('reclaim_idx') AS parked_after_vacuum_drain;
+SELECT CASE WHEN (SELECT pinned FROM reclaim_horizon) THEN 0
+            ELSE bm25_pending_free_pages('reclaim_idx') END
+    AS parked_after_vacuum_drain;
 
 -- The drained pages must be reusable from the FSM without extending the
 -- index relation.
@@ -118,9 +150,12 @@ INSERT INTO reclaim_docs
 SELECT g, 'vacuum reuse beta term' || (g % 50)
 FROM generate_series(3021, 3720) g;
 SELECT bm25_spill_index('reclaim_idx') > 0 AS vacuum_reuse_spilled;
-SELECT pg_relation_size('reclaim_idx') / current_setting('block_size')::int
-    <= :blocks_before_vacuum_reuse AS vacuum_reused_freed_pages_no_extension;
+SELECT (SELECT pinned FROM reclaim_horizon)
+       OR pg_relation_size('reclaim_idx') / current_setting('block_size')::int
+          <= :blocks_before_vacuum_reuse
+    AS vacuum_reused_freed_pages_no_extension;
 \pset format aligned
 
 DROP TABLE reclaim_docs;
+DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/vacuum.sql
+++ b/test/sql/vacuum.sql
@@ -3,22 +3,6 @@
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 
--- True when the reclaim horizon may be pinned, leaving deleted tuples
--- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
-CREATE FUNCTION horizon_pinned() RETURNS boolean
-LANGUAGE sql STABLE AS $$
-    SELECT EXISTS (
-               SELECT 1
-               FROM pg_stat_activity
-               WHERE pid <> pg_backend_pid()
-                 AND backend_xmin IS NOT NULL
-                 AND (datname = current_database()
-                      OR backend_type = 'walsender')
-           )
-        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
-        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
-$$;
-
 -- Create test table
 CREATE TABLE vacuum_test (
     id SERIAL PRIMARY KEY,
@@ -77,9 +61,7 @@ LIMIT 5;
 
 -- Test VACUUM FULL (more aggressive cleanup)
 -- VACUUM FULL rebuilds indexes
-CREATE TEMP TABLE vacuum_full_horizon AS SELECT horizon_pinned() AS pinned;
 DELETE FROM vacuum_test WHERE content NOT LIKE '%test%';
-UPDATE vacuum_full_horizon SET pinned = pinned OR horizon_pinned();
 -- We use \set VERBOSITY terse to avoid OID-specific error messages
 \set VERBOSITY terse
 -- The rebuild NOTICE reports the document count, which varies with the
@@ -89,14 +71,17 @@ VACUUM FULL vacuum_test;
 RESET client_min_messages;
 \set VERBOSITY default
 
--- Check statistics after VACUUM FULL.
-SELECT CASE
-           WHEN (SELECT pinned FROM vacuum_full_horizon) THEN '1'
-           ELSE split_part(
-                    split_part(bm25_dump_index('vacuum_idx')::text,
-                               'total_docs: ', 2),
-                    E'\n', 1)
-       END AS total_docs_after_vacuum_full;
+-- VACUUM FULL rewrites the heap and rebuilds every index in one
+-- command, so the bm25 doc count must match what core's primary key
+-- btree retains.  That holds whether or not the horizon is pinned; the
+-- absolute count does not, since a pinned horizon forces the rewrite to
+-- carry recently-dead tuples over.
+SELECT split_part(
+           split_part(bm25_dump_index('vacuum_idx')::text, 'total_docs: ', 2),
+           E'\n', 1)::int
+       = (SELECT reltuples::int FROM pg_class
+           WHERE oid = 'vacuum_test_pkey'::regclass)
+       AS total_docs_matches_btree;
 
 -- Verify search still works
 SELECT id, substring(content, 1, 30) as content_preview
@@ -105,5 +90,4 @@ ORDER BY content <@> to_bm25query('test', 'vacuum_idx');
 
 -- Clean up
 DROP TABLE vacuum_test;
-DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch;

--- a/test/sql/vacuum.sql
+++ b/test/sql/vacuum.sql
@@ -3,6 +3,22 @@
 -- Ensure extension is loaded
 CREATE EXTENSION IF NOT EXISTS pg_textsearch;
 
+-- True when the reclaim horizon may be pinned, leaving deleted tuples
+-- HEAPTUPLE_RECENTLY_DEAD; see memtable_reclaim.sql for the rationale.
+CREATE FUNCTION horizon_pinned() RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT EXISTS (
+               SELECT 1
+               FROM pg_stat_activity
+               WHERE pid <> pg_backend_pid()
+                 AND backend_xmin IS NOT NULL
+                 AND (datname = current_database()
+                      OR backend_type = 'walsender')
+           )
+        OR EXISTS (SELECT 1 FROM pg_replication_slots WHERE xmin IS NOT NULL)
+        OR EXISTS (SELECT 1 FROM pg_prepared_xacts);
+$$;
+
 -- Create test table
 CREATE TABLE vacuum_test (
     id SERIAL PRIMARY KEY,
@@ -61,17 +77,26 @@ LIMIT 5;
 
 -- Test VACUUM FULL (more aggressive cleanup)
 -- VACUUM FULL rebuilds indexes
+CREATE TEMP TABLE vacuum_full_horizon AS SELECT horizon_pinned() AS pinned;
 DELETE FROM vacuum_test WHERE content NOT LIKE '%test%';
+UPDATE vacuum_full_horizon SET pinned = pinned OR horizon_pinned();
 -- We use \set VERBOSITY terse to avoid OID-specific error messages
 \set VERBOSITY terse
+-- The rebuild NOTICE reports the document count, which varies with the
+-- horizon (VACUUM FULL copies recently-dead tuples too).  Silence it.
+SET client_min_messages = warning;
 VACUUM FULL vacuum_test;
+RESET client_min_messages;
 \set VERBOSITY default
 
--- Check statistics after VACUUM FULL
-SELECT split_part(
-    split_part(bm25_dump_index('vacuum_idx')::text, 'total_docs: ', 2),
-    E'\n', 1
-) AS total_docs_after_vacuum_full;
+-- Check statistics after VACUUM FULL.
+SELECT CASE
+           WHEN (SELECT pinned FROM vacuum_full_horizon) THEN '1'
+           ELSE split_part(
+                    split_part(bm25_dump_index('vacuum_idx')::text,
+                               'total_docs: ', 2),
+                    E'\n', 1)
+       END AS total_docs_after_vacuum_full;
 
 -- Verify search still works
 SELECT id, substring(content, 1, 30) as content_preview
@@ -80,4 +105,5 @@ ORDER BY content <@> to_bm25query('test', 'vacuum_idx');
 
 -- Clean up
 DROP TABLE vacuum_test;
+DROP FUNCTION horizon_pinned();
 DROP EXTENSION pg_textsearch;

--- a/test/sql/vacuum_bitmap.sql
+++ b/test/sql/vacuum_bitmap.sql
@@ -104,9 +104,12 @@ INSERT INTO vb_reuse (content)
 SELECT 'beta keyword document ' || i
 FROM generate_series(1, 50) i;
 
--- alpha should return nothing
-SELECT count(*) FROM (
-    SELECT id FROM vb_reuse
+-- No alpha content may resurface, whether or not CTIDs were reused.
+-- Counting returned rows instead would be horizon-dependent, since
+-- ORDER BY ... LIMIT does not filter.
+SELECT count(*) FILTER (WHERE content LIKE 'alpha%') AS stale_alpha_rows
+FROM (
+    SELECT id, content FROM vb_reuse
     ORDER BY content <@> to_bm25query('alpha', 'vb_reuse_idx')
     LIMIT 1000
 ) q;


### PR DESCRIPTION
Several regression tests asserted document or page counts taken after a `DELETE`, `VACUUM`, or `REINDEX`. Those counts are only stable when the cluster's reclaim horizon has advanced past the deleting transaction.

`GetOldestNonRemovableTransactionId()` is held back by anything `ComputeXidHorizons()` folds into `data_oldest_nonremovable`: an xmin-holding backend in our database, a backend flagged `PROC_AFFECTS_ALL_HORIZONS` (hot standby feedback), `procArray->replication_slot_xmin`, or a prepared transaction. While it is held back, deleted tuples stay `HEAPTUPLE_RECENTLY_DEAD`: VACUUM must retain them, and an index build **must still index them** to preserve MVCC for pre-existing snapshots — `heapam_handler.c` says so explicitly, and `_bt_build_callback()` spools them for the same reason.

So the affected assertions were failing against a correct extension. Confirmed on stock PostgreSQL 18.1: an equivalent **core btree** partial index reports the same post-REINDEX `reltuples` that bm25 does.

## Approach

Rather than teaching each assertion to skip itself when the horizon is pinned, most of them are rewritten so the horizon is irrelevant.

A single `VACUUM`, `VACUUM FULL`, or `REINDEX TABLE` processes every index on the table under **one** reclaim horizon. That makes a core btree over the same rows an exact oracle. Measured on PostgreSQL 18.1, unpinned vs pinned:

| Operation | Unpinned | Pinned |
|---|---|---|
| `VACUUM` | bm25 50, btree 50 | bm25 100, btree 100 |
| `VACUUM FULL` | docs 2, pkey 2 | docs 4, pkey 4 |
| `REINDEX` | bm25 20, btree 20 | bm25 30, btree 30 |

The absolute counts move; the equality does not. It is also a **stronger** assertion than the magic numbers it replaces, since it pins bm25 to core's convention rather than to a hand-picked range.

`catalog_stats.sql` and `vacuum.sql` therefore contain no horizon machinery at all — no helper, no latch table, no NOTICE-count guard. `vacuum_bitmap.sql` likewise now asserts that no deleted `alpha` content resurfaces, the invariant it actually cares about, instead of counting rows returned by an `ORDER BY ... LIMIT` that does not filter.

`segment_reclaim.sql` and `memtable_reclaim.sql` keep a guard: deferred FSM reclaim is *defined* in terms of the horizon, so it cannot be asserted without reference to it, and there is no oracle. `horizon_pinned()` covers all four sources above — note a standby with `hot_standby_feedback = on` publishes its xmin through the replication slot, not `pg_stat_activity`, which is why the pre-existing guard in `memtable_reclaim.sql` never fired in the topology that needs it.

Those two files sample the pin **both** in a pre-operation latch and inline in the assertion itself, so a pin appearing or clearing mid-window is still caught, at no extra statements. The residual case — a pin that both appears and disappears inside a single VACUUM — is not observable from SQL.

## CI coverage

The guards only do anything when the horizon is actually held back, and a single-node `make installcheck` never holds it back — so a missing guard could not fail in CI. It failed later, against a streaming standby, as a confusing count mismatch in a test that looks unrelated to replication. That is how this cluster of bugs escaped.

`test/scripts/pinned_horizon.sh` closes that gap. It reuses `replication_lib.sh` to stand up a primary plus a standby running with `hot_standby_feedback = on`, holds a `REPEATABLE READ` snapshot open on the standby, and reruns the full `REGRESS` list against the primary via `pg_regress --use-existing`. It runs in the existing shell-test step on PG 17 and 18 (~1–2 min per leg).

It asserts the topology is real before trusting a pass: the slot xmin must not advance while the standby snapshot is open and must trail an xid assigned afterwards, and `horizon_pinned()` must still return true here. Without those, a change in Postgres or in the setup would leave the job green while testing nothing.

**Verified to have teeth:** reverting `catalog_stats.sql` to its pre-fix state makes exactly that test fail under this script, with a diagnostic pointing at the fix pattern.

Supporting changes: `setup_primary()` gains a `SETUP_CREATE_EXTENSION` opt-out (pg_regress needs a bare database, since the tests create and drop the extension themselves; default behaviour unchanged), and the Makefile gains `test-pinned-horizon` plus `print-regress`.

## Verification

Full suite run both ways against PostgreSQL 18.1 — normally, and against a primary whose horizon is pinned by a hot-standby-feedback standby holding an open snapshot:

| Run | Before | After |
|---|---|---|
| Baseline | 75/75 | **75/75** |
| Pinned horizon | 70/75 | **75/75** |

Before this change the pinned run failed `catalog_stats`, `vacuum`, `vacuum_bitmap`, `memtable_reclaim`, and `segment_reclaim`. Also verified via `make format-check`. No product code is changed.

## Related

Explains a cluster of Orion CI bugs whose auto-generated RCAs attributed them to extension defects: `catalog_stats` (ADO 5539172), `vacuum_bitmap` (5540066), `memtable_reclaim` (5396714), `vacuum_extended` (5499619). Notably 5539172's suggested fix — skipping `!tupleIsAlive` in `tp_build_callback` — would have dropped index entries for rows older snapshots can still legitimately read, a silent wrong-results bug.

Note `vacuum_extended` (5499619) passes under the pinned harness, so its failure has a different trigger and is not addressed here.
