### PR TITLE
perf: bound VACUUM CTID reads

### DIFF
--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -334,11 +334,18 @@ tp_vacuum_identify_affected(
 		int64				   *total_dead_out)
 {
 	TpVacuumSegmentInfo *segments;
-	int					 capacity	= 32;
-	int					 count		= 0;
-	int64				 total_dead = 0;
+	/* Keep both CTID scratch arrays within roughly one PostgreSQL block. */
+	const uint32  ctid_batch_capacity = BLCKSZ / (sizeof(BlockNumber) +
+												  sizeof(OffsetNumber));
+	BlockNumber	 *ctid_pages;
+	OffsetNumber *ctid_offsets;
+	int			  capacity	 = 32;
+	int			  count		 = 0;
+	int64		  total_dead = 0;
 
-	segments = palloc(capacity * sizeof(TpVacuumSegmentInfo));
+	segments	 = palloc(capacity * sizeof(TpVacuumSegmentInfo));
+	ctid_pages	 = palloc(ctid_batch_capacity * sizeof(BlockNumber));
+	ctid_offsets = palloc(ctid_batch_capacity * sizeof(OffsetNumber));
 
 	for (int level = 0; level < TP_MAX_LEVELS; level++)
 	{
@@ -349,7 +356,7 @@ tp_vacuum_identify_affected(
 			TpSegmentReader *reader;
 			uint32			 seg_dead = 0;
 
-			reader = tp_segment_open_ex(index, seg, true);
+			reader = tp_segment_open_ex(index, seg, false);
 			if (!reader || !reader->header)
 			{
 				if (reader)
@@ -363,36 +370,64 @@ tp_vacuum_identify_affected(
 				uint32	dead_cap   = 0;
 				bool	has_bitset = (reader->header->alive_bitset_offset > 0);
 
-				for (uint32 i = 0; i < reader->header->num_docs; i++)
+				for (uint32 batch_start = 0;
+					 batch_start < reader->header->num_docs;
+					 batch_start += ctid_batch_capacity)
 				{
-					ItemPointerData ctid;
+					uint32 batch_count =
+							Min(ctid_batch_capacity,
+								reader->header->num_docs - batch_start);
 
-					/*
-					 * Skip docs already marked dead in the alive
-					 * bitset.  Without this, CTID reuse after a
-					 * previous VACUUM would double-count dead docs
-					 * and corrupt total_docs in the metapage.
-					 */
-					if (has_bitset && !tp_segment_is_alive(reader, i))
-						continue;
+					tp_segment_read(
+							reader,
+							reader->header->ctid_pages_offset +
+									(uint64)batch_start * sizeof(BlockNumber),
+							ctid_pages,
+							batch_count * sizeof(BlockNumber));
+					tp_segment_read(
+							reader,
+							reader->header->ctid_offsets_offset +
+									(uint64)batch_start * sizeof(OffsetNumber),
+							ctid_offsets,
+							batch_count * sizeof(OffsetNumber));
 
-					tp_segment_lookup_ctid(reader, i, &ctid);
-					if (ItemPointerIsValid(&ctid) &&
-						callback(&ctid, callback_state))
+					for (uint32 batch_pos = 0; batch_pos < batch_count;
+						 batch_pos++)
 					{
-						if (seg_dead >= dead_cap)
+						ItemPointerData ctid;
+						uint32			i = batch_start + batch_pos;
+
+						/*
+						 * Skip docs already marked dead in the alive
+						 * bitset.  Without this, CTID reuse after a
+						 * previous VACUUM would double-count dead docs
+						 * and corrupt total_docs in the metapage.
+						 */
+						if (has_bitset && !tp_segment_is_alive(reader, i))
+							continue;
+
+						ItemPointerSet(
+								&ctid,
+								ctid_pages[batch_pos],
+								ctid_offsets[batch_pos]);
+						if (ItemPointerIsValid(&ctid) &&
+							callback(&ctid, callback_state))
 						{
-							dead_cap = (dead_cap == 0) ? 64 : dead_cap * 2;
-							dead_ids = dead_ids
-											 ? repalloc(
-													   dead_ids,
-													   dead_cap *
-															   sizeof(uint32))
-											 : palloc(dead_cap *
-													  sizeof(uint32));
+							if (seg_dead >= dead_cap)
+							{
+								dead_cap = (dead_cap == 0) ? 64 : dead_cap * 2;
+								dead_ids =
+										dead_ids
+												? repalloc(
+														  dead_ids,
+														  dead_cap *
+																  sizeof(uint32))
+												: palloc(dead_cap *
+														 sizeof(uint32));
+							}
+							dead_ids[seg_dead] = i;
+							seg_dead++;
 						}
-						dead_ids[seg_dead] = i;
-						seg_dead++;
 					}
 				}
 
@@ -423,6 +458,9 @@ tp_vacuum_identify_affected(
 			tp_segment_close(reader);
 		}
 	}
+
+	pfree(ctid_offsets);
+	pfree(ctid_pages);
 
 	*num_segments_out = count;
 	*total_dead_out	  = total_dead;

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -434,4 +434,33 @@ SELECT bm25_dump_index('vb_dump_idx') LIKE '%Alive: 10 / 10 docs%'
 (1 row)
 
 DROP TABLE vb_dump;
+-- =============================================================
+-- Test 11: Batched CTID reads across pages and segments
+-- =============================================================
+CREATE TABLE vb_batched (id serial PRIMARY KEY, content text);
+INSERT INTO vb_batched (content)
+SELECT 'bounded batch ' || i
+FROM generate_series(1, 3000) i;
+CREATE INDEX vb_batched_idx ON vb_batched
+    USING bm25 (content) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation vb_batched_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 3000 documents, avg_length=3.00
+INSERT INTO vb_batched (content)
+SELECT 'bounded batch ' || i
+FROM generate_series(3001, 6000) i;
+DELETE FROM vb_batched WHERE id % 3 = 0;
+VACUUM vb_batched;
+SELECT count(*) FROM (
+    SELECT id FROM vb_batched
+    ORDER BY content <@> to_bm25query('bounded', 'vb_batched_idx')
+    LIMIT 6000
+) q;
+ count 
+-------
+  4000
+(1 row)
+
+DROP TABLE vb_batched;
 DROP EXTENSION pg_textsearch;

--- a/test/expected/vacuum_bitmap.out
+++ b/test/expected/vacuum_bitmap.out
@@ -450,6 +450,12 @@ NOTICE:  BM25 index build completed: 3000 documents, avg_length=3.00
 INSERT INTO vb_batched (content)
 SELECT 'bounded batch ' || i
 FROM generate_series(3001, 6000) i;
+SELECT bm25_spill_index('vb_batched_idx');
+ bm25_spill_index 
+------------------
+               61
+(1 row)
+
 DELETE FROM vb_batched WHERE id % 3 = 0;
 VACUUM vb_batched;
 SELECT count(*) FROM (

--- a/test/sql/vacuum_bitmap.sql
+++ b/test/sql/vacuum_bitmap.sql
@@ -347,4 +347,31 @@ SELECT bm25_dump_index('vb_dump_idx') LIKE '%Alive: 10 / 10 docs%'
 
 DROP TABLE vb_dump;
 
+-- =============================================================
+-- Test 11: Batched CTID reads across pages and segments
+-- =============================================================
+CREATE TABLE vb_batched (id serial PRIMARY KEY, content text);
+
+INSERT INTO vb_batched (content)
+SELECT 'bounded batch ' || i
+FROM generate_series(1, 3000) i;
+
+CREATE INDEX vb_batched_idx ON vb_batched
+    USING bm25 (content) WITH (text_config = 'english');
+
+INSERT INTO vb_batched (content)
+SELECT 'bounded batch ' || i
+FROM generate_series(3001, 6000) i;
+
+DELETE FROM vb_batched WHERE id % 3 = 0;
+VACUUM vb_batched;
+
+SELECT count(*) FROM (
+    SELECT id FROM vb_batched
+    ORDER BY content <@> to_bm25query('bounded', 'vb_batched_idx')
+    LIMIT 6000
+) q;
+
+DROP TABLE vb_batched;
+
 DROP EXTENSION pg_textsearch;

--- a/test/sql/vacuum_bitmap.sql
+++ b/test/sql/vacuum_bitmap.sql
@@ -363,6 +363,8 @@ INSERT INTO vb_batched (content)
 SELECT 'bounded batch ' || i
 FROM generate_series(3001, 6000) i;
 
+SELECT bm25_spill_index('vb_batched_idx');
+
 DELETE FROM vb_batched WHERE id % 3 = 0;
 VACUUM vb_batched;
 


### PR DESCRIPTION
## Summary

- open VACUUM segments without preloading their complete CTID mapping
- read CTID block numbers and tuple offsets in bounded sequential batches
- reuse the same scratch buffers across batches and segment boundaries
- add multi-page, multi-segment VACUUM regression coverage

Fixes #320.

## Why

The VACUUM identify phase previously called `tp_segment_open_ex(..., true)`.
That loaded two arrays for every document in a segment:

- 4 bytes for the PostgreSQL block number
- 2 bytes for the tuple offset

The allocation therefore grew by roughly six bytes per document. An
8.84-million-document segment needed about 50.6 MiB, while larger segments
could require hundreds of megabytes or several gigabytes.

VACUUM consumes these CTIDs sequentially, so retaining the complete mapping is
unnecessary. This change keeps the working set bounded independently of segment
size while preserving document order and the existing cleanup callbacks.

## Design

`tp_vacuum_identify_affected()` now opens each segment with
`load_ctids=false`. It reads page numbers and tuple offsets through the existing
segment storage primitives in fixed-size batches, processes the resulting CTIDs
in order, and reuses the buffers for the next batch and segment.

The change does not add a public API, dependency, configuration option, generic
iterator, or on-disk format change.

## Validation

- all 75 SQL regression tests passed
- the full concurrency suite passed
- formatting passed
- a five-run MSMARCO A/B benchmark produced identical final row counts, index
  sizes, and segment layouts in all ten runs, with no errors

| VACUUM scenario | Baseline median | Patched median | Delta |
| --- | ---: | ---: | ---: |
| Concentrated delete | 5.727 s | 5.643 s | -1.45% |
| Uniform delete | 8.391 s | 7.447 s | -11.25% |
| Uniform update | 7.260 s | 7.072 s | -2.59% |
| **Total** | **20.871 s** | **20.156 s** | **-3.42%** |

The timing ranges overlap, so these results show no measurable regression
rather than a demonstrated speedup. Process-level RSS sampling could not
reliably isolate the short-lived CTID allocation from PostgreSQL shared mappings
and allocator behavior; the bounded-memory property follows directly from
replacing the proportional arrays with fixed reusable buffers.
