### PR TITLE
fix: hold index lock while freeing drained tombstone blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,7 @@ jobs:
   sanitizer:
     name: PG${{ matrix.pg }} Sanitizer
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -517,6 +517,18 @@ jobs:
           cd test/scripts && ./concurrent_duplicate_read.sh
         "
 
+        # Covers the VACUUM-vs-merge races (#411, #465).  Only this
+        # job runs it under sanitizers on a PR, where the windows are
+        # wide enough to hit; scaled down because every page mutation
+        # is slow under ASAN.
+        echo "Running VACUUM concurrency tests under sanitizer..."
+        timeout 900s bash -c "
+          export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
+          export PGHOST=$PWD/tmp_sanitizer_test
+          export PGPORT=55433
+          cd test/scripts && TEST_SIZE_MULTIPLIER=0.35 ./vacuum_concurrent_merge.sh
+        "
+
         echo "Running crash recovery tests under sanitizer..."
         timeout 600s bash -c "
           export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
@@ -614,6 +626,7 @@ jobs:
         path: |
           tmp_sanitizer_test/
           test/scripts/tmp_*
+          test/tmp_*
         retention-days: 7
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,10 +517,9 @@ jobs:
           cd test/scripts && ./concurrent_duplicate_read.sh
         "
 
-        # Covers the VACUUM-vs-merge races (#411, #465).  Only this
-        # job runs it under sanitizers on a PR, where the timing
-        # windows are wide enough to hit.  Run at full scale: the
-        # scaled-down variant finishes too fast to exercise the race.
+        # Covers the VACUUM-vs-merge races (#411, #465).  This is the
+        # only sanitized run of it on a PR, where the timing windows
+        # are wide enough to hit.
         echo "Running VACUUM concurrency tests under sanitizer..."
         timeout 900s bash -c "
           export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,7 @@ jobs:
   sanitizer:
     name: PG${{ matrix.pg }} Sanitizer
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -518,15 +518,15 @@ jobs:
         "
 
         # Covers the VACUUM-vs-merge races (#411, #465).  Only this
-        # job runs it under sanitizers on a PR, where the windows are
-        # wide enough to hit; scaled down because every page mutation
-        # is slow under ASAN.
+        # job runs it under sanitizers on a PR, where the timing
+        # windows are wide enough to hit.  Run at full scale: the
+        # scaled-down variant finishes too fast to exercise the race.
         echo "Running VACUUM concurrency tests under sanitizer..."
         timeout 900s bash -c "
           export PATH=\"$HOME/$PG_INSTALL_DIR/bin:\$PATH\"
           export PGHOST=$PWD/tmp_sanitizer_test
           export PGPORT=55433
-          cd test/scripts && TEST_SIZE_MULTIPLIER=0.35 ./vacuum_concurrent_merge.sh
+          cd test/scripts && ./vacuum_concurrent_merge.sh
         "
 
         echo "Running crash recovery tests under sanitizer..."

--- a/.github/workflows/nightly-stress.yml
+++ b/.github/workflows/nightly-stress.yml
@@ -267,6 +267,7 @@ jobs:
         name: nightly-failure-debug-pg${{ matrix.pg }}
         path: |
           test/scripts/tmp_*/
+          test/tmp_*/
           tmp_nightly_test/
         retention-days: 7
 

--- a/.github/workflows/sanitizer-build-and-test.yml
+++ b/.github/workflows/sanitizer-build-and-test.yml
@@ -330,4 +330,5 @@ jobs:
         path: |
           tmp_sanitizer_test/
           test/scripts/tmp_*
+          test/tmp_*
         retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ test/regression.diffs
 test/regression.out
 test/results/
 tmp_check_shared/
+# Test scratch dirs, at any level (root, test/, test/scripts/)
+tmp_*/
+
+# PGXS dependency-tracking output
+.deps/
 
 # Coverage artifacts
 coverage-html/

--- a/docs/memtable_v2.md
+++ b/docs/memtable_v2.md
@@ -353,7 +353,21 @@ are the durable record.
 | Scan      | `LW_SHARED`      | chain pages SHARED one at a time      |
 | Spill     | `LW_EXCLUSIVE`   | chain pages DEAD via GenericXLog; then metapage + new seg header |
 | Vacuum    | `LW_SHARED`      | reclaim: DEAD pages SHARED read; FSM update not WAL-logged; spill takes `LW_EXCLUSIVE` separately |
