### PR TITLE
Add a Windows MSVC build job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
         for ($attempt = 1; $attempt -le 2; $attempt++) {
           if (Test-Path -LiteralPath $zip) { Remove-Item -LiteralPath $zip -Force }
           try {
-            Invoke-WebRequest -Uri '${{ matrix.url }}' -OutFile $zip -UseBasicParsing
+            Invoke-WebRequest -Uri '${{ matrix.url }}' -OutFile $zip -UseBasicParsing -TimeoutSec 300
             $actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash.ToLowerInvariant()
             if ($actual -eq $expected) { $verified = $true; break }
             Write-Host "attempt ${attempt}: SHA256 is $actual, expected $expected"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'pg_textsearch.control'
       - '.clang-format'
       - '.github/workflows/ci.yml'
+      - 'scripts/msvc-build.ps1'
   pull_request:
     branches: [ main ]
     paths:
@@ -21,6 +22,7 @@ on:
       - 'pg_textsearch.control'
       - '.clang-format'
       - '.github/workflows/ci.yml'
+      - 'scripts/msvc-build.ps1'
   workflow_dispatch:
 
 jobs:
@@ -275,6 +277,79 @@ jobs:
         make clean
         # Build with -Werror via PG_CFLAGS (CFLAGS is overridden by pgxs)
         make PG_CFLAGS="-Werror -Wno-error=unused-parameter"
+
+  build-msvc:
+    name: PG${{ matrix.pg_version }} MSVC Build
+    runs-on: windows-2022
+    timeout-minutes: 20
+    strategy:
+      # Do not cancel the remaining leg when one fails: comparing both logs
+      # shows whether a /WX failure comes from the toolset or from headers.
+      fail-fast: false
+      matrix:
+        include:
+          - pg_version: 17
+            url: 'https://get.enterprisedb.com/postgresql/postgresql-17.11-1-windows-x64-binaries.zip'
+            sha256: '6eabdf00d2893713b75db4336a23c3fdf505f056e217ec6e2e95d901750cfea3'
+          - pg_version: 18
+            url: 'https://get.enterprisedb.com/postgresql/postgresql-18.6-1-windows-x64-binaries.zip'
+            sha256: 'fbe23da234ee31547bf8a36d29dfd81e82b849df2d2b78d2eecb43d360252f8c'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download PostgreSQL ${{ matrix.pg_version }} binaries
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $ProgressPreference = 'SilentlyContinue'
+        $zip = Join-Path $env:RUNNER_TEMP 'pgsql.zip'
+        $dest = Join-Path $env:RUNNER_TEMP 'pg'
+        $expected = '${{ matrix.sha256 }}'
+
+        # The retry covers transport errors and hash mismatches alike: a
+        # truncated download of a ~340 MB archive gives a wrong hash. This
+        # job is a required check.
+        $verified = $false
+        for ($attempt = 1; $attempt -le 2; $attempt++) {
+          if (Test-Path -LiteralPath $zip) { Remove-Item -LiteralPath $zip -Force }
+          try {
+            Invoke-WebRequest -Uri '${{ matrix.url }}' -OutFile $zip -UseBasicParsing
+            $actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($actual -eq $expected) { $verified = $true; break }
+            Write-Host "attempt ${attempt}: SHA256 is $actual, expected $expected"
+          }
+          catch {
+            Write-Host "attempt ${attempt}: download failed: $($_.Exception.Message)"
+          }
+          if ($attempt -lt 2) { Start-Sleep -Seconds 15 }
+        }
+        if (-not $verified) {
+          throw "Could not fetch ${{ matrix.url }} with SHA256 $expected in 2 attempts."
+        }
+        Write-Host "SHA256 verified: $expected"
+
+        if (Test-Path -LiteralPath $dest) { Remove-Item -LiteralPath $dest -Recurse -Force }
+        New-Item -ItemType Directory -Path $dest -Force | Out-Null
+        # tar is bsdtar here and unpacks this zip far faster than Expand-Archive.
+        tar -xf $zip -C $dest
+        if ($LASTEXITCODE -ne 0) { throw "tar -xf failed with exit code $LASTEXITCODE" }
+
+        # EDB zips unpack into a single pgsql/ directory. A different root
+        # means the archive changed and the pin must be updated.
+        $pgRoot = Join-Path $dest 'pgsql'
+        foreach ($required in @('include\server', 'lib\postgres.lib')) {
+          $path = Join-Path $pgRoot $required
+          if (-not (Test-Path -LiteralPath $path)) { throw "Extracted tree is missing $path" }
+        }
+        # A plain $env: assignment would not survive this step.
+        "PGROOT=$pgRoot" >> $env:GITHUB_ENV
+
+    - name: Build with MSVC
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        ./scripts/msvc-build.ps1 -PgRoot $env:PGROOT -ExpectedMajor ${{ matrix.pg_version }}
 
   performance-test:
     runs-on: ubuntu-latest
@@ -1048,7 +1123,7 @@ jobs:
   # Umbrella job for branch protection rules
   all-tests-passed:
     runs-on: ubuntu-latest
-    needs: [test, build-test-multiple-configs, performance-test, format-check, sanitizer, coverage, pgspot]
+    needs: [test, build-test-multiple-configs, build-msvc, performance-test, format-check, sanitizer, coverage, pgspot]
     if: always()
     steps:
       - name: Check all jobs succeeded

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,3 +3,42 @@
 ## `package-deb.sh`
 
 Builds a Debian package for pg_textsearch.
+
+## `msvc-build.ps1`
+
+Builds `pg_textsearch.dll` with MSVC against a PostgreSQL 17 or 18 x64 tree,
+on Windows. PGXS cannot drive MSVC, so this script is the Windows build
+recipe; it reads `OBJS` and `DATA` from the `Makefile` instead of keeping a
+second source list. Requires Visual Studio 2022 Build Tools with the
+"Desktop development with C++" workload.
+
+```powershell
+.\scripts\msvc-build.ps1 -PgRoot 'C:\Program Files\PostgreSQL\18'
+```
+
+`-PgRoot` is any installation or extracted EDB binaries tree containing
+`include\server` and `lib\postgres.lib`. Output goes to `-WorkDir`, by default
+`target\msvc`; nothing is written into `-PgRoot` and nothing is installed.
+`-ExpectedMajor 17|18` refuses a tree of another major version.
+
+The build compiles with `/W3 /WX` and suppresses three conversion warnings
+(C4244, C4267, C4305) that already appear on `main`; every other warning
+fails the build. After compilation two gates run: `src/layout_check.c` stops
+the compile if MSVC lays out a packed or aligned on-disk struct differently
+from the reference GCC x86-64 build, and the export gate stops the build if
+the DLL does not export a symbol that the `DATA` SQL files use through
+`MODULE_PATHNAME`.
+
+Only `OBJS` and `DATA` are read from the `Makefile`; the version comes from
+`pg_textsearch.control`. Everything else that affects the build lives in two
+places: a semantic `-D` or `-I` added to `PG_CPPFLAGS`, or a link dependency
+added via `SHLIB_LINK`, must be mirrored in `scripts/msvc-build.ps1` in the
+same change, or the Windows DLL diverges from the PGXS build.
+
+The `build-msvc` job in `.github/workflows/ci.yml` runs the same script
+against EDB binary zips pinned by URL and SHA-256. When EDB replaces the
+release and the URL stops working, pick the new URL, compute its hash, and
+update URL and hash together in one commit; never change one side of a pin
+alone. If the hash does not match while the URL is unchanged, treat it as an
+incident and do not update the pin until the replacement archive's provenance
+has been independently verified.

--- a/scripts/msvc-build.ps1
+++ b/scripts/msvc-build.ps1
@@ -1,0 +1,500 @@
+<#
+.SYNOPSIS
+    Builds pg_textsearch.dll with MSVC against a PostgreSQL 17 or 18 x64 tree.
+
+.DESCRIPTION
+    PGXS cannot drive MSVC, so this script is the Windows build recipe. It
+    reads OBJS and DATA from the Makefile so there is no second source list
+    to keep in sync, compiles every object with /W3 /WX, links against
+    postgres.lib and runs two gates:
+
+      layout gate  src/layout_check.c checks every packed or aligned on-disk
+                   struct against the reference GCC x86-64 layout. If MSVC
+                   produces a different layout, compilation stops.
+      export gate  every C symbol used through MODULE_PATHNAME in the SQL
+                   files must be exported by the DLL, so a missing PGDLLEXPORT
+                   fails here instead of when PostgreSQL loads the library.
+
+    The script writes only into WorkDir: never into PgRoot, nothing installed.
+
+.PARAMETER PgRoot
+    Root of a PostgreSQL 17 or 18 x64 tree, either an installation or an
+    extracted EDB binaries zip. Must contain include\server and
+    lib\postgres.lib.
+
+.PARAMETER WorkDir
+    Scratch and output directory. Defaults to <repo>\target\msvc.
+
+.PARAMETER ExpectedMajor
+    Refuse to build unless the PgRoot headers report this major version.
+    Omitted, any of 17 or 18 is accepted.
+
+.EXAMPLE
+    .\scripts\msvc-build.ps1 -PgRoot 'C:\Program Files\PostgreSQL\18'
+
+.EXAMPLE
+    .\scripts\msvc-build.ps1 -PgRoot D:\pg17\pgsql -ExpectedMajor 17
+#>
+[CmdletBinding()]
+param(
+    [string]$PgRoot,
+    [string]$WorkDir,
+    [string]$ExpectedMajor
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+$global:LASTEXITCODE = 0
+
+$SupportedMajors = @('17', '18')
+
+# MSVC version of the flag block in the Makefile. Use /MD: postgres.exe uses
+# the dynamic CRT, and /MT would give the extension its own second CRT heap.
+# /WX works like -Werror on Unix.
+$CompileFlags = @(
+    '/nologo'
+    '/c'
+    '/MD'
+    '/O2'
+    '/std:c11'
+    '/utf-8'
+    '/W3'
+    '/WX'
+    # Conversion warnings that already occur on main; gcc/clang -Wall -Wextra
+    # does not report them. Nothing else is suppressed, so any new warning
+    # still fails the build.
+    '/wd4244'
+    '/wd4267'
+    '/wd4305'
+)
+
+$CompileDefines = @(
+    '/DWIN32'
+    '/D_WINDOWS'
+    '/D_CRT_SECURE_NO_WARNINGS'
+    '/D_CRT_NONSTDC_NO_DEPRECATE'
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ''
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Detail {
+    param([string]$Message)
+    Write-Host "    $Message"
+}
+
+function Get-FullPath {
+    param([string]$Path, [string]$BaseDir)
+    return [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($BaseDir, $Path))
+}
+
+function New-CleanDirectory {
+    param([string]$Path)
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+}
+
+function Write-TextFile {
+    param([string]$Path, [string[]]$Lines)
+    $content = ($Lines -join "`r`n") + "`r`n"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $content, $utf8NoBom)
+}
+
+function Find-VcVars {
+    $candidates = New-Object System.Collections.Generic.List[string]
+    $pf86 = ${env:ProgramFiles(x86)}
+    if ($pf86) {
+        $vswhere = Join-Path $pf86 'Microsoft Visual Studio\Installer\vswhere.exe'
+        if (Test-Path -LiteralPath $vswhere) {
+            $found = & $vswhere -products '*' -latest `
+                -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+                -property installationPath
+            $global:LASTEXITCODE = 0
+            foreach ($install in $found) {
+                if ($install) {
+                    $candidates.Add((Join-Path $install.Trim() 'VC\Auxiliary\Build\vcvars64.bat'))
+                }
+            }
+        }
+        $candidates.Add((Join-Path $pf86 'Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat'))
+    }
+    $pf = ${env:ProgramFiles}
+    if ($pf) {
+        foreach ($edition in @('Enterprise', 'Professional', 'Community', 'BuildTools')) {
+            $candidates.Add((Join-Path $pf "Microsoft Visual Studio\2022\$edition\VC\Auxiliary\Build\vcvars64.bat"))
+        }
+    }
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate) { return $candidate }
+    }
+    throw 'vcvars64.bat not found. Install Visual Studio 2022 Build Tools with the "Desktop development with C++" workload.'
+}
+
+function Import-VcVarsEnvironment {
+    param([string]$VcVarsPath)
+    # vcvars64.bat changes the environment of its own cmd.exe only, so run
+    # it in a child shell and copy the result into this process. The call
+    # goes through a temporary .cmd file because pwsh and cmd.exe escape
+    # embedded quotes differently.
+    $marker = 'VCVARS_ENVIRONMENT_FOLLOWS'
+    $shim = Join-Path ([System.IO.Path]::GetTempPath()) ('vcvars-' + [System.Guid]::NewGuid().ToString('N') + '.cmd')
+    Write-TextFile -Path $shim -Lines @(
+        '@echo off'
+        ('call "' + $VcVarsPath + '" >nul 2>&1')
+        'if errorlevel 1 exit /b 1'
+        "echo $marker"
+        'set'
+    )
+    try {
+        $lines = & cmd.exe /c $shim
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to run $VcVarsPath (exit code $LASTEXITCODE)"
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $shim -Force -ErrorAction SilentlyContinue
+    }
+    $started = $false
+    foreach ($line in $lines) {
+        if (-not $started) {
+            if ($line -eq $marker) { $started = $true }
+            continue
+        }
+        $split = $line.IndexOf('=')
+        if ($split -lt 1) { continue }
+        [System.Environment]::SetEnvironmentVariable(
+            $line.Substring(0, $split), $line.Substring($split + 1))
+    }
+    if (-not $started) {
+        throw "Could not capture the environment from $VcVarsPath"
+    }
+}
+
+function Get-MakefileVariable {
+    param([string]$MakefilePath, [string]$Name)
+    $lines = Get-Content -LiteralPath $MakefilePath
+    # Exactly one plain assignment may define the variable. A second one
+    # (+=, :=, ?=, a conditional block) means a Makefile shape this small
+    # parser cannot evaluate; silently ignoring it would drop objects or SQL
+    # files from the Windows build, so it fails instead.
+    $assigns = @($lines | Select-String -Pattern ('^\s*' + $Name + '\s*[:+?]?='))
+    if ($assigns.Count -eq 0) { throw "Variable $Name not found in $MakefilePath" }
+    if ($assigns.Count -gt 1) {
+        $at = ($assigns | ForEach-Object LineNumber) -join ', '
+        throw "$Name has $($assigns.Count) assignments in $MakefilePath (line $at);" +
+            ' this parser supports exactly one'
+    }
+    $buffer = New-Object System.Collections.Generic.List[string]
+    foreach ($line in $lines[$($assigns[0].LineNumber - 1)..($lines.Count - 1)]) {
+        $continues = ($line.TrimEnd() -match '\\$')
+        $buffer.Add(($line -replace '\\\s*$', ''))
+        if (-not $continues) { break }
+    }
+    $joined = ($buffer -join ' ') -replace ('^\s*' + $Name + '\s*=\s*'), ''
+    $values = @($joined -split '\s+' | Where-Object { $_ -ne '' })
+    if ($values.Count -eq 0) { throw "Variable $Name is empty in $MakefilePath" }
+    return $values
+}
+
+function Invoke-Cl {
+    param([string]$Tag, [string]$RspDir, [string]$ObjDir, [string[]]$Flags, [string[]]$Sources)
+    New-Item -ItemType Directory -Path $ObjDir -Force | Out-Null
+    $lines = @($Flags)
+    # The doubled backslash survives cl's argument unescaping as one trailing
+    # separator, which is what makes /Fo name a directory instead of a file.
+    $lines += ('/Fo"' + $ObjDir + '\\"')
+    foreach ($source in $Sources) { $lines += ('"' + $source + '"') }
+    $rspName = "cl-$Tag.rsp"
+    Write-TextFile -Path (Join-Path $RspDir $rspName) -Lines $lines
+    # Run from the response directory so the @ argument needs no quoting.
+    Push-Location -LiteralPath $RspDir
+    try {
+        & cl.exe "@$rspName"
+        if ($LASTEXITCODE -ne 0) { throw "cl.exe failed for $Tag (exit code $LASTEXITCODE)" }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Get-DllExport {
+    param([string]$DllPath)
+    # link /dump prints what dumpbin prints. /dump must come first, or
+    # link.exe treats the DLL as an input object.
+    $output = & link.exe /dump /nologo /exports $DllPath
+    if ($LASTEXITCODE -ne 0) { throw "link /dump /exports failed for $DllPath" }
+    $names = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+    foreach ($line in $output) {
+        $match = [regex]::Match($line, '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]{8}\s+(\S+)')
+        if ($match.Success) { $names.Add($match.Groups[1].Value) | Out-Null }
+    }
+    # Leading comma keeps PowerShell from turning the set into an array,
+    # which would make Contains a slow linear search.
+    return ,$names
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+Write-Step 'Preflight'
+
+if (-not $PSScriptRoot) { throw 'This script must be run from a file, not pasted into a shell.' }
+if ($ExpectedMajor -and $SupportedMajors -notcontains $ExpectedMajor) {
+    throw "-ExpectedMajor must be one of $($SupportedMajors -join ', ')."
+}
+$RepoRoot = (Split-Path -Parent $PSScriptRoot).TrimEnd('\')
+
+$makefile = Join-Path $RepoRoot 'Makefile'
+$controlFile = Join-Path $RepoRoot 'pg_textsearch.control'
+$srcDir = Join-Path $RepoRoot 'src'
+foreach ($required in @($makefile, $controlFile, $srcDir)) {
+    if (-not (Test-Path -LiteralPath $required)) {
+        throw "$RepoRoot does not look like a pg_textsearch checkout: missing $required"
+    }
+}
+
+$version = ([regex]::Match((Get-Content -LiteralPath $controlFile -Raw),
+    "default_version\s*=\s*'([^']+)'")).Groups[1].Value
+if (-not $version) {
+    throw "Could not parse default_version from $controlFile"
+}
+$installSql = Join-Path $RepoRoot "sql\pg_textsearch--$version.sql"
+if (-not (Test-Path -LiteralPath $installSql)) {
+    throw "Missing install script for version ${version}: $installSql"
+}
+Write-Detail "repository root: $RepoRoot"
+Write-Detail "pg_textsearch version: $version"
+
+if (-not $PgRoot) {
+    throw 'Specify -PgRoot: the root of a PostgreSQL 17 or 18 x64 tree (containing include\server and lib\postgres.lib).'
+}
+# Relative -PgRoot/-WorkDir follow the caller's location; the repository root
+# never does, it comes from $PSScriptRoot alone.
+$callerDir = (Get-Location).ProviderPath
+$PgRoot = (Get-FullPath -Path $PgRoot -BaseDir $callerDir).TrimEnd('\')
+$pgInclude = Join-Path $PgRoot 'include\server'
+$pgLib = Join-Path $PgRoot 'lib\postgres.lib'
+foreach ($required in @($pgInclude, $pgLib)) {
+    if (-not (Test-Path -LiteralPath $required)) {
+        throw "PgRoot does not look like a PostgreSQL tree: missing $required"
+    }
+}
+
+if ($WorkDir) {
+    $WorkDir = (Get-FullPath -Path $WorkDir -BaseDir $callerDir).TrimEnd('\')
+}
+else {
+    $WorkDir = (Join-Path $RepoRoot 'target\msvc').TrimEnd('\')
+}
+
+# Keep PostgreSQL inputs and build outputs disjoint. This makes cleanup safe
+# even if the scratch layout changes later.
+$pgRootLower = $PgRoot.ToLowerInvariant()
+$workDirLower = $WorkDir.ToLowerInvariant()
+if ($workDirLower -eq $pgRootLower -or $workDirLower.StartsWith($pgRootLower + '\')) {
+    throw 'WorkDir must not be inside PgRoot. This script never writes into the PostgreSQL tree.'
+}
+if ($pgRootLower.StartsWith($workDirLower + '\')) {
+    throw 'PgRoot must not be inside WorkDir. The PostgreSQL tree and build output must not overlap.'
+}
+
+$pgConfigH = Join-Path $pgInclude 'pg_config.h'
+$versionLine = Select-String -LiteralPath $pgConfigH -Pattern '^#define\s+PG_VERSION\s+"' |
+    Select-Object -First 1
+if (-not $versionLine) {
+    throw "Could not read PG_VERSION from $pgConfigH"
+}
+$pgVersion = ([regex]::Match($versionLine.Line, '"([^"]+)"')).Groups[1].Value
+$pgMajor = ([regex]::Match($pgVersion, '^(\d+)')).Groups[1].Value
+Write-Detail "PostgreSQL headers report version $pgVersion"
+if ($ExpectedMajor) {
+    if ($pgMajor -ne $ExpectedMajor) {
+        throw "PgRoot is PostgreSQL $pgVersion but -ExpectedMajor $ExpectedMajor was requested."
+    }
+}
+elseif ($SupportedMajors -notcontains $pgMajor) {
+    throw "PgRoot is PostgreSQL $pgVersion; this script supports $($SupportedMajors -join ' and ')."
+}
+
+$vcvars = Find-VcVars
+Write-Detail "vcvars64.bat: $vcvars"
+Import-VcVarsEnvironment $vcvars
+if ($env:VCToolsVersion) { Write-Detail "MSVC toolset: $env:VCToolsVersion" }
+if ($env:VSCMD_VER) { Write-Detail "Visual Studio: $env:VSCMD_VER" }
+if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
+    throw 'cl.exe is not on PATH after running vcvars64.bat'
+}
+if (-not (Get-Command link.exe -ErrorAction SilentlyContinue)) {
+    throw 'link.exe is not on PATH after running vcvars64.bat'
+}
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+
+Write-Step 'Sources'
+
+# Group by directory: three different directories contain a scan.c, so one
+# flat object directory would silently drop objects.
+$sourceGroups = [ordered]@{}
+$layoutCheckRelative = 'src\layout_check.c'
+$haveLayoutCheck = $false
+$sourceCount = 0
+foreach ($obj in (Get-MakefileVariable -MakefilePath $makefile -Name 'OBJS')) {
+    if ($obj -notmatch '\.o$') { throw "Unexpected OBJS entry in ${makefile}: $obj" }
+    $relative = ($obj -replace '\.o$', '.c') -replace '/', '\'
+    if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot $relative))) {
+        throw "Makefile OBJS lists $obj but $relative does not exist"
+    }
+    if ($relative -eq $layoutCheckRelative) { $haveLayoutCheck = $true }
+    $dir = Split-Path -Parent $relative
+    if (-not $sourceGroups.Contains($dir)) {
+        $sourceGroups[$dir] = New-Object System.Collections.Generic.List[string]
+    }
+    $sourceGroups[$dir].Add($relative)
+    $sourceCount++
+}
+if (-not $haveLayoutCheck) {
+    throw "Makefile OBJS no longer lists $layoutCheckRelative; the struct layout gate would be silently gone."
+}
+Write-Detail "$sourceCount sources in $($sourceGroups.Count) directories, from the Makefile OBJS list"
+
+$dataFiles = Get-MakefileVariable -MakefilePath $makefile -Name 'DATA'
+Write-Detail "$($dataFiles.Count) SQL files from the Makefile DATA list"
+
+# ---------------------------------------------------------------------------
+# Compile
+# ---------------------------------------------------------------------------
+
+Write-Step 'Compile'
+$dll = Join-Path $WorkDir 'pg_textsearch.dll'
+if (Test-Path -LiteralPath $dll) {
+    Remove-Item -LiteralPath $dll -Force
+}
+
+$objRoot = Join-Path $WorkDir 'obj'
+$rspDir = Join-Path $WorkDir 'rsp'
+New-CleanDirectory $objRoot
+New-CleanDirectory $rspDir
+
+# Same include paths as the Makefile (-I$(srcdir)/src) plus the PostgreSQL
+# tree; no source includes "src/...", so no repository-root /I is needed.
+$flags = @($CompileFlags)
+$flags += $CompileDefines
+# \" puts quotes into the /D value so PG_TEXTSEARCH_VERSION becomes a quoted
+# string, same as -DPG_TEXTSEARCH_VERSION=\"...\" in the GCC build.
+$flags += ('/DPG_TEXTSEARCH_VERSION=\"' + $version + '\"')
+$flags += ('/I"' + $srcDir + '"')
+foreach ($include in @('include\server\port\win32_msvc', 'include\server\port\win32', 'include\server', 'include')) {
+    $flags += ('/I"' + (Join-Path $PgRoot $include) + '"')
+}
+
+$objectFiles = New-Object System.Collections.Generic.List[string]
+
+# Compile layout_check.c first and alone: a layout failure then stands alone
+# instead of mixing with errors from every other translation unit.
+Write-Detail "layout gate: compiling $layoutCheckRelative"
+try {
+    Invoke-Cl -Tag 'layout-check' -RspDir $rspDir -ObjDir (Join-Path $objRoot 'src') -Flags $flags `
+        -Sources @((Join-Path $RepoRoot $layoutCheckRelative))
+}
+catch {
+    Write-Host ''
+    Write-Host 'LAYOUT GATE: FAIL' -ForegroundColor Red
+    Write-Host 'The layout-check translation unit did not compile; inspect the compiler diagnostics above.' -ForegroundColor Red
+    Write-Host 'If a static layout assertion failed, this build cannot safely read existing index data.' -ForegroundColor Red
+    throw
+}
+Write-Host '    LAYOUT GATE: PASS' -ForegroundColor Green
+$objectFiles.Add((Join-Path $objRoot ($layoutCheckRelative -replace '\.c$', '.obj')))
+
+foreach ($dir in $sourceGroups.Keys) {
+    $relatives = @($sourceGroups[$dir] | Where-Object { $_ -ne $layoutCheckRelative })
+    if ($relatives.Count -eq 0) { continue }
+    Write-Detail "compiling $($dir -replace '\\', '/') ($($relatives.Count) files)"
+    Invoke-Cl -Tag ($dir -replace '\\', '_') -RspDir $rspDir -ObjDir (Join-Path $objRoot $dir) `
+        -Flags $flags -Sources @($relatives | ForEach-Object { Join-Path $RepoRoot $_ })
+    foreach ($relative in $relatives) {
+        $objectFiles.Add((Join-Path $objRoot ($relative -replace '\.c$', '.obj')))
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Link
+# ---------------------------------------------------------------------------
+
+Write-Step 'Link'
+
+$linkLines = @(
+    '/nologo'
+    '/DLL'
+    '/MACHINE:X64'
+    ('/OUT:"' + $dll + '"')
+    ('/IMPLIB:"' + (Join-Path $objRoot 'pg_textsearch.lib') + '"')
+    ('"' + $pgLib + '"')
+)
+foreach ($obj in $objectFiles) {
+    if (-not (Test-Path -LiteralPath $obj)) { throw "Missing object file: $obj" }
+    $linkLines += ('"' + $obj + '"')
+}
+Write-TextFile -Path (Join-Path $rspDir 'link.rsp') -Lines $linkLines
+Push-Location -LiteralPath $rspDir
+try {
+    & link.exe '@link.rsp'
+    if ($LASTEXITCODE -ne 0) { throw "link.exe failed (exit code $LASTEXITCODE)" }
+}
+finally {
+    Pop-Location
+}
+Write-Detail "linked $($objectFiles.Count) objects into $dll"
+
+# ---------------------------------------------------------------------------
+# Export gate
+# ---------------------------------------------------------------------------
+
+Write-Step 'Export gate'
+
+# Every DATA file, not just the install script: tp_memory_usage is only
+# bound by an upgrade script and would otherwise go unchecked.
+$wanted = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+foreach ($data in $dataFiles) {
+    $path = Join-Path $RepoRoot ($data -replace '/', '\')
+    if (-not (Test-Path -LiteralPath $path)) { throw "Makefile DATA lists $data but it does not exist" }
+    $text = Get-Content -LiteralPath $path -Raw
+    $matched = [regex]::Matches($text, "MODULE_PATHNAME'\s*,\s*'([A-Za-z0-9_]+)'")
+    # The one-argument AS 'MODULE_PATHNAME' form would name the symbol after
+    # the SQL function and escape the regex, so count the mentions too.
+    $mentions = ([regex]::Matches($text, 'MODULE_PATHNAME')).Count
+    if ($mentions -ne $matched.Count) {
+        throw "$data has $mentions MODULE_PATHNAME mentions but $($matched.Count) parse as explicit symbol references; the export gate would miss $($mentions - $matched.Count) of them."
+    }
+    foreach ($match in $matched) { $wanted.Add($match.Groups[1].Value) | Out-Null }
+}
+if ($wanted.Count -eq 0) { throw 'Found no MODULE_PATHNAME symbol references in the DATA SQL files' }
+
+# Case-sensitive comparison: GetProcAddress matches case exactly, while
+# PowerShell string comparison ignores case by default.
+$exported = Get-DllExport -DllPath $dll
+$missing = @($wanted | Where-Object { -not $exported.Contains($_) } | Sort-Object)
+if ($missing.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'EXPORT GATE: FAIL' -ForegroundColor Red
+    Write-Host "Not exported by the DLL: $($missing -join ', ')" -ForegroundColor Red
+    throw 'The built DLL does not export every symbol the SQL scripts bind. A PGDLLEXPORT is probably missing.'
+}
+Write-Host "    EXPORT GATE: PASS ($($wanted.Count) SQL symbols, $($exported.Count) exports in the DLL)" -ForegroundColor Green
+
+Write-Step 'Done'
+Write-Detail ("{0} ({1:N0} bytes)" -f $dll, (Get-Item -LiteralPath $dll).Length)
+Write-Detail 'Nothing was written into the PostgreSQL tree.'


### PR DESCRIPTION
This follows #439, where [tjgreen42 requested an MSVC CI job](https://github.com/timescale/pg_textsearch/pull/439#pullrequestreview-4963637797).

- `scripts/msvc-build.ps1` is the Windows build recipe. PGXS cannot drive MSVC and nmake cannot reuse the GNU Makefile, so instead of a second hand-maintained source list the script reads `OBJS` and `DATA` straight out of the `Makefile`.
- `ci.yml` adds a `build-msvc` matrix for PostgreSQL 17 and 18 on `windows-2022`, the same VS 2022 toolchain used to develop #439; EDB binary zips are pinned by URL and SHA-256. Like `build-test-multiple-configs`, the job compiles and links only, with no tests and no artifacts.
- A `scripts/README.md` entry documents the script and the pin-refresh procedure.

The job adds two checks beyond compilation:

- *Layout:* `src/layout_check.c`, introduced in #439 and already listed in `OBJS`, checks every packed or aligned on-disk struct against the reference GCC x86-64 layout, so MSVC layout drift fails at compile time.
- *Exports:* every symbol bound through `MODULE_PATHNAME` in a `DATA` SQL file must appear in the DLL export table. On Windows, a missing `PGDLLEXPORT` would otherwise surface only when the relevant SQL runs during extension creation or upgrade. Symbol names are compared case-sensitively, and the scan fails closed on any `MODULE_PATHNAME` occurrence it cannot parse as an explicit symbol reference.

`/W3 /WX` mirrors the Unix `-Werror`. The only suppressions are three conversion warnings (C4244, C4267, C4305) that `-Wextra` does not enable; any other warning fails the build.

Verified locally on Windows against the PostgreSQL 17 and 18 EDB trees: both build clean under `/WX` and pass the layout and export gates. [CI run 32907936088](https://github.com/nikitatsym/pg_textsearch/actions/runs/32907936088) passed all jobs, including both MSVC legs.

`build-msvc` sits in `all-tests-passed.needs`, gating merges like the other build jobs.

Out of scope: running the test suite on Windows (needs an installed tree and a running server) and official Windows binaries or packaging.