+| Vacuum: tombstone drain | `LW_EXCLUSIVE` | per drained tombstone, held across the unlink and that tombstone's page frees |
 | Merge     | (segment-only)   | metapage + new seg header via GenericXLog |
+| Force-merge truncate | `LW_EXCLUSIVE` | held end-to-end across `tp_truncate_dead_pages` → `RelationTruncate` |
+
+Tombstone drain vs truncate: `tp_tombstone_drain()` (VACUUM
+cleanup, `own_lock=true`) and `tp_truncate_dead_pages()`
+(`bm25_force_merge`) are mutually exclusive under the per-index
+`LW_EXCLUSIVE`. Unlinking a tombstone removes its parked blocks
+from `tp_tombstone_max_used_block()`'s high-water mark, so
+truncation would be free to shrink the relation beneath them; the
+drain therefore holds the lock across the unlink *and* the frees.
+Dropping it in between let a concurrent truncate strand the frees
+past EOF, or — after a truncate plus a re-extension — stamp
+`TP_FREE_PAGE_MAGIC` on a block already handed to a live
+structure, a corruption that replicates to standbys.
 
 Insert vs scan: both SHARED at LWLock; the tail buffer's EXCL
 lock serializes the per-page race, the same way any heap or

--- a/docs/memtable_v2.md
+++ b/docs/memtable_v2.md
@@ -361,11 +361,11 @@ Tombstone drain vs truncate: `tp_tombstone_drain()` (VACUUM
 cleanup, `own_lock=true`) and `tp_truncate_dead_pages()`
 (`bm25_force_merge`) are mutually exclusive under the per-index
 `LW_EXCLUSIVE`. Unlinking a tombstone removes its parked blocks
-from `tp_tombstone_max_used_block()`'s high-water mark, so
-truncation would be free to shrink the relation beneath them; the
-drain therefore holds the lock across the unlink *and* the frees.
-Dropping it in between let a concurrent truncate strand the frees
-past EOF, or — after a truncate plus a re-extension — stamp
+from `tp_tombstone_max_used_block()`'s high-water mark, so a
+truncate would then be free to shrink the relation beneath them.
+The drain therefore holds the lock across the unlink *and* the
+frees. Dropping it in between let a truncate strand the frees past
+EOF, or — after a truncate plus a re-extension — stamp
 `TP_FREE_PAGE_MAGIC` on a block already handed to a live
 structure, a corruption that replicates to standbys.
 

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -1215,8 +1215,8 @@ tp_vacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 		 * tombstone chain (metap->pending_free_head and tombstone
 		 * next_page links), so it must run under LW_EXCLUSIVE, not
 		 * LW_SHARED.  tp_tombstone_drain takes/releases the lock per
-		 * unlink (own_lock=true) so concurrent reads never wait more
-		 * than a single unlink.
+		 * drained tombstone (own_lock=true) so concurrent reads never
+		 * wait more than a single unlink plus its page frees.
 		 */
 		if (index_state != NULL)
 		{

--- a/src/segment/tombstone.c
+++ b/src/segment/tombstone.c
@@ -236,6 +236,9 @@ tp_tombstone_drain(
 {
 	uint32 freed = 0;
 
+	/* own_lock=true needs `state` to acquire and release the lock. */
+	Assert(!own_lock || state != NULL);
+
 	for (;;)
 	{
 		BlockNumber	 nblocks;
@@ -256,11 +259,17 @@ tp_tombstone_drain(
 			tp_acquire_index_lock(state, LW_EXCLUSIVE);
 
 		/*
-		 * Read the relation size under the lock, once per iteration.
-		 * The index can shrink between iterations
-		 * (tp_truncate_dead_pages runs under this same lock), so a
-		 * value cached across iterations would be stale-high and would
-		 * let the sanity check below accept an out-of-range block.
+		 * Re-read the relation size under the lock, once per
+		 * iteration.  Note this is NOT what makes the frees below
+		 * safe against a concurrent tp_truncate_dead_pages() — the
+		 * LWLock held across them is (a fresh bound would still go
+		 * stale between the check and the free).  It only keeps the
+		 * defensive b >= nblocks check honest across the gap where
+		 * the lock is dropped between iterations, since the old code
+		 * cached this in a C local for the whole call.  The value
+		 * itself is current either way: outside recovery
+		 * smgrnblocks_cached() refuses the smgr size cache, so
+		 * RelationGetNumberOfBlocks() re-stats the file.
 		 */
 		nblocks = RelationGetNumberOfBlocks(index);
 
@@ -380,9 +389,22 @@ tp_tombstone_drain(
 		 * window where the frees below either read past EOF ("could
 		 * not read blocks N..N in file ...") or, worse, stamped a
 		 * block that a truncate plus a concurrent extension had
-		 * already handed to a live structure.  The extra hold is
-		 * bounded by one tombstone page's block list.
+		 * already handed to a live structure.
+		 *
+		 * Freeing before the unlink would shorten the hold but is
+		 * unsafe: a still-chained tombstone's blocks could be claimed
+		 * from the FSM and then freed again by a later drain of that
+		 * same tombstone.  The hold is bounded by one tombstone
+		 * page's block list (TP_TOMBSTONE_CAPACITY, ~2036 blocks at
+		 * 8kB).  This loop is deliberately free of a cancellation
+		 * point: the tombstone is already unlinked, so erroring out
+		 * part-way would strand the remaining blocks with nothing left
+		 * to free them.  The CHECK_FOR_INTERRUPTS at the head of the
+		 * drain loop cancels between tombstones instead, where the
+		 * chain is consistent.
 		 */
+		Assert(!own_lock ||
+			   LWLockHeldByMeInMode(&state->shared->lock, LW_EXCLUSIVE));
 		{
 			uint32 k;
 

--- a/src/segment/tombstone.c
+++ b/src/segment/tombstone.c
@@ -234,11 +234,11 @@ tp_tombstone_drain(
 		FullTransactionId		  horizon,
 		bool					  own_lock)
 {
-	uint32		freed	= 0;
-	BlockNumber nblocks = RelationGetNumberOfBlocks(index);
+	uint32 freed = 0;
 
 	for (;;)
 	{
+		BlockNumber	 nblocks;
 		BlockNumber	 prev = InvalidBlockNumber;
 		BlockNumber	 cur;
 		BlockNumber	 victim		   = InvalidBlockNumber;
@@ -254,6 +254,15 @@ tp_tombstone_drain(
 
 		if (own_lock)
 			tp_acquire_index_lock(state, LW_EXCLUSIVE);
+
+		/*
+		 * Read the relation size under the lock, once per iteration.
+		 * The index can shrink between iterations
+		 * (tp_truncate_dead_pages runs under this same lock), so a
+		 * value cached across iterations would be stale-high and would
+		 * let the sanity check below accept an out-of-range block.
+		 */
+		nblocks = RelationGetNumberOfBlocks(index);
 
 		/* Walk the chain to find the first past-horizon tombstone. */
 		cur = tp_tombstone_read_head(index);
@@ -361,10 +370,19 @@ tp_tombstone_drain(
 		/* Unlink first (corruption-safe; a crash here only leaks). */
 		tombstone_unlink(index, victim_prev, victim, victim_next);
 
-		if (own_lock)
-			tp_release_index_lock(state);
-
-		/* Now free the victim's blocks + its own page, unlocked. */
+		/*
+		 * Free the victim's blocks and its own page while still
+		 * holding the per-index lock.  Once unlinked they are no
+		 * longer visible to tp_tombstone_max_used_block(), so
+		 * tp_truncate_dead_pages() — which runs under this same lock
+		 * (see bm25_force_merge) — is free to truncate the relation
+		 * below them.  Dropping the lock here therefore opened a
+		 * window where the frees below either read past EOF ("could
+		 * not read blocks N..N in file ...") or, worse, stamped a
+		 * block that a truncate plus a concurrent extension had
+		 * already handed to a live structure.  The extra hold is
+		 * bounded by one tombstone page's block list.
+		 */
 		{
 			uint32 k;
 
@@ -373,6 +391,10 @@ tp_tombstone_drain(
 			tp_record_free_index_page(index, victim);
 			freed += victim_count + 1;
 		}
+
+		if (own_lock)
+			tp_release_index_lock(state);
+
 		if (victim_blocks)
 			pfree(victim_blocks);
 	}

--- a/src/segment/tombstone.c
+++ b/src/segment/tombstone.c
@@ -259,17 +259,10 @@ tp_tombstone_drain(
 			tp_acquire_index_lock(state, LW_EXCLUSIVE);
 
 		/*
-		 * Re-read the relation size under the lock, once per
-		 * iteration.  Note this is NOT what makes the frees below
-		 * safe against a concurrent tp_truncate_dead_pages() — the
-		 * LWLock held across them is (a fresh bound would still go
-		 * stale between the check and the free).  It only keeps the
-		 * defensive b >= nblocks check honest across the gap where
-		 * the lock is dropped between iterations, since the old code
-		 * cached this in a C local for the whole call.  The value
-		 * itself is current either way: outside recovery
-		 * smgrnblocks_cached() refuses the smgr size cache, so
-		 * RelationGetNumberOfBlocks() re-stats the file.
+		 * Re-read under the lock each iteration: the lock is dropped
+		 * between iterations and the relation can shrink.  This only
+		 * keeps the b >= nblocks check below honest; it is not what
+		 * makes the frees safe (see below).
 		 */
 		nblocks = RelationGetNumberOfBlocks(index);
 
@@ -380,28 +373,18 @@ tp_tombstone_drain(
 		tombstone_unlink(index, victim_prev, victim, victim_next);
 
 		/*
-		 * Free the victim's blocks and its own page while still
-		 * holding the per-index lock.  Once unlinked they are no
-		 * longer visible to tp_tombstone_max_used_block(), so
-		 * tp_truncate_dead_pages() — which runs under this same lock
-		 * (see bm25_force_merge) — is free to truncate the relation
-		 * below them.  Dropping the lock here therefore opened a
-		 * window where the frees below either read past EOF ("could
-		 * not read blocks N..N in file ...") or, worse, stamped a
-		 * block that a truncate plus a concurrent extension had
-		 * already handed to a live structure.
+		 * Free under the same lock as the unlink.  Once unlinked the
+		 * blocks are invisible to tp_tombstone_max_used_block(), so
+		 * tp_truncate_dead_pages() (bm25_force_merge, same lock) could
+		 * truncate below them, leaving these frees to read past EOF or
+		 * to stamp a block that a truncate plus re-extension already
+		 * handed to a live structure.  Freeing before the unlink is no
+		 * better: a still-chained tombstone's blocks could be claimed
+		 * from the FSM, then freed again by a later drain.
 		 *
-		 * Freeing before the unlink would shorten the hold but is
-		 * unsafe: a still-chained tombstone's blocks could be claimed
-		 * from the FSM and then freed again by a later drain of that
-		 * same tombstone.  The hold is bounded by one tombstone
-		 * page's block list (TP_TOMBSTONE_CAPACITY, ~2036 blocks at
-		 * 8kB).  This loop is deliberately free of a cancellation
-		 * point: the tombstone is already unlinked, so erroring out
-		 * part-way would strand the remaining blocks with nothing left
-		 * to free them.  The CHECK_FOR_INTERRUPTS at the head of the
-		 * drain loop cancels between tombstones instead, where the
-		 * chain is consistent.
+		 * No CHECK_FOR_INTERRUPTS here — the tombstone is already
+		 * unlinked, so erroring part-way strands the rest.  The loop
+		 * is bounded by TP_TOMBSTONE_CAPACITY.
 		 */
 		Assert(!own_lock ||
 			   LWLockHeldByMeInMode(&state->shared->lock, LW_EXCLUSIVE));

--- a/src/segment/tombstone.h
+++ b/src/segment/tombstone.h
@@ -99,8 +99,11 @@ extern BlockNumber tp_tombstone_enqueue_extend(
  *
  * `own_lock` selects locking discipline:
  *   - true  (vacuum path): acquire/release the per-index LWLock
- *     EXCLUSIVE around each single unlink, so reads never wait more
- *     than one unlink.  `state` must be non-NULL.
+ *     EXCLUSIVE once per drained tombstone, held across the unlink
+ *     AND that tombstone's page frees so a concurrent
+ *     tp_truncate_dead_pages() cannot shrink the relation beneath
+ *     them.  Reads therefore wait for one chain walk, unlink, and up
+ *     to TP_TOMBSTONE_CAPACITY page frees.  `state` must be non-NULL.
  *   - false (merge path): caller already holds the per-index lock
  *     EXCLUSIVE end-to-end; `state` is ignored.
  *

--- a/src/segment/tombstone.h
+++ b/src/segment/tombstone.h
@@ -98,12 +98,11 @@ extern BlockNumber tp_tombstone_enqueue_extend(
  * its listed blocks and its own page.
  *
  * `own_lock` selects locking discipline:
- *   - true  (vacuum path): acquire/release the per-index LWLock
- *     EXCLUSIVE once per drained tombstone, held across the unlink
- *     AND that tombstone's page frees so a concurrent
- *     tp_truncate_dead_pages() cannot shrink the relation beneath
- *     them.  Reads therefore wait for one chain walk, unlink, and up
- *     to TP_TOMBSTONE_CAPACITY page frees.  `state` must be non-NULL.
+ *   - true  (vacuum path): take the per-index LWLock EXCLUSIVE once
+ *     per drained tombstone, held across the unlink and that
+ *     tombstone's page frees (see tp_tombstone_drain).  Readers wait
+ *     for one chain walk, unlink, and up to TP_TOMBSTONE_CAPACITY
+ *     frees.  `state` must be non-NULL.
  *   - false (merge path): caller already holds the per-index lock
  *     EXCLUSIVE end-to-end; `state` is ignored.
  *

--- a/test/scripts/vacuum_concurrent_merge.sh
+++ b/test/scripts/vacuum_concurrent_merge.sh
@@ -21,8 +21,9 @@
 # tombstone chain, which stranded the drain's page frees past EOF
 # ("could not read blocks N..N ... read only 0 of 8192 bytes").
 #
-# TEST_SIZE_MULTIPLIER scales the loop counts (default 1.0); CI uses a
-# smaller value under sanitizers, where every page mutation is slow.
+# TEST_SIZE_MULTIPLIER scales the loop counts (default 1.0), for
+# scaling the run down on a constrained runner.  Prefer full scale:
+# these are timing races, and a shorter run finds them less often.
 #
 
 set -e

--- a/test/scripts/vacuum_concurrent_merge.sh
+++ b/test/scripts/vacuum_concurrent_merge.sh
@@ -15,6 +15,15 @@
 # is also aggressive).  Before the fix this fails within seconds; after it,
 # it completes cleanly with no segment-header errors and no crash.
 #
+# It also covers the tombstone-drain-vs-truncate race (issue #465):
+# the merger's bm25_force_merge truncates the index via
+# tp_truncate_dead_pages while the vacuumer drains the deferred-free
+# tombstone chain, which stranded the drain's page frees past EOF
+# ("could not read blocks N..N ... read only 0 of 8192 bytes").
+#
+# TEST_SIZE_MULTIPLIER scales the loop counts (default 1.0); CI uses a
+# smaller value under sanitizers, where every page mutation is slow.
+#
 
 set -e
 
@@ -24,6 +33,14 @@ TEST_DB=vacuum_concurrent_merge_test
 DATA_DIR="${SCRIPT_DIR}/../tmp_vacuum_concurrent_merge"
 LOGFILE="${DATA_DIR}/postgres.log"
 ERR_DIR="${DATA_DIR}/client_logs"
+KEEP_DIR="${SCRIPT_DIR}/../tmp_vacuum_concurrent_merge_logs"
+TEST_SIZE_MULTIPLIER=${TEST_SIZE_MULTIPLIER:-1.0}
+
+# Scale a loop count by TEST_SIZE_MULTIPLIER (minimum 1).
+scaled_count() {
+    awk "BEGIN {n = int($1 * ${TEST_SIZE_MULTIPLIER} + 0.5);
+                print (n < 1 ? 1 : n)}"
+}
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -40,6 +57,16 @@ cleanup() {
     jobs -p | xargs -r kill 2>/dev/null || true
     if [ -f "${DATA_DIR}/postmaster.pid" ]; then
         pg_ctl stop -D "${DATA_DIR}" -m immediate &>/dev/null || true
+    fi
+    # Preserve the logs on failure: without the server log a CI
+    # reproduction is undebuggable, and the data dir itself is too
+    # large to upload.
+    if [ "$exit_code" -ne 0 ] && [ -d "${DATA_DIR}" ]; then
+        rm -rf "${KEEP_DIR}"
+        mkdir -p "${KEEP_DIR}"
+        cp "${LOGFILE}" "${KEEP_DIR}/" 2>/dev/null || true
+        cp -r "${ERR_DIR}" "${KEEP_DIR}/" 2>/dev/null || true
+        warn "Preserved logs in ${KEEP_DIR}"
     fi
     rm -rf "${DATA_DIR}"
     exit $exit_code
@@ -97,7 +124,7 @@ SQL
 # Spill the memtable aggressively so many small segments accrue for the
 # merger to compact.
 writer() {
-    for i in $(seq 1 120); do
+    for i in $(seq 1 $(scaled_count 120)); do
         $PSQL -c "SET pg_textsearch.memtable_pages_threshold=4;
           SET statement_timeout='60s'; SET lock_timeout='30s';
           INSERT INTO docs (body)
@@ -111,7 +138,7 @@ writer() {
 # Concurrent spill + force-merge: the LW_EXCLUSIVE segment recycler that
 # races VACUUM.
 merger() {
-    for i in $(seq 1 250); do
+    for i in $(seq 1 $(scaled_count 250)); do
         $PSQL -c "SELECT bm25_spill_index('docs_bm25');
                   SELECT bm25_force_merge('docs_bm25')" \
           >>"${ERR_DIR}/merger.log" 2>&1 || return 30
@@ -121,7 +148,7 @@ merger() {
 # Delete the oldest rows by id (monotonic -> no row-lock deadlocks) to
 # create dead tuples for VACUUM bulk-delete to reclaim.
 deleter() {
-    for i in $(seq 1 250); do
+    for i in $(seq 1 $(scaled_count 250)); do
         $PSQL -c "DELETE FROM docs
                   WHERE id IN (SELECT id FROM docs ORDER BY id ASC LIMIT 120)" \
           >>"${ERR_DIR}/deleter.log" 2>&1 || return 40
@@ -132,7 +159,7 @@ deleter() {
 # Explicit VACUUM in a loop deterministically exercises the bulk-delete and
 # cleanup paths concurrently with the merger.
 vacuumer() {
-    for i in $(seq 1 200); do
+    for i in $(seq 1 $(scaled_count 200)); do
         $PSQL -c "VACUUM docs" >>"${ERR_DIR}/vacuumer.log" 2>&1 || return 50
         sleep 0.05
     done
@@ -159,6 +186,19 @@ run_test() {
         warn "Found 'invalid segment header':"
         grep -RIn "invalid segment header" "${ERR_DIR}" "${LOGFILE}" | head -5
         error "TEST FAILED: issue #411 reproduced (invalid segment header)"
+    fi
+
+    # The tombstone-drain-vs-truncate race (issue #465): the drain
+    # frees a block that a concurrent force-merge truncate already
+    # removed.  Check explicitly — an autovacuum-side occurrence is
+    # server-log only and would otherwise slip past the client-exit
+    # check below.
+    if grep -REIl "could not read blocks?.*read only [0-9]+ of" \
+        "${ERR_DIR}" "${LOGFILE}" >/dev/null 2>&1; then
+        warn "Found a past-EOF index read:"
+        grep -REIn "could not read blocks?.*read only [0-9]+ of" \
+            "${ERR_DIR}" "${LOGFILE}" | head -5
+        error "TEST FAILED: issue #465 reproduced (read past EOF)"
     fi
 
     # An out-of-bounds alive-bitset write crashes the backend.

--- a/test/scripts/vacuum_concurrent_merge.sh
+++ b/test/scripts/vacuum_concurrent_merge.sh
@@ -16,14 +16,13 @@
 # it completes cleanly with no segment-header errors and no crash.
 #
 # It also covers the tombstone-drain-vs-truncate race (issue #465):
-# the merger's bm25_force_merge truncates the index via
-# tp_truncate_dead_pages while the vacuumer drains the deferred-free
-# tombstone chain, which stranded the drain's page frees past EOF
-# ("could not read blocks N..N ... read only 0 of 8192 bytes").
+# bm25_force_merge truncates the index via tp_truncate_dead_pages
+# while VACUUM drains the deferred-free tombstone chain, stranding the
+# drain's page frees past EOF ("could not read blocks N..N").
 #
-# TEST_SIZE_MULTIPLIER scales the loop counts (default 1.0), for
-# scaling the run down on a constrained runner.  Prefer full scale:
-# these are timing races, and a shorter run finds them less often.
+# TEST_SIZE_MULTIPLIER scales the loop counts (default 1.0) for
+# constrained runners.  Prefer full scale: these are timing races, and
+# a shorter run finds them less often.
 #
 
 set -e
@@ -59,9 +58,8 @@ cleanup() {
     if [ -f "${DATA_DIR}/postmaster.pid" ]; then
         pg_ctl stop -D "${DATA_DIR}" -m immediate &>/dev/null || true
     fi
-    # Preserve the logs on failure: without the server log a CI
-    # reproduction is undebuggable, and the data dir itself is too
-    # large to upload.
+    # Preserve the logs on failure: the data dir is too large to
+    # upload, and without the server log a CI failure is undebuggable.
     if [ "$exit_code" -ne 0 ] && [ -d "${DATA_DIR}" ]; then
         rm -rf "${KEEP_DIR}"
         mkdir -p "${KEEP_DIR}"
@@ -189,11 +187,9 @@ run_test() {
         error "TEST FAILED: issue #411 reproduced (invalid segment header)"
     fi
 
-    # The tombstone-drain-vs-truncate race (issue #465): the drain
-    # frees a block that a concurrent force-merge truncate already
-    # removed.  Check explicitly — an autovacuum-side occurrence is
-    # server-log only and would otherwise slip past the client-exit
-    # check below.
+    # The tombstone-drain-vs-truncate race (issue #465).  Check
+    # explicitly: an autovacuum-side occurrence is server-log only and
+    # would slip past the client-exit check below.
     if grep -REIl "could not read blocks?.*read only [0-9]+ of" \
         "${ERR_DIR}" "${LOGFILE}" >/dev/null 2>&1; then
         warn "Found a past-EOF index read:"


### PR DESCRIPTION
## Problem

The `Sanitizer test` workflow failed on `main` (run [32755889405](https://github.com/timescale/pg_textsearch/actions/runs/32755889405), both PG17.2 and PG18.1) in `test/scripts/vacuum_concurrent_merge.sh`:

```
ERROR:  could not read blocks 296..296 in file "base/16384/16450": read only 0 of 8192 bytes
CONTEXT:  while cleaning up index "docs_bm25" of relation "public.docs"
```

No ASAN/UBSAN report accompanied it — this is a plain read-past-EOF.

## Root cause

`tp_tombstone_drain()` unlinks a past-horizon tombstone page from the deferred-free chain (#380), **releases the per-index LWLock**, and only then frees the blocks that tombstone parked.

Once unlinked, those blocks are invisible to `tp_tombstone_max_used_block()`, so a concurrent `bm25_force_merge` → `tp_truncate_dead_pages()` → `RelationTruncate()` — which runs under that same lock — truncates the relation below them. The subsequent `ReadBuffer()` in `tp_record_free_index_page()` is then past EOF.

The error is the *benign* outcome. If another backend extended the relation after the truncate, the unlocked free would stamp `TP_FREE_PAGE_MAGIC` on a block already handed to a live structure and push it into the FSM. That stamp is WAL-logged, so the corruption would replicate to standbys.

### Where it came from

Not #380, and **not a regression from #462**. `f69d22d7` (#380) introduced the release-before-free, but the free was then a pure `RecordFreeIndexPage()` — an FSM push that never touches the page, so running it unlocked was harmless. `08048d29` (#429, #427) swapped in the buffer-reading `tp_record_free_index_page()` and kept the early release, which is what made the window exploitable.

A/B against #462's parent (`c3bb8e2c`) reproduces the failure identically (1/8 runs); #462 only shifted VACUUM timing.

### Evidence

Built a clang+ASAN PostgreSQL 18 matching the sanitizer workflow and reproduced the CI error locally (~1 failure per 5 runs; never reproduces on a non-sanitizer build). Backtrace via `backtrace_functions`:

```
md_readv_report <- mdreadv <- ReadBuffer
  <- tp_record_free_index_page  (src/index/freepage.c:39)
  <- tp_tombstone_drain         (src/segment/tombstone.c)
  <- tp_vacuumcleanup           (src/access/vacuum.c:1229)
```

Temporary instrumentation in the drain caught the relation shrinking mid-drain, immediately before the error:

```
TPDBG drain listed blk=138 victim=110 nblocks_entry=149 nblocks_now=114
ERROR:  could not read blocks 138..138 ... read only 0 of 8192 bytes
```

## Fix

Hold the per-index LWLock EXCLUSIVE from the unlink through the victim's page frees, making the drain and `tp_truncate_dead_pages()` mutually exclusive. That mutual exclusion is the whole fix; the rest is hardening.

The extra hold is bounded by one tombstone page's block list (`TP_TOMBSTONE_CAPACITY`, ~2036 blocks). Freeing *before* the unlink would shorten it but is not safe: a still-chained tombstone's blocks could be claimed from the FSM and then freed a second time by a later drain of that same tombstone.

The free loop deliberately has no cancellation point — the tombstone is already unlinked, so erroring out part-way would strand the remaining blocks with nothing left to free them. The existing `CHECK_FOR_INTERRUPTS` at the head of the drain loop cancels between tombstones, where the chain is consistent.

`Assert(!own_lock || LWLockHeldByMeInMode(...))` pins the invariant, so a future change that moves the release back up trips deterministically in any `--enable-cassert` build instead of waiting for the timing window.

Also re-read `RelationGetNumberOfBlocks()` once per drain iteration rather than caching it in a C local for the whole call. To be clear about what this does and does not do: it is **not** what makes the frees safe — a fresh bound still goes stale between the check and the free, and the lock is the only real guard. It just keeps the defensive out-of-range check honest across the gap where the lock is dropped between iterations.

## Testing

- `make installcheck`: 75/75 pass (assert-enabled PG18).
- `make format-check`: clean.
- ASAN `vacuum_concurrent_merge.sh`: 60 consecutive runs pass, against a baseline of ~3 failures per 27 runs. Useful, but a clean run of a timing race is weak evidence on its own — the real argument is the mutual-exclusion invariant, plus the assert that now enforces it deterministically.

## CI coverage

The gap that let this reach `main` was the *combination*, not sanitizers alone:

- `ci.yml` runs `vacuum_concurrent_merge.sh` in the plain, non-sanitizer job — the window there is too narrow to hit (10/10 pass locally on a normal build).
- `ci.yml`'s own sanitizer job ran the regression tests plus `concurrency.sh` and `concurrent_duplicate_read.sh`, but not `vacuum_concurrent_merge.sh`.
- Only `sanitizer-build-and-test.yml`, which is `main`-only, ran it *under* sanitizers.

This PR closes that:

- Run `vacuum_concurrent_merge.sh` in `ci.yml`'s sanitizer job, at full scale. The job has ample budget — it finishes in ~14m against a 45m timeout. (A first attempt scaled it to 0.35 and completed in 16s, which verified the script *runs* rather than that the race is absent; not useful for a timing race. A `TEST_SIZE_MULTIPLIER` knob remains, for constrained runners.) That job builds with `--enable-cassert`, so the new assert is live there too.
- Grep for the past-EOF signature explicitly. The race can surface in autovacuum, where it is server-log only and would otherwise slip past the client exit-code check.
- Preserve the server and client logs on failure. The script's cleanup trap deleted its data dir, so the original failing run's CI artifacts contained no server log at all.
- Upload `test/tmp_*` as failure artifacts. Every shell test writes there, but all three workflows only globbed `test/scripts/tmp_*`, so shell-test logs were never actually collected.
- Ignore test scratch dirs and PGXS `.deps/` output, neither of which was ignored.

## Follow-ups (not in this PR)

- #468 — `tp_record_free_index_page()` reads the block with no bounds check of its own; a WARNING-and-skip there would turn any future stale-block bug into a log line instead of an `ERROR`.
- #469 — the three tombstone chain walks don't bound `cur` against `nblocks` before reading, so a corrupt `next_page` past EOF errors out before reaching the magic check that would otherwise self-heal.
- A deterministic injection test for drain-vs-truncate (the assert covers the regression case, so this is lower priority).