### PR TITLE
Add per-index compaction controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,20 @@ jobs:
           echo "✗ Deferred-reclaim crash recovery tests failed"
           exit 1
         fi
+        echo "Running per-index compaction recovery-guard tests..."
+        if (cd test/scripts && ./compaction_recovery.sh); then
+          echo "✓ Compaction recovery-guard tests passed"
+        else
+          echo "✗ Compaction recovery-guard tests failed"
+          exit 1
+        fi
+        echo "Running compaction ownership-check source guard..."
+        if (cd test/scripts && ./compaction_ownercheck_source.sh); then
+          echo "✓ Compaction ownership-check source guard passed"
+        else
+          echo "✗ Compaction ownership-check source guard failed"
+          exit 1
+        fi
         echo "Running shutdown spill tests..."
         if (cd test/scripts && ./shutdown_spill.sh); then
           echo "✓ Shutdown spill tests passed"
@@ -701,6 +715,7 @@ jobs:
         (cd test/scripts && ./segment.sh) || true
         (cd test/scripts && ./recovery.sh) || true
         (cd test/scripts && ./standby_reclaim.sh) || true
+        (cd test/scripts && ./compaction_recovery.sh) || true
         (cd test/scripts && ./shutdown_spill.sh) || true
         (cd test/scripts && ./cic.sh) || true
         (cd test/scripts && ./multi_index.sh) || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,9 +288,22 @@ See [RELEASING.md](RELEASING.md) for release instructions.
   `pg_textsearch.max_segment_size`. It does **not** guarantee a single
   segment: large indexes may intentionally retain several immutable
   segments, and an existing segment that already exceeds the budget
-  remains an indivisible singleton. Published sources stay immutable
+  remains an uncombinable singleton. Published sources stay immutable
   while replacements are built; displaced pages enter deferred reclaim
   (see #380) rather than becoming immediately reusable.
+- `bm25_level_counts(idx regclass)` - Segments held at each of the eight
+  LSM levels
+- `bm25_needs_compaction(idx regclass)` - Whether any level holds at
+  least `segments_per_level` segments. Advisory only: a level whose
+  segments all exceed `max_segment_size` cannot be reduced but still
+  counts as full, so this must not be used on its own as a loop
+  condition. Drive loops from `bm25_compact_step()`'s return value.
+- `bm25_compact(idx regclass)` - Run compaction passes to completion
+  under one per-index exclusive lock. Requires index ownership. A
+  published pass is a physical change and is **not** undone by ROLLBACK.
+- `bm25_compact_step(idx regclass)` - Run at most one pass and report
+  whether one ran, letting a caller spread a cascade over several
+  transactions. Requires index ownership.
 - `bm25_pending_free_pages(index_name)` - Count displaced segment pages
   currently parked in the deferred-free tombstone chain (issue #380),
   awaiting standby-safe FSM reclaim

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ OBJS = \
 	src/access/build.o \
 	src/access/build_context.o \
 	src/access/build_parallel.o \
+	src/access/compaction_api.o \
 	src/access/scan.o \
 	src/access/vacuum.o \
 	src/memtable/arena.o \
@@ -86,7 +87,7 @@ PG_CPPFLAGS += -Wno-unknown-warning-option -Wno-clobbered -Wno-packed-not-aligne
 # PG_CPPFLAGS += -DDEBUG_DUMP_INDEX
 
 # Test configuration
-REGRESS = abort aerodocs basic binary_io bmw bmw_skip_advance bulk_load cache_apply cache_memory_cap cache_source cache_spill catalog_stats chain_source compression concurrent_build coverage deletion vacuum vacuum_bitmap vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index filtered_seed force_merge implicit index inheritance large_documents limits lock manyterms memory memtable_append memtable_page memtable_spill memtable_spill_dead memtable_reclaim merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security security_acl segment segment_integrity segment_reclaim tombstone_reuse tombstone_recover strings temp_table text_array text_config unsupported updates vector vector_v1_rejected unlogged_index wand
+REGRESS = abort aerodocs basic binary_io bmw bmw_skip_advance bulk_load cache_apply cache_memory_cap cache_source cache_spill catalog_stats chain_source compaction compression concurrent_build coverage deletion vacuum vacuum_bitmap vacuum_extended vacuum_rebuild dropped empty explicit_index expression_index filtered_seed force_merge implicit index inheritance large_documents limits lock manyterms memory memtable_append memtable_page memtable_spill memtable_spill_dead memtable_reclaim merge mixed parallel_build parallel_bmw partitioned partitioned_many partial_index pgstats queries quoted_identifiers rescan schema scoring1 scoring2 scoring3 scoring4 scoring5 scoring6 security security_acl segment segment_integrity segment_reclaim tombstone_reuse tombstone_recover strings temp_table text_array text_config unsupported updates vector vector_v1_rejected unlogged_index wand
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG ?= pg_config
@@ -94,9 +95,12 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 # SQL regression tests
-test:
+test: test-compaction-ownercheck
 	@echo "Running SQL regression tests..."
 	@$(pg_regress_installcheck) $(REGRESS_OPTS) $(REGRESS)
+
+test-compaction-ownercheck:
+	@./test/scripts/compaction_ownercheck_source.sh
 
 # Custom local test target with dedicated PostgreSQL instance
 test-local: install
@@ -136,6 +140,7 @@ test-recovery:
 	@cd test/scripts && ./recovery.sh
 	@cd test/scripts && ./shutdown_spill.sh
 	@cd test/scripts && ./standby_reclaim.sh
+	@cd test/scripts && ./compaction_recovery.sh
 
 test-segment:
 	@echo "Running multi-backend segment tests..."
@@ -344,6 +349,7 @@ help:
 	@echo ""
 	@echo "Testing targets:"
 	@echo "  make test         - Run source guard and SQL regression tests"
+	@echo "  make test-compaction-ownercheck - Check compaction ownership ordering"
 	@echo "  make installcheck - Run SQL regression tests"
 	@echo "  make test-local   - Run tests with dedicated PostgreSQL instance"
 	@echo "  make test-all     - Run all tests (SQL regression + shell scripts)"
@@ -378,4 +384,4 @@ help:
 	@echo "  make test-all"
 	@echo "  make format"
 
-.PHONY: test clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help
+.PHONY: test test-compaction-ownercheck clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help

--- a/README.md
+++ b/README.md
@@ -363,9 +363,59 @@ SELECT bm25_force_merge('docs_idx');
 
 Published source segments remain immutable while replacement segments are
 built. Existing segments that already exceed the configured size budget
-remain indivisible singletons. Pages displaced by publication enter deferred
+remain uncombinable singletons. Pages displaced by publication enter deferred
 reclaim rather than becoming immediately reusable. Best used after large
 batch inserts, not during ongoing write traffic.
+
+#### Compacting an index
+
+`bm25_force_merge()` collapses an index into as few segments as it can. When
+you instead want to work off only the levels that have accumulated segments,
+use the threshold-driven controls:
+
+```sql
+-- Is any level at pg_textsearch.segments_per_level segments?
+SELECT bm25_needs_compaction('docs_idx'::regclass);
+
+-- Segments held at each of the eight LSM levels
+SELECT bm25_level_counts('docs_idx'::regclass);
+
+-- Compact until no level is over threshold
+SELECT bm25_compact('docs_idx'::regclass);
+
+-- Or run a single pass, reporting whether one ran
+SELECT bm25_compact_step('docs_idx'::regclass);
+```
+
+A *pass* is the unit of work and of publication: every segment a pass produces
+becomes visible in one metapage update, so a pass that fails leaves the layout
+it started from. `bm25_compact()` runs passes until none is due, all under one
+per-index exclusive lock. `bm25_compact_step()` runs at most one, so a
+maintenance job can spread a cascade over several transactions and release the
+lock in between.
+
+Three properties matter when scripting these:
+
+- **A published pass is not undone by `ROLLBACK`.** It is a physical change,
+  so a cascade that errors partway leaves its earlier passes applied.
+- **Neither mutating function is cancellable while a pass runs**, and a pass
+  is not a bounded amount of work. Holding the lock also holds off interrupts.
+- **`bm25_needs_compaction()` is advisory and must not be used on its own as
+  a loop condition.** It answers "is any level at the threshold", not "is
+  there work to do": a level whose segments all exceed
+  `pg_textsearch.max_segment_size` cannot be reduced but still counts as
+  full, so `WHILE bm25_needs_compaction(...) DO bm25_compact_step(...)` never
+  terminates on such an index. Drive the loop from `bm25_compact_step()`'s
+  return value instead, and stop when it returns false.
+
+The mutating functions require ownership of the index. They are rejected on
+partitioned parent indexes, which have no storage of their own — compact each
+partition's index instead — and during recovery. A session can compact its own
+temporary index in a read-only transaction; permanent and unlogged indexes it
+cannot.
+
+See [docs/background_compaction.md](docs/background_compaction.md) for the
+engine's level, sizing, and page-reclaim rules.
 
 #### Index fragmentation on update-heavy workloads
 
@@ -559,9 +609,12 @@ incremental inserts. This is an active area of development.
 
 ### No Background Compaction
 
-Segment compaction currently runs synchronously during memtable spill
-operations. Write-heavy workloads may observe compaction latency during
-spills. Background compaction is planned for a future release.
+Segment compaction runs synchronously during memtable spill operations, so
+write-heavy workloads may observe compaction latency during spills. No
+background worker compacts on its own; `bm25_compact()` and
+`bm25_compact_step()` let an external job drive it on a schedule of your
+choosing. See [Compacting an index](#compacting-an-index). A built-in
+background scheduler is planned for a future release.
 
 ### Partitioned Tables
 
@@ -799,6 +852,22 @@ An end-to-end regression test for this setup lives in
 above applies the same `n,v,a,i,e,l` zhparser mapping to a chunked
 `text[]` column.
 
+### Compaction Functions
+
+Compaction runs automatically during memtable spills. These functions let an
+administrator or a maintenance job drive it explicitly. All four take a
+`regclass`, so an index can be named as `'docs_idx'::regclass` or by OID. The
+mutating functions require ownership of the index; the inspection functions do
+not. See [Compacting an index](#compacting-an-index) for the caveats that
+matter when scripting them.
+
+Function | Description
+--- | ---
+bm25_level_counts(index) → int4[] | Segments held at each of the eight LSM levels
+bm25_needs_compaction(index) → bool | Whether any level holds at least `segments_per_level` segments; advisory only, and not safe as a loop condition on its own
+bm25_compact(index) → void | Run compaction passes to completion under one per-index exclusive lock
+bm25_compact_step(index) → bool | Run at most one pass and report whether one ran, letting a caller spread a cascade over several transactions
+
 ### Development Functions
 
 These functions are for debugging and development use only. Their interface may
@@ -807,8 +876,9 @@ superuser privileges.
 
 Function | Description
 --- | ---
-bm25_force_merge(index_name) → void | Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; over-budget singletons remain indivisible and displaced pages enter deferred reclaim
+bm25_force_merge(index_name) → void | Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; over-budget singletons remain uncombinable and displaced pages enter deferred reclaim
 bm25_spill_index(index_name) → int4 | Force memtable spill to disk segment
+bm25_pending_free_pages(index_name) † → int8 | Count displaced segment pages parked in the deferred-free chain, awaiting standby-safe reclaim
 bm25_dump_index(index_name) † → text | Dump internal index structure (truncated)
 bm25_summarize_index(index_name) † → text | Show index statistics without content
 

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -1,0 +1,74 @@
+# Native compaction controls
+
+pg_textsearch provides scheduler-independent SQL functions for inspecting and
+compacting one BM25 index:
+
+- `bm25_level_counts(regclass)` returns the persisted segment count for each
+  of the eight LSM levels.
+- `bm25_needs_compaction(regclass)` reports whether any compactable level,
+  L0 through L6, has reached `pg_textsearch.segments_per_level`.
+- `bm25_compact(regclass)` runs compaction passes until no compactable level
+  is left with debt this engine can reduce.
+- `bm25_compact_step(regclass)` runs at most one compaction pass and returns
+  whether a pass ran.
+
+Both mutating functions drive the same size-bounded compaction engine that
+threshold compaction and `bm25_force_merge()` use, so they share its
+capacity, sizing, and reclaim behavior.
+
+## Passes
+
+A pass is the engine's unit of work and its unit of publication. The planner
+selects the lowest triggered level, groups its segments into batches that fit
+`pg_textsearch.max_segment_size`, and recursively plans any additional
+compaction needed to make room at the destination levels. The whole plan is
+built and validated against the per-level segment capacity before a single
+page is written, so a pass either publishes completely or leaves the index
+exactly as it found it.
+
+Because each pass is independently complete, `bm25_compact()` and repeated
+`bm25_compact_step()` calls converge on the same layout. They differ only in
+how long the lock is held.
+
+Both functions act on segments only. They are the same operation the storage
+layer runs at the tail of a spill, exposed for manual and scheduled use, so
+neither flushes the memtable first. Use `bm25_spill_index()` for that, or
+`bm25_force_merge()`, which spills and then compacts as aggressively as the
+size budget allows.
+
+## Locking
+
+The two mutating functions require ownership of the index. They open the
+relation with `RowExclusiveLock` and hold the index's `LW_EXCLUSIVE` lock
+while merging. `bm25_compact()` holds that lock for the entire cascade.
+`bm25_compact_step()` releases it after one pass, allowing callers to split a
+cascade across transactions.
+
+## Restrictions
+
+Permanent and unlogged indexes cannot be compacted in a read-only transaction,
+and no index can be compacted during recovery. A local temporary index remains
+available to its owning backend and may be compacted in a read-only
+transaction.
+
+Partitioned BM25 parent indexes have no physical storage and are rejected by
+all four per-index functions. Call the functions on the physical indexes of
+individual partitions instead.
+
+## Debt that cannot be reduced
+
+`bm25_needs_compaction()` is a cheap advisory signal derived from the level
+counts alone. A level can hold `segments_per_level` segments that the engine
+still cannot compact, because every candidate group already exceeds
+`max_segment_size` and an over-budget segment is an indivisible singleton. In
+that case `bm25_needs_compaction()` reports true while `bm25_compact_step()`
+returns false. A scheduler should treat a false return as "nothing further to
+do for now" rather than retrying immediately.
+
+L7 is the terminal level and is not itself compactable, so
+`bm25_needs_compaction()` considers only L0 through L6. If L7 has no room for
+a promotion out of L6, planning that pass raises
+`bm25 segment count limit reached at level 7` before writing anything. Passes
+that can legally run still run: `bm25_compact()` reduces the lower-level debt
+it can and then reports the terminal conflict. Operators must resolve such a
+layout rather than retrying it as ordinary compaction debt.

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -34,7 +34,9 @@ page:
 * A pass that fails can still have written pages. It drains the deferred-free
   tombstone chain before planning, and it merges its outputs before
   publishing, so a failure can leave reclaimed pages reclaimed and unpublished
-  output pages unreachable until the next `VACUUM` or `REINDEX`.
+  output pages allocated but unreachable. `VACUUM` does not recover those:
+  it reclaims dead memtable pages and past-horizon tombstones, not pages a
+  failed pass never linked. `REINDEX` is what returns them.
 
 A published pass is **not undone by `ROLLBACK`**. The metapage update is a
 physical change, so it survives abort of the surrounding transaction:
@@ -116,10 +118,19 @@ under the same size budget. It is therefore reducible like any other level,
 carries no special count ceiling, and `bm25_needs_compaction()` considers
 every level including L7.
 
-Note that levels are cascade generations, not achievable size classes. A
-level's nominal size is `8MB * 8^level`, but no merge may exceed
-`pg_textsearch.max_segment_size`, whose default *and maximum* is 4095MB —
-just under L3's 4096MB boundary. So no merge can ever emit a segment whose
-size class is above L3; levels L4 through L7 are reached only by the
-one-level promotion that each pass applies to its output. A segment sitting
-at L7 is at most 4095MB, not the 2TB its level nominally denotes.
+Note that a level is a hybrid rank rather than a pure size class. A pass
+places its output at whichever is higher: the output's size class, or one
+level above the level the sources came from. A level's nominal ceiling is
+`8MB * segments_per_level^level`, so the ladder's shape follows
+`pg_textsearch.segments_per_level` (2 to 64, default 8) and is not fixed.
+
+At the default fanout of 8 that ceiling reaches 4096MB at L3, while
+`pg_textsearch.max_segment_size` caps a newly combined segment at 4095MB, so
+under default settings no merge emits a segment above size class 3 and L4
+through L7 are reached only by the one-level promotion. That is a property of
+the default, not of the design: at `segments_per_level = 2` the L6 ceiling is
+512MB and a 4095MB output lands at L7 on size alone.
+
+`max_segment_size` also bounds only the segments a pass *combines*. An
+existing segment larger than the current setting stays a valid indivisible
+singleton, so a segment at any level may exceed it.

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -5,10 +5,10 @@ compacting one BM25 index:
 
 - `bm25_level_counts(regclass)` returns the persisted segment count for each
   of the eight LSM levels.
-- `bm25_needs_compaction(regclass)` reports whether any compactable level,
-  L0 through L6, has reached `pg_textsearch.segments_per_level`.
-- `bm25_compact(regclass)` runs compaction passes until no compactable level
-  is left with debt this engine can reduce.
+- `bm25_needs_compaction(regclass)` reports whether any level, L0 through L7,
+  has reached `pg_textsearch.segments_per_level`.
+- `bm25_compact(regclass)` runs compaction passes until no level is left with
+  debt this engine can reduce.
 - `bm25_compact_step(regclass)` runs at most one compaction pass and returns
   whether a pass ran.
 
@@ -110,12 +110,16 @@ bm25_compact_step(...)` never terminates on such an index. Drive the loop from
 false; use `bm25_needs_compaction()` only to decide whether it is worth
 starting, and for observability.
 
-L7 is the terminal level and is not itself compactable, so
-`bm25_needs_compaction()` considers only L0 through L6. If L7 has no room for
-a promotion out of L6, planning that pass raises
-`bm25 segment count limit reached at level 7` and publishes no layout change.
-Passes that can legally run still run: `bm25_compact()` reduces the
-lower-level debt it can and then reports the terminal conflict — and, as
-above, the passes it already published stay published. A caller must treat
-this error as a permanent condition for an operator to resolve, not as a
-retryable failure.
+The top level (L7) is where the ladder ends, but it is not a wall: a run that
+would promote past it stays there instead, and the level compacts into itself
+under the same size budget. It is therefore reducible like any other level,
+carries no special count ceiling, and `bm25_needs_compaction()` considers
+every level including L7.
+
+Note that levels are cascade generations, not achievable size classes. A
+level's nominal size is `8MB * 8^level`, but no merge may exceed
+`pg_textsearch.max_segment_size`, whose default *and maximum* is 4095MB —
+just under L3's 4096MB boundary. So no merge can ever emit a segment whose
+size class is above L3; levels L4 through L7 are reached only by the
+one-level promotion that each pass applies to its output. A segment sitting
+at L7 is at most 4095MB, not the 2TB its level nominally denotes.

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -22,13 +22,41 @@ A pass is the engine's unit of work and its unit of publication. The planner
 selects the lowest triggered level, groups its segments into batches that fit
 `pg_textsearch.max_segment_size`, and recursively plans any additional
 compaction needed to make room at the destination levels. The whole plan is
-built and validated against the per-level segment capacity before a single
-page is written, so a pass either publishes completely or leaves the index
-exactly as it found it.
+built and validated against the per-level segment capacity before any output
+is merged, and every output a pass produces becomes visible in one metapage
+update.
+
+The guarantee is about the visible segment layout, not about every physical
+page:
+
+* Until that metapage update, the existing segments stay authoritative, so a
+  pass that fails leaves the layout it started from.
+* A pass that fails can still have written pages. It drains the deferred-free
+  tombstone chain before planning, and it merges its outputs before
+  publishing, so a failure can leave reclaimed pages reclaimed and unpublished
+  output pages unreachable until the next `VACUUM` or `REINDEX`.
+
+A published pass is **not undone by `ROLLBACK`**. The metapage update is a
+physical change, so it survives abort of the surrounding transaction:
+
+```sql
+BEGIN;
+SELECT bm25_compact_step('idx'::regclass);  -- t, layout now changed
+ROLLBACK;                                   -- layout stays changed
+```
 
 Because each pass is independently complete, `bm25_compact()` and repeated
 `bm25_compact_step()` calls converge on the same layout. They differ only in
 how long the lock is held.
+
+A pass is not a bounded amount of work. It runs only when at least one batch
+merges two or more segments, but the prefix it selects may hold up to
+`pg_textsearch.segments_per_level` segments, may span several batches, and may
+pull in further batches to unblock a destination level. A segment that is
+already over `pg_textsearch.max_segment_size` is never *combined* with
+another, but it is still rewritten when it falls inside a running pass's
+prefix. Treat `bm25_compact_step()` as one publication, not as a latency
+bound.
 
 Both functions act on segments only. They are the same operation the storage
 layer runs at the tail of a spill, exposed for manual and scheduled use, so
@@ -43,6 +71,16 @@ relation with `RowExclusiveLock` and hold the index's `LW_EXCLUSIVE` lock
 while merging. `bm25_compact()` holds that lock for the entire cascade.
 `bm25_compact_step()` releases it after one pass, allowing callers to split a
 cascade across transactions.
+
+Holding an `LWLock` holds off interrupts, so neither function is cancellable
+by `pg_cancel_backend()` or `statement_timeout` while a pass is running. This
+is the main reason to prefer `bm25_compact_step()` for scheduled work:
+`bm25_compact()` is uninterruptible for as long as the whole cascade takes.
+
+`pg_textsearch.segments_per_level` is `PGC_SUSET`. The planner and
+`bm25_needs_compaction()` both read the *calling* session's value, so a
+scheduler session with a different setting than the writers will disagree with
+them about which levels carry debt.
 
 ## Restrictions
 
@@ -59,16 +97,25 @@ individual partitions instead.
 
 `bm25_needs_compaction()` is a cheap advisory signal derived from the level
 counts alone. A level can hold `segments_per_level` segments that the engine
-still cannot compact, because every candidate group already exceeds
-`max_segment_size` and an over-budget segment is an indivisible singleton. In
-that case `bm25_needs_compaction()` reports true while `bm25_compact_step()`
-returns false. A scheduler should treat a false return as "nothing further to
-do for now" rather than retrying immediately.
+still cannot compact, because a pass runs only when at least one batch merges
+two or more segments, and every candidate group here is a single over-budget
+segment. In that case `bm25_needs_compaction()` reports true while
+`bm25_compact_step()` returns false.
+
+**`bm25_needs_compaction()` must not be used on its own as a retry or loop
+condition.** It does not go false when the debt it reports is unreducible, so
+a scheduler that loops `WHILE bm25_needs_compaction(...) DO
+bm25_compact_step(...)` never terminates on such an index. Drive the loop from
+`bm25_compact_step()`'s return value instead, and stop as soon as it returns
+false; use `bm25_needs_compaction()` only to decide whether it is worth
+starting, and for observability.
 
 L7 is the terminal level and is not itself compactable, so
 `bm25_needs_compaction()` considers only L0 through L6. If L7 has no room for
 a promotion out of L6, planning that pass raises
-`bm25 segment count limit reached at level 7` before writing anything. Passes
-that can legally run still run: `bm25_compact()` reduces the lower-level debt
-it can and then reports the terminal conflict. Operators must resolve such a
-layout rather than retrying it as ordinary compaction debt.
+`bm25 segment count limit reached at level 7` and publishes no layout change.
+Passes that can legally run still run: `bm25_compact()` reduces the
+lower-level debt it can and then reports the terminal conflict — and, as
+above, the passes it already published stay published. A caller must treat
+this error as a permanent condition for an operator to resolve, not as a
+retryable failure.

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -26,6 +26,28 @@ built and validated against the per-level segment capacity before any output
 is merged, and every output a pass produces becomes visible in one metapage
 update.
 
+Batching is greedy over a head prefix of the level, and a batch that ends up
+holding a single segment combines nothing: merging it rewrites the whole
+segment to produce a segment of the same size. Because spills prepend, a
+level reads newest-first, so its oldest and largest runs — the ones already
+past `max_segment_size` — sit at the tail. A pass therefore hands the
+trailing run of single-segment batches back to the level before planning
+anything further, and leaves those segments where they are, at the level
+they were already on. Without that, one pairable pair at the head of a level
+would authorize rewriting every over-budget segment behind it.
+
+This applies to the level a pass chose to compact. When a pass instead
+compacts a level to make room for its own output, promoting a
+single-segment batch is what makes that room, so those are not handed
+back.
+
+Handing back a *trailing* run is what keeps this cheap. The selection is a
+head prefix, so the chain behind it is untouched and returning segments is
+just moving the level's head pointer back; nothing on disk changes. A
+single-segment batch in the middle of a prefix is still rewritten, because
+excising one would mean repointing its predecessor, and those writes do not
+fit alongside the metapage update that publishes the pass.
+
 The guarantee is about the visible segment layout, not about every physical
 page:
 
@@ -82,7 +104,7 @@ is the main reason to prefer `bm25_compact_step()` for scheduled work:
 `pg_textsearch.segments_per_level` is `PGC_SUSET`. The planner and
 `bm25_needs_compaction()` both read the *calling* session's value, so a
 scheduler session with a different setting than the writers will disagree with
-them about which levels carry debt.
+them about which levels are full.
 
 ## Restrictions
 
@@ -95,17 +117,19 @@ Partitioned BM25 parent indexes have no physical storage and are rejected by
 all four per-index functions. Call the functions on the physical indexes of
 individual partitions instead.
 
-## Debt that cannot be reduced
+## Full levels with nothing to compact
 
 `bm25_needs_compaction()` is a cheap advisory signal derived from the level
-counts alone. A level can hold `segments_per_level` segments that the engine
-still cannot compact, because a pass runs only when at least one batch merges
+counts alone. It answers "is any level at its segment threshold", not "is
+there work to do". A level can sit at `segments_per_level` and still have
+nothing to compact, because a pass runs only when at least one batch merges
 two or more segments, and every candidate group here is a single over-budget
-segment. In that case `bm25_needs_compaction()` reports true while
-`bm25_compact_step()` returns false.
+segment. Such a level is not carrying compaction debt — no pass would reduce
+it — but a count-only signal cannot tell the two apart, so it reports true
+while `bm25_compact_step()` returns false.
 
 **`bm25_needs_compaction()` must not be used on its own as a retry or loop
-condition.** It does not go false when the debt it reports is unreducible, so
+condition.** It stays true on a full level that has nothing to reduce, so
 a scheduler that loops `WHILE bm25_needs_compaction(...) DO
 bm25_compact_step(...)` never terminates on such an index. Drive the loop from
 `bm25_compact_step()`'s return value instead, and stop as soon as it returns
@@ -132,5 +156,5 @@ the default, not of the design: at `segments_per_level = 2` the L6 ceiling is
 512MB and a 4095MB output lands at L7 on size alone.
 
 `max_segment_size` also bounds only the segments a pass *combines*. An
-existing segment larger than the current setting stays a valid indivisible
+existing segment larger than the current setting stays a valid uncombinable
 singleton, so a segment at any level may exceed it.

--- a/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
@@ -16,7 +16,7 @@ BEGIN
 END $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_force_merge(text) IS
-    'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain indivisible, and displaced pages enter deferred reclaim.';
+    'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain uncombinable, and displaced pages enter deferred reclaim.';
 
 -- PARALLEL RESTRICTED: opens the index relation, which may be a local
 -- temporary index whose buffers a parallel worker cannot reach.
@@ -60,4 +60,4 @@ AS $$
 $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
-    'Report whether any level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';
+    'Report whether any level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget is reported as full even though bm25_compact_step has no way to reduce it, so this must not be used on its own as a retry condition.';

--- a/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
@@ -18,10 +18,12 @@ END $$;
 COMMENT ON FUNCTION @extschema@.bm25_force_merge(text) IS
     'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain indivisible, and displaced pages enter deferred reclaim.';
 
+-- PARALLEL RESTRICTED: opens the index relation, which may be a local
+-- temporary index whose buffers a parallel worker cannot reach.
 CREATE FUNCTION @extschema@.bm25_level_counts(idx regclass)
 RETURNS int[]
 AS 'MODULE_PATHNAME', 'tp_level_counts'
-LANGUAGE C STRICT PARALLEL SAFE;
+LANGUAGE C VOLATILE STRICT PARALLEL RESTRICTED;
 
 CREATE FUNCTION @extschema@.bm25_compact(idx regclass)
 RETURNS void
@@ -29,7 +31,7 @@ AS 'MODULE_PATHNAME', 'tp_compact_index'
 LANGUAGE C VOLATILE STRICT;
 
 COMMENT ON FUNCTION @extschema@.bm25_compact(regclass) IS
-    'Run threshold compaction to completion under one per-index exclusive lock, in size-bounded passes.';
+    'Run threshold compaction to completion under one per-index exclusive lock. Passes already published are not undone by ROLLBACK, so a cascade that errors partway leaves its earlier passes applied.';
 
 CREATE FUNCTION @extschema@.bm25_compact_step(idx regclass)
 RETURNS boolean
@@ -37,22 +39,29 @@ AS 'MODULE_PATHNAME', 'tp_compact_index_step'
 LANGUAGE C VOLATILE STRICT;
 
 COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
-    'Run at most one size-bounded compaction pass and report whether one ran, letting a caller spread a cascade over several transactions.';
+    'Run at most one compaction pass and report whether one ran, letting a caller spread a cascade over several transactions. A published pass is not undone by ROLLBACK.';
 
+-- VOLATILE because it reads live metapage state, and PARALLEL
+-- RESTRICTED to match bm25_level_counts.  The terminal level is
+-- excluded by array length rather than a literal so the predicate
+-- tracks TP_MAX_LEVELS.
 CREATE FUNCTION @extschema@.bm25_needs_compaction(idx regclass)
 RETURNS boolean
-LANGUAGE sql STABLE
+LANGUAGE sql VOLATILE STRICT PARALLEL RESTRICTED
 SET search_path = pg_catalog, pg_temp
 AS $$
+    WITH c(counts) AS (
+        SELECT @extschema@.bm25_level_counts(idx)
+    )
     SELECT EXISTS (
         SELECT 1
-        FROM pg_catalog.unnest(@extschema@.bm25_level_counts(idx))
+        FROM c, pg_catalog.unnest(c.counts)
              WITH ORDINALITY AS t(cnt, lvl)
-        WHERE t.lvl <= 7
+        WHERE t.lvl < pg_catalog.array_length(c.counts, 1)
           AND t.cnt >= pg_catalog.current_setting(
                   'pg_textsearch.segments_per_level')::int
     );
 $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
-    'Report whether any level holds at least segments_per_level segments. Advisory: a level built entirely from over-budget segments reports debt that bm25_compact_step cannot reduce.';
+    'Report whether any non-terminal level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';

--- a/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
@@ -17,3 +17,42 @@ END $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_force_merge(text) IS
     'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain indivisible, and displaced pages enter deferred reclaim.';
+
+CREATE FUNCTION @extschema@.bm25_level_counts(idx regclass)
+RETURNS int[]
+AS 'MODULE_PATHNAME', 'tp_level_counts'
+LANGUAGE C STRICT PARALLEL SAFE;
+
+CREATE FUNCTION @extschema@.bm25_compact(idx regclass)
+RETURNS void
+AS 'MODULE_PATHNAME', 'tp_compact_index'
+LANGUAGE C VOLATILE STRICT;
+
+COMMENT ON FUNCTION @extschema@.bm25_compact(regclass) IS
+    'Run threshold compaction to completion under one per-index exclusive lock, in size-bounded passes.';
+
+CREATE FUNCTION @extschema@.bm25_compact_step(idx regclass)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tp_compact_index_step'
+LANGUAGE C VOLATILE STRICT;
+
+COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
+    'Run at most one size-bounded compaction pass and report whether one ran, letting a caller spread a cascade over several transactions.';
+
+CREATE FUNCTION @extschema@.bm25_needs_compaction(idx regclass)
+RETURNS boolean
+LANGUAGE sql STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_catalog.unnest(@extschema@.bm25_level_counts(idx))
+             WITH ORDINALITY AS t(cnt, lvl)
+        WHERE t.lvl <= 7
+          AND t.cnt >= pg_catalog.current_setting(
+                  'pg_textsearch.segments_per_level')::int
+    );
+$$;
+
+COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
+    'Report whether any level holds at least segments_per_level segments. Advisory: a level built entirely from over-budget segments reports debt that bm25_compact_step cannot reduce.';

--- a/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
@@ -42,26 +42,22 @@ COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
     'Run at most one compaction pass and report whether one ran, letting a caller spread a cascade over several transactions. A published pass is not undone by ROLLBACK.';
 
 -- VOLATILE because it reads live metapage state, and PARALLEL
--- RESTRICTED to match bm25_level_counts.  The terminal level is
--- excluded by array length rather than a literal so the predicate
--- tracks TP_MAX_LEVELS.
+-- RESTRICTED to match bm25_level_counts.  Every level counts: the top
+-- level compacts into itself, so its debt is reducible like any
+-- other's.
 CREATE FUNCTION @extschema@.bm25_needs_compaction(idx regclass)
 RETURNS boolean
 LANGUAGE sql VOLATILE STRICT PARALLEL RESTRICTED
 SET search_path = pg_catalog, pg_temp
 AS $$
-    WITH c(counts) AS (
-        SELECT @extschema@.bm25_level_counts(idx)
-    )
     SELECT EXISTS (
         SELECT 1
-        FROM c, pg_catalog.unnest(c.counts)
-             WITH ORDINALITY AS t(cnt, lvl)
-        WHERE t.lvl < pg_catalog.array_length(c.counts, 1)
-          AND t.cnt >= pg_catalog.current_setting(
+        FROM pg_catalog.unnest(
+                 @extschema@.bm25_level_counts(idx)) AS cnt
+        WHERE cnt >= pg_catalog.current_setting(
                   'pg_textsearch.segments_per_level')::int
     );
 $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
-    'Report whether any non-terminal level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';
+    'Report whether any level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';

--- a/sql/pg_textsearch--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.5.0-dev.sql
@@ -258,6 +258,45 @@ LANGUAGE C VOLATILE STRICT;
 COMMENT ON FUNCTION @extschema@.bm25_force_merge(text) IS
     'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain indivisible, and displaced pages enter deferred reclaim.';
 
+CREATE FUNCTION @extschema@.bm25_level_counts(idx regclass)
+RETURNS int[]
+AS 'MODULE_PATHNAME', 'tp_level_counts'
+LANGUAGE C STRICT PARALLEL SAFE;
+
+CREATE FUNCTION @extschema@.bm25_compact(idx regclass)
+RETURNS void
+AS 'MODULE_PATHNAME', 'tp_compact_index'
+LANGUAGE C VOLATILE STRICT;
+
+COMMENT ON FUNCTION @extschema@.bm25_compact(regclass) IS
+    'Run threshold compaction to completion under one per-index exclusive lock, in size-bounded passes.';
+
+CREATE FUNCTION @extschema@.bm25_compact_step(idx regclass)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tp_compact_index_step'
+LANGUAGE C VOLATILE STRICT;
+
+COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
+    'Run at most one size-bounded compaction pass and report whether one ran, letting a caller spread a cascade over several transactions.';
+
+CREATE FUNCTION @extschema@.bm25_needs_compaction(idx regclass)
+RETURNS boolean
+LANGUAGE sql STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_catalog.unnest(@extschema@.bm25_level_counts(idx))
+             WITH ORDINALITY AS t(cnt, lvl)
+        WHERE t.lvl <= 7
+          AND t.cnt >= pg_catalog.current_setting(
+                  'pg_textsearch.segments_per_level')::int
+    );
+$$;
+
+COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
+    'Report whether any level holds at least segments_per_level segments. Advisory: a level built entirely from over-budget segments reports debt that bm25_compact_step cannot reduce.';
+
 -- Fast summary function showing only statistics (no content dump)
 CREATE FUNCTION @extschema@.bm25_summarize_index(text) RETURNS text
     AS 'MODULE_PATHNAME', 'tp_summarize_index'

--- a/sql/pg_textsearch--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.5.0-dev.sql
@@ -282,29 +282,25 @@ COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
     'Run at most one compaction pass and report whether one ran, letting a caller spread a cascade over several transactions. A published pass is not undone by ROLLBACK.';
 
 -- VOLATILE because it reads live metapage state, and PARALLEL
--- RESTRICTED to match bm25_level_counts.  The terminal level is
--- excluded by array length rather than a literal so the predicate
--- tracks TP_MAX_LEVELS.
+-- RESTRICTED to match bm25_level_counts.  Every level counts: the top
+-- level compacts into itself, so its debt is reducible like any
+-- other's.
 CREATE FUNCTION @extschema@.bm25_needs_compaction(idx regclass)
 RETURNS boolean
 LANGUAGE sql VOLATILE STRICT PARALLEL RESTRICTED
 SET search_path = pg_catalog, pg_temp
 AS $$
-    WITH c(counts) AS (
-        SELECT @extschema@.bm25_level_counts(idx)
-    )
     SELECT EXISTS (
         SELECT 1
-        FROM c, pg_catalog.unnest(c.counts)
-             WITH ORDINALITY AS t(cnt, lvl)
-        WHERE t.lvl < pg_catalog.array_length(c.counts, 1)
-          AND t.cnt >= pg_catalog.current_setting(
+        FROM pg_catalog.unnest(
+                 @extschema@.bm25_level_counts(idx)) AS cnt
+        WHERE cnt >= pg_catalog.current_setting(
                   'pg_textsearch.segments_per_level')::int
     );
 $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
-    'Report whether any non-terminal level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';
+    'Report whether any level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';
 
 -- Fast summary function showing only statistics (no content dump)
 CREATE FUNCTION @extschema@.bm25_summarize_index(text) RETURNS text

--- a/sql/pg_textsearch--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.5.0-dev.sql
@@ -256,7 +256,7 @@ AS 'MODULE_PATHNAME', 'tp_force_merge'
 LANGUAGE C VOLATILE STRICT;
 
 COMMENT ON FUNCTION @extschema@.bm25_force_merge(text) IS
-    'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain indivisible, and displaced pages enter deferred reclaim.';
+    'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain uncombinable, and displaced pages enter deferred reclaim.';
 
 -- PARALLEL RESTRICTED: opens the index relation, which may be a local
 -- temporary index whose buffers a parallel worker cannot reach.
@@ -300,7 +300,7 @@ AS $$
 $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
-    'Report whether any level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';
+    'Report whether any level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget is reported as full even though bm25_compact_step has no way to reduce it, so this must not be used on its own as a retry condition.';
 
 -- Fast summary function showing only statistics (no content dump)
 CREATE FUNCTION @extschema@.bm25_summarize_index(text) RETURNS text

--- a/sql/pg_textsearch--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.5.0-dev.sql
@@ -258,10 +258,12 @@ LANGUAGE C VOLATILE STRICT;
 COMMENT ON FUNCTION @extschema@.bm25_force_merge(text) IS
     'Run one-shot copy-on-write compaction into the fewest conservatively size-bounded segments; existing over-budget singletons remain indivisible, and displaced pages enter deferred reclaim.';
 
+-- PARALLEL RESTRICTED: opens the index relation, which may be a local
+-- temporary index whose buffers a parallel worker cannot reach.
 CREATE FUNCTION @extschema@.bm25_level_counts(idx regclass)
 RETURNS int[]
 AS 'MODULE_PATHNAME', 'tp_level_counts'
-LANGUAGE C STRICT PARALLEL SAFE;
+LANGUAGE C VOLATILE STRICT PARALLEL RESTRICTED;
 
 CREATE FUNCTION @extschema@.bm25_compact(idx regclass)
 RETURNS void
@@ -269,7 +271,7 @@ AS 'MODULE_PATHNAME', 'tp_compact_index'
 LANGUAGE C VOLATILE STRICT;
 
 COMMENT ON FUNCTION @extschema@.bm25_compact(regclass) IS
-    'Run threshold compaction to completion under one per-index exclusive lock, in size-bounded passes.';
+    'Run threshold compaction to completion under one per-index exclusive lock. Passes already published are not undone by ROLLBACK, so a cascade that errors partway leaves its earlier passes applied.';
 
 CREATE FUNCTION @extschema@.bm25_compact_step(idx regclass)
 RETURNS boolean
@@ -277,25 +279,32 @@ AS 'MODULE_PATHNAME', 'tp_compact_index_step'
 LANGUAGE C VOLATILE STRICT;
 
 COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
-    'Run at most one size-bounded compaction pass and report whether one ran, letting a caller spread a cascade over several transactions.';
+    'Run at most one compaction pass and report whether one ran, letting a caller spread a cascade over several transactions. A published pass is not undone by ROLLBACK.';
 
+-- VOLATILE because it reads live metapage state, and PARALLEL
+-- RESTRICTED to match bm25_level_counts.  The terminal level is
+-- excluded by array length rather than a literal so the predicate
+-- tracks TP_MAX_LEVELS.
 CREATE FUNCTION @extschema@.bm25_needs_compaction(idx regclass)
 RETURNS boolean
-LANGUAGE sql STABLE
+LANGUAGE sql VOLATILE STRICT PARALLEL RESTRICTED
 SET search_path = pg_catalog, pg_temp
 AS $$
+    WITH c(counts) AS (
+        SELECT @extschema@.bm25_level_counts(idx)
+    )
     SELECT EXISTS (
         SELECT 1
-        FROM pg_catalog.unnest(@extschema@.bm25_level_counts(idx))
+        FROM c, pg_catalog.unnest(c.counts)
              WITH ORDINALITY AS t(cnt, lvl)
-        WHERE t.lvl <= 7
+        WHERE t.lvl < pg_catalog.array_length(c.counts, 1)
           AND t.cnt >= pg_catalog.current_setting(
                   'pg_textsearch.segments_per_level')::int
     );
 $$;
 
 COMMENT ON FUNCTION @extschema@.bm25_needs_compaction(regclass) IS
-    'Report whether any level holds at least segments_per_level segments. Advisory: a level built entirely from over-budget segments reports debt that bm25_compact_step cannot reduce.';
+    'Report whether any non-terminal level holds at least segments_per_level segments. Advisory only: a level whose segments are all over budget reports debt that bm25_compact_step declines to reduce, so this must not be used on its own as a retry condition.';
 
 -- Fast summary function showing only statistics (no content dump)
 CREATE FUNCTION @extschema@.bm25_summarize_index(text) RETURNS text

--- a/src/access/compaction_api.c
+++ b/src/access/compaction_api.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * compaction.c - BM25 index compaction inspection and control
+ * compaction_api.c - BM25 index compaction inspection and control
  */
 #include <postgres.h>
 

--- a/src/access/compaction_api.c
+++ b/src/access/compaction_api.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2025-2026 Tiger Data, Inc.
+ * Licensed under the PostgreSQL License. See LICENSE for details.
+ *
+ * compaction.c - BM25 index compaction inspection and control
+ */
+#include <postgres.h>
+
+#include <access/relation.h>
+#include <access/xlog.h>
+#include <catalog/objectaccess.h>
+#include <catalog/pg_class.h>
+#include <catalog/pg_type.h>
+#include <miscadmin.h>
+#include <utils/acl.h>
+#include <utils/array.h>
+#include <utils/lsyscache.h>
+
+#include "access/am.h"
+#include "constants.h"
+#include "index/metapage.h"
+#include "index/state.h"
+#include "segment/compaction.h"
+
+/*
+ * Open a bm25 index by OID, validating that it is in fact a bm25
+ * index and (optionally) that the caller owns it.
+ */
+static Relation
+tp_open_bm25_index(Oid indexoid, LOCKMODE lockmode, bool need_owner)
+{
+	Relation index_rel;
+
+	/*
+	 * Reject nonowners before queuing for a heavyweight lock. Recheck after
+	 * opening because ALTER OWNER can complete while this caller waits.
+	 */
+	if (need_owner &&
+		!object_ownercheck(RelationRelationId, indexoid, GetUserId()))
+	{
+		char *relname = get_rel_name(indexoid);
+
+		if (relname == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("relation with OID %u does not exist", indexoid)));
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_INDEX, relname);
+	}
+
+	index_rel = relation_open(indexoid, lockmode);
+
+	if (index_rel->rd_indam == NULL ||
+		index_rel->rd_indam->ambuild != tp_build)
+	{
+		char *relname = pstrdup(RelationGetRelationName(index_rel));
+
+		relation_close(index_rel, lockmode);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a bm25 index", relname)));
+	}
+
+	if (index_rel->rd_rel->relkind == RELKIND_PARTITIONED_INDEX)
+	{
+		char *relname = pstrdup(RelationGetRelationName(index_rel));
+
+		relation_close(index_rel, lockmode);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is a partitioned bm25 index", relname),
+				 errhint("Use a physical partition index instead.")));
+	}
+
+	if (need_owner &&
+		!object_ownercheck(RelationRelationId, indexoid, GetUserId()))
+	{
+		char *relname = pstrdup(RelationGetRelationName(index_rel));
+
+		relation_close(index_rel, lockmode);
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_INDEX, relname);
+	}
+
+	return index_rel;
+}
+
+PG_FUNCTION_INFO_V1(tp_level_counts);
+
+Datum
+tp_level_counts(PG_FUNCTION_ARGS)
+{
+	Oid					 indexoid = PG_GETARG_OID(0);
+	Relation			 index_rel;
+	TpIndexMetaPageData *metap;
+	Datum				 elems[TP_MAX_LEVELS];
+	ArrayType			*result;
+	int					 i;
+
+	index_rel = tp_open_bm25_index(indexoid, AccessShareLock, false);
+
+	metap = tp_get_metapage(index_rel);
+	for (i = 0; i < TP_MAX_LEVELS; i++)
+		elems[i] = Int32GetDatum((int32)metap->level_counts[i]);
+	pfree(metap);
+
+	relation_close(index_rel, AccessShareLock);
+
+	result = construct_array(
+			elems, TP_MAX_LEVELS, INT4OID, sizeof(int32), true, TYPALIGN_INT);
+	PG_RETURN_ARRAYTYPE_P(result);
+}
+
+PG_FUNCTION_INFO_V1(tp_compact_index);
+
+Datum
+tp_compact_index(PG_FUNCTION_ARGS)
+{
+	Oid				   indexoid = PG_GETARG_OID(0);
+	Relation		   index_rel;
+	TpLocalIndexState *index_state;
+
+	if (RecoveryInProgress())
+		ereport(ERROR,
+				(errcode(ERRCODE_READ_ONLY_SQL_TRANSACTION),
+				 errmsg("cannot compact a bm25 index during recovery")));
+
+	index_rel = tp_open_bm25_index(indexoid, RowExclusiveLock, true);
+
+	if (!RelationUsesLocalBuffers(index_rel))
+		PreventCommandIfReadOnly("bm25 index compaction");
+
+	index_state = tp_get_local_index_state(indexoid);
+	if (index_state == NULL)
+	{
+		char *relname = pstrdup(RelationGetRelationName(index_rel));
+
+		relation_close(index_rel, RowExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not get index state for \"%s\"", relname)));
+	}
+
+	tp_acquire_index_lock(index_state, LW_EXCLUSIVE);
+	PG_TRY();
+	{
+		tp_maybe_compact_level(index_state, index_rel, 0);
+	}
+	PG_FINALLY();
+	{
+		tp_release_index_lock(index_state);
+		relation_close(index_rel, RowExclusiveLock);
+	}
+	PG_END_TRY();
+
+	PG_RETURN_VOID();
+}
+
+PG_FUNCTION_INFO_V1(tp_compact_index_step);
+
+Datum
+tp_compact_index_step(PG_FUNCTION_ARGS)
+{
+	Oid				   indexoid = PG_GETARG_OID(0);
+	Relation		   index_rel;
+	TpLocalIndexState *index_state;
+	bool			   pass_ran;
+
+	if (RecoveryInProgress())
+		ereport(ERROR,
+				(errcode(ERRCODE_READ_ONLY_SQL_TRANSACTION),
+				 errmsg("cannot compact a bm25 index during recovery")));
+
+	index_rel = tp_open_bm25_index(indexoid, RowExclusiveLock, true);
+
+	if (!RelationUsesLocalBuffers(index_rel))
+		PreventCommandIfReadOnly("bm25 index compaction");
+
+	index_state = tp_get_local_index_state(indexoid);
+	if (index_state == NULL)
+	{
+		char *relname = pstrdup(RelationGetRelationName(index_rel));
+
+		relation_close(index_rel, RowExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not get index state for \"%s\"", relname)));
+	}
+
+	tp_acquire_index_lock(index_state, LW_EXCLUSIVE);
+	PG_TRY();
+	{
+		pass_ran = tp_compact_step(index_state, index_rel);
+	}
+	PG_FINALLY();
+	{
+		tp_release_index_lock(index_state);
+		relation_close(index_rel, RowExclusiveLock);
+	}
+	PG_END_TRY();
+
+	PG_RETURN_BOOL(pass_ran);
+}

--- a/src/mod.c
+++ b/src/mod.c
@@ -288,7 +288,7 @@ _PG_init(void)
 			"pg_textsearch.max_segment_size",
 			"Maximum conservative size of a merged segment.",
 			"Bounds newly merged multi-source segments. A larger existing "
-			"segment remains an indivisible singleton.",
+			"segment remains an uncombinable singleton.",
 			&tp_max_segment_size_mb,
 			TP_DEFAULT_SEGMENT_SIZE_MB,
 			TP_MIN_SEGMENT_SIZE_MB,

--- a/src/segment/compaction.c
+++ b/src/segment/compaction.c
@@ -46,7 +46,7 @@ typedef struct TpCompactionBatch
 	uint32			  first_source;
 	uint32			  source_count;
 	uint32			  output_level;
-	bool			  indivisible;
+	bool			  uncombinable;
 	TpSegmentEstimate estimate;
 } TpCompactionBatch;
 
@@ -113,7 +113,7 @@ tp_u64_round_up_divide(uint64 value, uint64 divisor, uint64 *result)
 /*
  * Calculate the conservative current-format bound.  Arithmetic overflow is
  * distinct from a representational limit: source overflow is corrupt
- * metadata, while an otherwise valid oversized source remains indivisible.
+ * metadata, while an otherwise valid oversized source remains uncombinable.
  */
 static bool
 tp_estimate_physical_bytes(TpSegmentEstimate *estimate, bool *representable)
@@ -454,10 +454,10 @@ tp_append_bounded_batches(
 		batch->first_source = source_index;
 		batch->source_count = 1;
 		batch->estimate		= plan->sources[source_index].estimate;
-		batch->indivisible	= batch->estimate.bytes > budget;
+		batch->uncombinable = batch->estimate.bytes > budget;
 		source_index++;
 
-		while (!batch->indivisible && source_index < source_end)
+		while (!batch->uncombinable && source_index < source_end)
 		{
 			TpSegmentEstimate combined;
 
@@ -875,6 +875,46 @@ tp_select_level_prefix(
 	return first_source;
 }
 
+/*
+ * Give back a trailing run of batches that combine nothing.
+ *
+ * A one-source batch rewrites its whole segment and produces a segment
+ * of the same size, so the pass pays a full copy for no reduction.  At
+ * the tail of a prefix those are usually the level's oldest and largest
+ * runs, already past max_segment_size and unable to absorb anything, so
+ * a single pairable pair at the head can otherwise authorize rewriting
+ * every one of them.
+ *
+ * Returning them is cheap precisely because the selection is a head
+ * prefix: the chain behind it is untouched, so moving the retained head
+ * back to the first returned segment restores the level without
+ * rewriting any segment header.  They also keep their level, so nothing
+ * about them changes on disk.  A one-source batch in the middle of a
+ * prefix is still rewritten -- excising it would require repointing its
+ * predecessor, which no longer fits in the publishing metapage record.
+ *
+ * This applies only to the level a pass chose to compact.  The capacity
+ * recourse below selects a level to make room at, and there promoting a
+ * one-source batch is the mechanism that makes it: handing those back
+ * would leave the level exactly as full and turn a wasteful pass into a
+ * failed one.
+ */
+static void
+tp_trim_uncombinable_tail(
+		TpCompactionPlan *plan, uint32 first_batch, uint32 level)
+{
+	while (plan->num_batches > first_batch &&
+		   plan->batches[plan->num_batches - 1].source_count == 1)
+	{
+		TpCompactionBatch *batch = &plan->batches[plan->num_batches - 1];
+
+		plan->retained_heads[level] = plan->sources[batch->first_source].root;
+		plan->retained_counts[level]++;
+		plan->num_sources = batch->first_source;
+		plan->num_batches--;
+	}
+}
+
 static void
 tp_assign_ordinary_batches(
 		TpCompactionPlan *plan,
@@ -945,6 +985,7 @@ tp_build_ordinary_plan(
 				index, snapshot, plan, candidate, threshold);
 		first_batch = plan->num_batches;
 		tp_append_bounded_batches(plan, first_source, threshold);
+		tp_trim_uncombinable_tail(plan, first_batch, candidate);
 		tp_assign_ordinary_batches(plan, first_batch, planned_outputs);
 
 		/*

--- a/src/segment/compaction.c
+++ b/src/segment/compaction.c
@@ -800,7 +800,11 @@ static uint32
 tp_compaction_candidate(
 		const uint16 level_counts[TP_MAX_LEVELS], uint32 first_level)
 {
-	for (uint32 level = first_level; level < TP_MAX_LEVELS - 1; level++)
+	/*
+	 * Every level is a candidate, including the top one: it compacts
+	 * into itself rather than promoting, so its debt is reducible.
+	 */
+	for (uint32 level = first_level; level < TP_MAX_LEVELS; level++)
 	{
 		if ((uint32)level_counts[level] >= (uint32)tp_segments_per_level)
 			return level;
@@ -886,12 +890,15 @@ tp_assign_ordinary_batches(
 
 		if (output_level < minimum_level)
 			output_level = minimum_level;
-		if (output_level >= TP_MAX_LEVELS)
-			ereport(ERROR,
-					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-					 errmsg("bounded compaction cannot promote a segment "
-							"above level %u",
-							source->source_level)));
+
+		/*
+		 * The top level is the ladder's terminal bucket, not a wall.
+		 * A run that would promote past it stays there and compacts
+		 * into itself, so the level is reducible like any other and
+		 * carries no special count ceiling.
+		 */
+		if (output_level > TP_MAX_LEVELS - 1)
+			output_level = TP_MAX_LEVELS - 1;
 
 		for (uint32 j = 1; j < batch->source_count; j++)
 		{
@@ -930,7 +937,7 @@ tp_build_ordinary_plan(
 
 		candidate =
 				tp_compaction_candidate(snapshot->level_counts, search_level);
-		if (candidate >= TP_MAX_LEVELS - 1)
+		if (candidate >= TP_MAX_LEVELS)
 			return false;
 
 		tp_initialize_ordinary_plan(index, snapshot, plan);
@@ -940,15 +947,20 @@ tp_build_ordinary_plan(
 		tp_append_bounded_batches(plan, first_source, threshold);
 		tp_assign_ordinary_batches(plan, first_batch, planned_outputs);
 
-		for (uint32 level = candidate + 1; level < TP_MAX_LEVELS; level++)
+		/*
+		 * Outputs no longer always land above the candidate: the top
+		 * level compacts into itself.  Check every level this plan
+		 * would grow, and treat a full level uniformly -- it is over
+		 * capacity only when it also has too few segments to compact.
+		 */
+		for (uint32 level = 0; level < TP_MAX_LEVELS; level++)
 		{
 			while (planned_outputs[level] > 0 &&
 				   (uint64)plan->retained_counts[level] +
 								   (uint64)planned_outputs[level] >
 						   (uint64)plan->output_capacity)
 			{
-				if (level == TP_MAX_LEVELS - 1 ||
-					plan->retained_counts[level] < threshold)
+				if (plan->retained_counts[level] < threshold)
 					ereport(ERROR,
 							(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 							 errmsg("bm25 segment count limit reached at "
@@ -1010,7 +1022,7 @@ tp_compact_once(
 	uint32			 drained;
 
 	tp_require_compaction_lock(index_state);
-	if (first_level >= TP_MAX_LEVELS - 1)
+	if (first_level >= TP_MAX_LEVELS)
 		return false;
 
 	/*
@@ -1021,7 +1033,7 @@ tp_compact_once(
 	 */
 	snapshot = tp_get_metapage(index);
 	if (tp_compaction_candidate(snapshot->level_counts, first_level) >=
-		TP_MAX_LEVELS - 1)
+		TP_MAX_LEVELS)
 	{
 		pfree(snapshot);
 		return false;

--- a/src/segment/compaction.c
+++ b/src/segment/compaction.c
@@ -988,52 +988,77 @@ tp_free_compaction_plan(TpCompactionPlan *plan)
 		pfree(plan->batches);
 }
 
+/*
+ * Plan and run a single bounded compaction pass, searching for a
+ * triggered level at or above first_level.  Returns true when a plan
+ * executed and false when no level at or above first_level carries
+ * threshold debt this engine can reduce.
+ *
+ * One pass is one publication: the plan is built in full -- including
+ * any recursive compaction of a blocking destination level -- and
+ * validated against the per-level segment capacity before
+ * tp_execute_plan touches a page.  A caller that must bound how long it
+ * holds the per-index exclusive lock can therefore run exactly one pass
+ * and release, leaving the index in a consistent state.
+ */
+static bool
+tp_compact_once(
+		TpLocalIndexState *index_state, Relation index, uint32 first_level)
+{
+	TpIndexMetaPage	 snapshot;
+	TpCompactionPlan plan;
+	uint32			 drained;
+
+	tp_require_compaction_lock(index_state);
+	if (first_level >= TP_MAX_LEVELS - 1)
+		return false;
+
+	/*
+	 * Reclaiming displaced pages is part of compacting, not part of every
+	 * write.  Leave the tombstone chain alone unless a level is actually
+	 * triggered, so an ordinary spill cannot free pages that a merge
+	 * parked for standby-safe reclaim.
+	 */
+	snapshot = tp_get_metapage(index);
+	if (tp_compaction_candidate(snapshot->level_counts, first_level) >=
+		TP_MAX_LEVELS - 1)
+	{
+		pfree(snapshot);
+		return false;
+	}
+	pfree(snapshot);
+
+	drained = tp_tombstone_drain(
+			index, NULL, tp_reclaim_horizon(NULL), /* own_lock */ false);
+	if (drained > 0)
+		IndexFreeSpaceMapVacuum(index);
+
+	snapshot = tp_get_metapage(index);
+	if (!tp_build_ordinary_plan(index, snapshot, first_level, &plan))
+	{
+		pfree(snapshot);
+		tp_free_compaction_plan(&plan);
+		return false;
+	}
+
+	tp_execute_plan(index, snapshot, &plan);
+	pfree(snapshot);
+	tp_free_compaction_plan(&plan);
+	return true;
+}
+
 void
 tp_maybe_compact_level(
 		TpLocalIndexState *index_state, Relation index, uint32 first_level)
 {
-	tp_require_compaction_lock(index_state);
-	if (first_level >= TP_MAX_LEVELS - 1)
-		return;
+	while (tp_compact_once(index_state, index, first_level))
+		;
+}
 
-	while (true)
-	{
-		TpIndexMetaPage	 snapshot;
-		TpCompactionPlan plan;
-		uint32			 drained;
-
-		/*
-		 * Reclaiming displaced pages is part of compacting, not part of
-		 * every write.  Leave the tombstone chain alone unless a level is
-		 * actually triggered, so an ordinary spill cannot free pages that
-		 * a merge parked for standby-safe reclaim.
-		 */
-		snapshot = tp_get_metapage(index);
-		if (tp_compaction_candidate(snapshot->level_counts, first_level) >=
-			TP_MAX_LEVELS - 1)
-		{
-			pfree(snapshot);
-			return;
-		}
-		pfree(snapshot);
-
-		drained = tp_tombstone_drain(
-				index, NULL, tp_reclaim_horizon(NULL), /* own_lock */ false);
-		if (drained > 0)
-			IndexFreeSpaceMapVacuum(index);
-
-		snapshot = tp_get_metapage(index);
-		if (!tp_build_ordinary_plan(index, snapshot, first_level, &plan))
-		{
-			pfree(snapshot);
-			tp_free_compaction_plan(&plan);
-			return;
-		}
-
-		tp_execute_plan(index, snapshot, &plan);
-		pfree(snapshot);
-		tp_free_compaction_plan(&plan);
-	}
+bool
+tp_compact_step(TpLocalIndexState *index_state, Relation index)
+{
+	return tp_compact_once(index_state, index, 0);
 }
 
 void

--- a/src/segment/compaction.h
+++ b/src/segment/compaction.h
@@ -14,5 +14,15 @@ extern void	  tp_maybe_compact_level(
 		  struct TpLocalIndexState *index_state,
 		  Relation					index,
 		  uint32					first_level);
+
+/*
+ * Run at most one bounded compaction pass and report whether one ran.
+ * Splitting a cascade into passes lets each pass run in its own
+ * transaction, so the per-index exclusive lock is released between
+ * passes rather than held for the whole cascade.
+ */
+extern bool
+tp_compact_step(struct TpLocalIndexState *index_state, Relation index);
+
 extern void
 tp_force_compact(struct TpLocalIndexState *index_state, Relation index);

--- a/test/expected/compaction.out
+++ b/test/expected/compaction.out
@@ -348,16 +348,20 @@ RESET pg_textsearch.max_segment_size;
 RESET pg_textsearch.memtable_pages_threshold;
 RESET pg_textsearch.bulk_load_threshold;
 DROP TABLE compaction_unreducible CASCADE;
--- A full L7 blocks L6 promotion without changing the segment layout.
--- (Reclaim of already-parked pages may still run; only the published
--- level counts are asserted here.)
+-- The top level is a terminal bucket, not a wall.  When promotion out
+-- The top level is a terminal bucket, not a wall.  With a per-level
+-- count limit of 2, driving 384 segments up the ladder once failed
+-- closed with "segment count limit reached at level 7", because the
+-- top level was never a compaction candidate and so could never make
+-- room for a promotion out of L6.  It now compacts into itself, so
+-- the ladder drains instead of jamming.  (Reclaim of already-parked
+-- pages may also run; only the published level counts are asserted.)
 CREATE TABLE compaction_terminal (id serial PRIMARY KEY, body text);
 CREATE INDEX compaction_terminal_idx ON compaction_terminal
     USING bm25(body) WITH (text_config = 'english');
 SET pg_textsearch.debug_segment_count_limit = 2;
 DO $$
 DECLARE
-    counts int[];
     n integer;
 BEGIN
     FOR n IN 1..384 LOOP
@@ -369,52 +373,43 @@ BEGIN
         PERFORM set_config(
             'pg_textsearch.segments_per_level', '2', true);
 
+        -- The documented driver shape: stop on the step's own report
+        -- rather than on bm25_needs_compaction, which stays true on
+        -- debt no pass can reduce.
         WHILE bm25_needs_compaction(
                   'compaction_terminal_idx'::regclass) LOOP
-            counts :=
-                bm25_level_counts('compaction_terminal_idx'::regclass);
-            EXIT WHEN counts = ARRAY[0, 0, 0, 0, 0, 0, 2, 2];
-
-            IF NOT bm25_compact_step(
-                       'compaction_terminal_idx'::regclass) THEN
-                RAISE EXCEPTION
-                    'terminal setup stopped after source segment %', n;
-            END IF;
+            EXIT WHEN NOT bm25_compact_step(
+                              'compaction_terminal_idx'::regclass);
         END LOOP;
     END LOOP;
 END
 $$;
+SET pg_textsearch.segments_per_level = 2;
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           ARRAY[0, 0, 0, 0, 0, 0, 2, 2]
-       AND bm25_needs_compaction('compaction_terminal_idx'::regclass)
-       AS terminal_starts_blocked;
-terminal_starts_blocked
+           ARRAY[0, 0, 0, 0, 0, 0, 0, 1]
+       AND NOT bm25_needs_compaction(
+                   'compaction_terminal_idx'::regclass)
+       AS top_level_drains;
+top_level_drains
 t
 (1 row)
-CREATE TEMP TABLE compaction_terminal_before AS
-SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
+-- The ladder has settled: both entry points report no work rather
+-- than raising a capacity error.
 SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
-ERROR:  bm25 segment count limit reached at level 7
-SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           before.counts
-       AS terminal_step_fails_closed
-FROM compaction_terminal_before before;
-terminal_step_fails_closed
-t
+bm25_compact_step
+f
 (1 row)
 SELECT bm25_compact('compaction_terminal_idx'::regclass);
-ERROR:  bm25 segment count limit reached at level 7
+bm25_compact
+
+(1 row)
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           before.counts
-       AS terminal_full_fails_closed
-FROM compaction_terminal_before before;
-terminal_full_fails_closed
+           ARRAY[0, 0, 0, 0, 0, 0, 0, 1]
+       AS terminal_is_settled;
+terminal_is_settled
 t
 (1 row)
--- Lower-level debt still compacts when a terminal conflict is present.
--- The bounded planner validates each pass in full before publishing it,
--- so every pass that runs is complete and durable; only the pass whose
--- output cannot fit reports the capacity limit.
+-- Lower-level debt compacts normally against a populated top level.
 SET pg_textsearch.segments_per_level = 64;
 DO $$
 DECLARE
@@ -429,39 +424,42 @@ END
 $$;
 SET pg_textsearch.segments_per_level = 2;
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           ARRAY[2, 0, 0, 0, 0, 0, 2, 2]
-       AS mixed_terminal_starts_blocked;
-mixed_terminal_starts_blocked
+           ARRAY[2, 0, 0, 0, 0, 0, 0, 1]
+       AS mixed_lower_debt_starts;
+mixed_lower_debt_starts
 t
 (1 row)
 SELECT bm25_compact('compaction_terminal_idx'::regclass);
-ERROR:  bm25 segment count limit reached at level 7
+bm25_compact
+
+(1 row)
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           ARRAY[0, 1, 0, 0, 0, 0, 2, 2]
-       AS mixed_full_compacts_legal_debt;
-mixed_full_compacts_legal_debt
+           ARRAY[0, 1, 0, 0, 0, 0, 0, 1]
+       AS mixed_full_compacts_lower_debt;
+mixed_full_compacts_lower_debt
 t
 (1 row)
-SELECT count(*) = 386 AS mixed_rejection_preserves_documents
+SELECT count(*) = 386 AS mixed_compaction_preserves_documents
 FROM (
     SELECT 1
     FROM compaction_terminal
     ORDER BY body <@> to_bm25query('filler', 'compaction_terminal_idx')
 ) ranked;
-mixed_rejection_preserves_documents
+mixed_compaction_preserves_documents
 t
 (1 row)
--- No legal pass remains, so a step reports the same conflict and
--- leaves the layout untouched.
+-- With every level under threshold a step is a no-op, not an error.
 CREATE TEMP TABLE compaction_mixed_after AS
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
 SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
-ERROR:  bm25 segment count limit reached at level 7
+bm25_compact_step
+f
+(1 row)
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
            after.counts
-       AS mixed_step_fails_closed
+       AS mixed_step_is_a_noop
 FROM compaction_mixed_after after;
-mixed_step_fails_closed
+mixed_step_is_a_noop
 t
 (1 row)
 SELECT count(*) = 386 AS terminal_preserves_documents

--- a/test/expected/compaction.out
+++ b/test/expected/compaction.out
@@ -282,10 +282,12 @@ rollback_does_not_undo_a_published_pass
 t
 (1 row)
 DROP TABLE compaction_rollback CASCADE;
--- A level can carry threshold debt the engine cannot reduce: every
--- candidate group already exceeds max_segment_size, and an over-budget
--- segment is an indivisible singleton.  bm25_needs_compaction() is a
--- count-only signal, so it reports debt that bm25_compact_step()
+-- A level can sit at the segment threshold with nothing to compact:
+-- every candidate group already exceeds max_segment_size, and an
+-- over-budget segment is an uncombinable singleton.  This is not
+-- compaction debt -- no pass would reduce it -- but
+-- bm25_needs_compaction() is a count-only signal and cannot tell the
+-- two apart, so it reports the full level that bm25_compact_step()
 -- correctly declines to act on.  A scheduler that retried on a false
 -- return would spin here.
 CREATE TABLE compaction_unreducible (id bigint PRIMARY KEY, body text);
@@ -315,8 +317,8 @@ unreducible_level_is_at_threshold
 t
 (1 row)
 SELECT bm25_needs_compaction('compaction_unreducible_idx'::regclass)
-       AS unreducible_reports_debt;
-unreducible_reports_debt
+       AS unreducible_reports_full_level;
+unreducible_reports_full_level
 t
 (1 row)
 SELECT bm25_compact_step('compaction_unreducible_idx'::regclass)
@@ -348,7 +350,88 @@ RESET pg_textsearch.max_segment_size;
 RESET pg_textsearch.memtable_pages_threshold;
 RESET pg_textsearch.bulk_load_threshold;
 DROP TABLE compaction_unreducible CASCADE;
--- The top level is a terminal bucket, not a wall.  When promotion out
+-- A pass must not copy segments it cannot combine.  Spills prepend, so
+-- a level reads newest-first and its oldest, largest runs sit at the
+-- tail.  Here two fresh small segments head a 2MB run that is already
+-- over max_segment_size: the pair merges, and the run is handed back
+-- instead of being rewritten to say the same thing in a new place.
+--
+-- The handback is visible as a level count: a retained segment keeps
+-- its level, while a rewritten one is promoted.  Without the trim this
+-- ends at [0, 2, ...] with the run copied to a fresh block, and the
+-- index grows by the full size of the run rather than by the pair.
+CREATE TABLE compaction_uncombinable_tail (id bigint PRIMARY KEY, body text);
+CREATE INDEX compaction_uncombinable_tail_idx ON compaction_uncombinable_tail
+    USING bm25(body) WITH (text_config = 'simple');
+SET pg_textsearch.memtable_pages_threshold = 0;
+SET pg_textsearch.bulk_load_threshold = 0;
+SET pg_textsearch.max_segment_size = '1MB';
+-- Build the layout with a fanout no spill can reach, so that the only
+-- compaction in this fixture is the one under test.
+SET pg_textsearch.segments_per_level = 64;
+INSERT INTO compaction_uncombinable_tail
+SELECT gs, 'common ' || repeat(md5(gs::text), 32)
+FROM generate_series(1, 2000) gs;
+SELECT bm25_spill_index('compaction_uncombinable_tail_idx') > 0
+       AS tail_run_spilled;
+tail_run_spilled
+t
+(1 row)
+INSERT INTO compaction_uncombinable_tail
+SELECT 100000 + gs, 'common small ' || gs FROM generate_series(1, 20) gs;
+SELECT bm25_spill_index('compaction_uncombinable_tail_idx') > 0
+       AS head_pair_first_spilled;
+head_pair_first_spilled
+t
+(1 row)
+INSERT INTO compaction_uncombinable_tail
+SELECT 200000 + gs, 'common small ' || gs FROM generate_series(1, 20) gs;
+SELECT bm25_spill_index('compaction_uncombinable_tail_idx') > 0
+       AS head_pair_second_spilled;
+head_pair_second_spilled
+t
+(1 row)
+SET pg_textsearch.segments_per_level = 3;
+SELECT bm25_level_counts('compaction_uncombinable_tail_idx'::regclass) =
+           ARRAY[3, 0, 0, 0, 0, 0, 0, 0]
+       AS tail_level_is_at_threshold;
+tail_level_is_at_threshold
+t
+(1 row)
+CREATE TEMP TABLE compaction_tail_before AS
+SELECT pg_relation_size('compaction_uncombinable_tail_idx') AS bytes;
+SELECT bm25_compact('compaction_uncombinable_tail_idx'::regclass);
+bm25_compact
+
+(1 row)
+SELECT bm25_level_counts('compaction_uncombinable_tail_idx'::regclass) =
+           ARRAY[1, 1, 0, 0, 0, 0, 0, 0]
+       AS tail_run_retained_at_its_level;
+tail_run_retained_at_its_level
+t
+(1 row)
+SELECT pg_relation_size('compaction_uncombinable_tail_idx') - before.bytes
+           < 1024 * 1024
+       AS tail_run_was_not_copied
+FROM compaction_tail_before before;
+tail_run_was_not_copied
+t
+(1 row)
+SELECT count(*) = 2040 AS tail_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_uncombinable_tail
+    ORDER BY body <@> to_bm25query(
+        'common', 'compaction_uncombinable_tail_idx')
+    LIMIT 5000
+) ranked;
+tail_preserves_documents
+t
+(1 row)
+RESET pg_textsearch.max_segment_size;
+RESET pg_textsearch.memtable_pages_threshold;
+RESET pg_textsearch.bulk_load_threshold;
+DROP TABLE compaction_uncombinable_tail CASCADE;
 -- The top level is a terminal bucket, not a wall.  With a per-level
 -- count limit of 2, driving 384 segments up the ladder once failed
 -- closed with "segment count limit reached at level 7", because the

--- a/test/expected/compaction.out
+++ b/test/expected/compaction.out
@@ -1,0 +1,443 @@
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+\pset format unaligned
+SET client_min_messages = warning;
+SET pg_textsearch.segments_per_level = 64;
+CREATE TABLE compaction_step (id serial PRIMARY KEY, body text);
+CREATE TABLE compaction_full (id serial PRIMARY KEY, body text);
+CREATE INDEX compaction_step_idx ON compaction_step
+    USING bm25(body) WITH (text_config = 'english');
+CREATE INDEX compaction_full_idx ON compaction_full
+    USING bm25(body) WITH (text_config = 'english');
+CREATE INDEX compaction_btree_idx ON compaction_step(id);
+CREATE TABLE compaction_partitioned (id integer, body text)
+    PARTITION BY RANGE (id);
+CREATE TABLE compaction_partitioned_leaf
+    PARTITION OF compaction_partitioned FOR VALUES FROM (0) TO (10);
+CREATE INDEX compaction_partitioned_idx ON compaction_partitioned
+    USING bm25(body) WITH (text_config = 'english');
+-- New indexes expose all levels and have no compaction debt.
+SELECT array_length(
+           bm25_level_counts('compaction_step_idx'::regclass), 1) = 8
+       AS has_all_levels;
+has_all_levels
+t
+(1 row)
+SELECT bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS new_index_needs_compaction;
+new_index_needs_compaction
+f
+(1 row)
+-- Non-bm25 relations are rejected.
+SELECT bm25_level_counts('compaction_btree_idx'::regclass);
+ERROR:  "compaction_btree_idx" is not a bm25 index
+SELECT bm25_level_counts('compaction_step'::regclass);
+ERROR:  "compaction_step" is not a bm25 index
+-- Partitioned parents have no storage; their physical leaves remain usable.
+SELECT bm25_level_counts('compaction_partitioned_idx'::regclass);
+ERROR:  "compaction_partitioned_idx" is a partitioned bm25 index
+HINT:  Use a physical partition index instead.
+SELECT bm25_compact('compaction_partitioned_idx'::regclass);
+ERROR:  "compaction_partitioned_idx" is a partitioned bm25 index
+HINT:  Use a physical partition index instead.
+SELECT bm25_compact_step('compaction_partitioned_idx'::regclass);
+ERROR:  "compaction_partitioned_idx" is a partitioned bm25 index
+HINT:  Use a physical partition index instead.
+SELECT bm25_needs_compaction('compaction_partitioned_idx'::regclass);
+ERROR:  "compaction_partitioned_idx" is a partitioned bm25 index
+HINT:  Use a physical partition index instead.
+CONTEXT:  SQL function "bm25_needs_compaction" statement 1
+SELECT array_length(bm25_level_counts(i.inhrelid), 1) = 8
+       AS partition_leaf_counts_supported
+FROM pg_inherits i
+WHERE i.inhparent = 'compaction_partitioned_idx'::regclass;
+partition_leaf_counts_supported
+t
+(1 row)
+SELECT bm25_compact(i.inhrelid)
+FROM pg_inherits i
+WHERE i.inhparent = 'compaction_partitioned_idx'::regclass;
+bm25_compact
+
+(1 row)
+SELECT NOT bm25_compact_step(i.inhrelid)
+       AND NOT bm25_needs_compaction(i.inhrelid)
+       AS partition_leaf_compaction_supported
+FROM pg_inherits i
+WHERE i.inhparent = 'compaction_partitioned_idx'::regclass;
+partition_leaf_compaction_supported
+t
+(1 row)
+-- Construct identical four-segment layouts without inline compaction.
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..4 LOOP
+        INSERT INTO compaction_step (body)
+        SELECT format('step batch %s document %s filler', n, i)
+        FROM generate_series(1, 20) i;
+        INSERT INTO compaction_full (body)
+        SELECT format('full batch %s document %s filler', n, i)
+        FROM generate_series(1, 20) i;
+        PERFORM bm25_spill_index('compaction_step_idx');
+        PERFORM bm25_spill_index('compaction_full_idx');
+    END LOOP;
+END
+$$;
+SET pg_textsearch.segments_per_level = 2;
+SELECT bm25_level_counts('compaction_step_idx'::regclass) =
+           ARRAY[4, 0, 0, 0, 0, 0, 0, 0]
+       AND bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS step_starts_with_debt;
+step_starts_with_debt
+t
+(1 row)
+-- Permanent-index mutators reject read-only transactions.
+BEGIN READ ONLY;
+SELECT bm25_compact('compaction_step_idx'::regclass);
+ERROR:  cannot execute bm25 index compaction in a read-only transaction
+ROLLBACK;
+BEGIN READ ONLY;
+SELECT bm25_compact_step('compaction_step_idx'::regclass);
+ERROR:  cannot execute bm25 index compaction in a read-only transaction
+ROLLBACK;
+-- One step merges exactly one batch and reports that work was performed.
+SELECT bm25_compact_step('compaction_step_idx'::regclass)
+       AS one_batch_ran;
+one_batch_ran
+t
+(1 row)
+SELECT bm25_level_counts('compaction_step_idx'::regclass) =
+           ARRAY[2, 1, 0, 0, 0, 0, 0, 0]
+       AND bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS one_batch_only;
+one_batch_only
+t
+(1 row)
+-- Repeated steps converge, then report that no batch ran.
+CREATE TEMP TABLE compaction_step_result (steps integer);
+DO $$
+DECLARE
+    step_count integer := 0;
+BEGIN
+    WHILE bm25_needs_compaction('compaction_step_idx'::regclass) LOOP
+        step_count := step_count + 1;
+        IF step_count > 100 THEN
+            RAISE EXCEPTION 'bm25_compact_step did not terminate';
+        END IF;
+        IF NOT bm25_compact_step('compaction_step_idx'::regclass) THEN
+            RAISE EXCEPTION 'bm25_needs_compaction disagrees with step';
+        END IF;
+    END LOOP;
+    INSERT INTO compaction_step_result VALUES (step_count);
+END
+$$;
+SELECT steps = 2 AS step_split_cascade
+FROM compaction_step_result;
+step_split_cascade
+t
+(1 row)
+SELECT NOT bm25_needs_compaction('compaction_step_idx'::regclass)
+       AND NOT bm25_compact_step('compaction_step_idx'::regclass)
+       AS step_converged;
+step_converged
+t
+(1 row)
+-- Whole-index compaction reaches the same terminal layout.
+SELECT bm25_compact('compaction_full_idx'::regclass);
+bm25_compact
+
+(1 row)
+SELECT NOT bm25_needs_compaction('compaction_full_idx'::regclass)
+       AND bm25_level_counts('compaction_step_idx'::regclass) =
+           bm25_level_counts('compaction_full_idx'::regclass)
+       AS full_compaction_converged;
+full_compaction_converged
+t
+(1 row)
+SELECT count(*) = 80 AS step_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_step
+    ORDER BY body <@> to_bm25query('filler', 'compaction_step_idx')
+) ranked;
+step_preserves_documents
+t
+(1 row)
+SELECT count(*) = 80 AS full_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_full
+    ORDER BY body <@> to_bm25query('filler', 'compaction_full_idx')
+) ranked;
+full_preserves_documents
+t
+(1 row)
+-- Inspection is public, but only the index owner may mutate it.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'compaction_user') THEN
+        EXECUTE 'REASSIGN OWNED BY compaction_user TO CURRENT_USER';
+        EXECUTE 'DROP OWNED BY compaction_user CASCADE';
+        DROP ROLE compaction_user;
+    END IF;
+END
+$$;
+CREATE ROLE compaction_user LOGIN;
+GRANT USAGE ON SCHEMA public TO compaction_user;
+SET ROLE compaction_user;
+SELECT array_length(
+           bm25_level_counts('compaction_step_idx'::regclass), 1) = 8
+       AS nonowner_can_inspect;
+nonowner_can_inspect
+t
+(1 row)
+SELECT bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS nonowner_can_check;
+nonowner_can_check
+f
+(1 row)
+SELECT bm25_compact('compaction_step_idx'::regclass);
+ERROR:  must be owner of index compaction_step_idx
+SELECT bm25_compact_step('compaction_step_idx'::regclass);
+ERROR:  must be owner of index compaction_step_idx
+RESET ROLE;
+DROP OWNED BY compaction_user CASCADE;
+DROP ROLE compaction_user;
+-- Local temporary indexes remain mutable in read-only transactions.
+SET pg_textsearch.segments_per_level = 64;
+CREATE TEMP TABLE compaction_temp_step (id serial, body text);
+CREATE TEMP TABLE compaction_temp_full (id serial, body text);
+CREATE INDEX compaction_temp_step_idx ON compaction_temp_step
+    USING bm25(body) WITH (text_config = 'english');
+CREATE INDEX compaction_temp_full_idx ON compaction_temp_full
+    USING bm25(body) WITH (text_config = 'english');
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..2 LOOP
+        INSERT INTO compaction_temp_step (body)
+        VALUES (format('temporary step document %s filler', n));
+        INSERT INTO compaction_temp_full (body)
+        VALUES (format('temporary full document %s filler', n));
+        PERFORM bm25_spill_index('compaction_temp_step_idx');
+        PERFORM bm25_spill_index('compaction_temp_full_idx');
+    END LOOP;
+END
+$$;
+SET pg_textsearch.segments_per_level = 2;
+BEGIN READ ONLY;
+SELECT bm25_compact_step('compaction_temp_step_idx'::regclass)
+       AS temp_step_ran;
+temp_step_ran
+t
+(1 row)
+SELECT bm25_compact('compaction_temp_full_idx'::regclass);
+bm25_compact
+
+(1 row)
+COMMIT;
+SELECT NOT bm25_needs_compaction('compaction_temp_step_idx'::regclass)
+       AND NOT bm25_needs_compaction(
+           'compaction_temp_full_idx'::regclass)
+       AS temp_indexes_converged;
+temp_indexes_converged
+t
+(1 row)
+-- A level can carry threshold debt the engine cannot reduce: every
+-- candidate group already exceeds max_segment_size, and an over-budget
+-- segment is an indivisible singleton.  bm25_needs_compaction() is a
+-- count-only signal, so it reports debt that bm25_compact_step()
+-- correctly declines to act on.  A scheduler that retried on a false
+-- return would spin here.
+CREATE TABLE compaction_unreducible (id bigint PRIMARY KEY, body text);
+CREATE INDEX compaction_unreducible_idx ON compaction_unreducible
+    USING bm25(body) WITH (text_config = 'simple');
+SET pg_textsearch.max_segment_size = '1MB';
+SET pg_textsearch.memtable_pages_threshold = 0;
+SET pg_textsearch.bulk_load_threshold = 0;
+SET pg_textsearch.segments_per_level = 2;
+DO $$
+DECLARE
+    batch integer;
+BEGIN
+    FOR batch IN 0..1 LOOP
+        INSERT INTO compaction_unreducible
+        SELECT batch * 2000 + gs,
+               'common ' || repeat(md5((batch * 2000 + gs)::text), 32)
+        FROM generate_series(1, 2000) gs;
+        PERFORM bm25_spill_index('compaction_unreducible_idx');
+    END LOOP;
+END
+$$;
+SELECT bm25_level_counts('compaction_unreducible_idx'::regclass) =
+           ARRAY[2, 0, 0, 0, 0, 0, 0, 0]
+       AS unreducible_level_is_at_threshold;
+unreducible_level_is_at_threshold
+t
+(1 row)
+SELECT bm25_needs_compaction('compaction_unreducible_idx'::regclass)
+       AS unreducible_reports_debt;
+unreducible_reports_debt
+t
+(1 row)
+SELECT bm25_compact_step('compaction_unreducible_idx'::regclass)
+       AS unreducible_step_declines;
+unreducible_step_declines
+f
+(1 row)
+SELECT bm25_compact('compaction_unreducible_idx'::regclass);
+bm25_compact
+
+(1 row)
+SELECT bm25_level_counts('compaction_unreducible_idx'::regclass) =
+           ARRAY[2, 0, 0, 0, 0, 0, 0, 0]
+       AS unreducible_full_is_a_noop;
+unreducible_full_is_a_noop
+t
+(1 row)
+SELECT count(*) = 4000 AS unreducible_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_unreducible
+    ORDER BY body <@> to_bm25query('common', 'compaction_unreducible_idx')
+    LIMIT 5000
+) ranked;
+unreducible_preserves_documents
+t
+(1 row)
+RESET pg_textsearch.max_segment_size;
+RESET pg_textsearch.memtable_pages_threshold;
+RESET pg_textsearch.bulk_load_threshold;
+DROP TABLE compaction_unreducible CASCADE;
+-- A full L7 blocks L6 promotion without mutating the index.
+CREATE TABLE compaction_terminal (id serial PRIMARY KEY, body text);
+CREATE INDEX compaction_terminal_idx ON compaction_terminal
+    USING bm25(body) WITH (text_config = 'english');
+SET pg_textsearch.debug_segment_count_limit = 2;
+DO $$
+DECLARE
+    counts int[];
+    n integer;
+BEGIN
+    FOR n IN 1..384 LOOP
+        PERFORM set_config(
+            'pg_textsearch.segments_per_level', '64', true);
+        INSERT INTO compaction_terminal (body)
+        VALUES (format('terminal segment document %s filler', n));
+        PERFORM bm25_spill_index('compaction_terminal_idx');
+        PERFORM set_config(
+            'pg_textsearch.segments_per_level', '2', true);
+
+        WHILE bm25_needs_compaction(
+                  'compaction_terminal_idx'::regclass) LOOP
+            counts :=
+                bm25_level_counts('compaction_terminal_idx'::regclass);
+            EXIT WHEN counts = ARRAY[0, 0, 0, 0, 0, 0, 2, 2];
+
+            IF NOT bm25_compact_step(
+                       'compaction_terminal_idx'::regclass) THEN
+                RAISE EXCEPTION
+                    'terminal setup stopped after source segment %', n;
+            END IF;
+        END LOOP;
+    END LOOP;
+END
+$$;
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           ARRAY[0, 0, 0, 0, 0, 0, 2, 2]
+       AND bm25_needs_compaction('compaction_terminal_idx'::regclass)
+       AS terminal_starts_blocked;
+terminal_starts_blocked
+t
+(1 row)
+CREATE TEMP TABLE compaction_terminal_before AS
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
+SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
+ERROR:  bm25 segment count limit reached at level 7
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           before.counts
+       AS terminal_step_fails_closed
+FROM compaction_terminal_before before;
+terminal_step_fails_closed
+t
+(1 row)
+SELECT bm25_compact('compaction_terminal_idx'::regclass);
+ERROR:  bm25 segment count limit reached at level 7
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           before.counts
+       AS terminal_full_fails_closed
+FROM compaction_terminal_before before;
+terminal_full_fails_closed
+t
+(1 row)
+-- Lower-level debt still compacts when a terminal conflict is present.
+-- The bounded planner validates each pass in full before publishing it,
+-- so every pass that runs is complete and durable; only the pass whose
+-- output cannot fit reports the capacity limit.
+SET pg_textsearch.segments_per_level = 64;
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..2 LOOP
+        INSERT INTO compaction_terminal (body)
+        VALUES (format('mixed lower segment document %s filler', n));
+        PERFORM bm25_spill_index('compaction_terminal_idx');
+    END LOOP;
+END
+$$;
+SET pg_textsearch.segments_per_level = 2;
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           ARRAY[2, 0, 0, 0, 0, 0, 2, 2]
+       AS mixed_terminal_starts_blocked;
+mixed_terminal_starts_blocked
+t
+(1 row)
+SELECT bm25_compact('compaction_terminal_idx'::regclass);
+ERROR:  bm25 segment count limit reached at level 7
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           ARRAY[0, 1, 0, 0, 0, 0, 2, 2]
+       AS mixed_full_compacts_legal_debt;
+mixed_full_compacts_legal_debt
+t
+(1 row)
+SELECT count(*) = 386 AS mixed_rejection_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_terminal
+    ORDER BY body <@> to_bm25query('filler', 'compaction_terminal_idx')
+) ranked;
+mixed_rejection_preserves_documents
+t
+(1 row)
+-- No legal pass remains, so a step reports the same conflict and
+-- leaves the layout untouched.
+CREATE TEMP TABLE compaction_mixed_after AS
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
+SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
+ERROR:  bm25 segment count limit reached at level 7
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           after.counts
+       AS mixed_step_fails_closed
+FROM compaction_mixed_after after;
+mixed_step_fails_closed
+t
+(1 row)
+SELECT count(*) = 386 AS terminal_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_terminal
+    ORDER BY body <@> to_bm25query('filler', 'compaction_terminal_idx')
+) ranked;
+terminal_preserves_documents
+t
+(1 row)
+RESET pg_textsearch.debug_segment_count_limit;
+RESET pg_textsearch.segments_per_level;
+DROP TABLE compaction_terminal CASCADE;
+DROP TABLE compaction_partitioned CASCADE;
+DROP TABLE compaction_full CASCADE;
+DROP TABLE compaction_step CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/expected/compaction.out
+++ b/test/expected/compaction.out
@@ -101,7 +101,9 @@ BEGIN READ ONLY;
 SELECT bm25_compact_step('compaction_step_idx'::regclass);
 ERROR:  cannot execute bm25 index compaction in a read-only transaction
 ROLLBACK;
--- One step merges exactly one batch and reports that work was performed.
+-- In this layout one pass happens to merge exactly one batch.  A pass is
+-- not limited to one batch in general; it may span several, and may pull
+-- in further batches to unblock a destination level.
 SELECT bm25_compact_step('compaction_step_idx'::regclass)
        AS one_batch_ran;
 one_batch_ran
@@ -245,6 +247,41 @@ SELECT NOT bm25_needs_compaction('compaction_temp_step_idx'::regclass)
 temp_indexes_converged
 t
 (1 row)
+-- A published pass is a physical change, so ROLLBACK does not undo it.
+-- A caller must not treat a step as transactional work.
+CREATE TABLE compaction_rollback (id serial, body text);
+CREATE INDEX compaction_rollback_idx ON compaction_rollback
+    USING bm25(body) WITH (text_config = 'english');
+SET pg_textsearch.segments_per_level = 64;
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..4 LOOP
+        INSERT INTO compaction_rollback (body)
+        VALUES (format('rollback document %s filler', n));
+        PERFORM bm25_spill_index('compaction_rollback_idx');
+    END LOOP;
+END
+$$;
+SET pg_textsearch.segments_per_level = 2;
+CREATE TEMP TABLE compaction_rollback_before AS
+SELECT bm25_level_counts('compaction_rollback_idx'::regclass) AS counts;
+BEGIN;
+SELECT bm25_compact_step('compaction_rollback_idx'::regclass)
+       AS rollback_step_ran;
+rollback_step_ran
+t
+(1 row)
+ROLLBACK;
+SELECT bm25_level_counts('compaction_rollback_idx'::regclass)
+           <> before.counts
+       AS rollback_does_not_undo_a_published_pass
+FROM compaction_rollback_before before;
+rollback_does_not_undo_a_published_pass
+t
+(1 row)
+DROP TABLE compaction_rollback CASCADE;
 -- A level can carry threshold debt the engine cannot reduce: every
 -- candidate group already exceeds max_segment_size, and an over-budget
 -- segment is an indivisible singleton.  bm25_needs_compaction() is a
@@ -311,7 +348,9 @@ RESET pg_textsearch.max_segment_size;
 RESET pg_textsearch.memtable_pages_threshold;
 RESET pg_textsearch.bulk_load_threshold;
 DROP TABLE compaction_unreducible CASCADE;
--- A full L7 blocks L6 promotion without mutating the index.
+-- A full L7 blocks L6 promotion without changing the segment layout.
+-- (Reclaim of already-parked pages may still run; only the published
+-- level counts are asserted here.)
 CREATE TABLE compaction_terminal (id serial PRIMARY KEY, body text);
 CREATE INDEX compaction_terminal_idx ON compaction_terminal
     USING bm25(body) WITH (text_config = 'english');

--- a/test/expected/force_merge.out
+++ b/test/expected/force_merge.out
@@ -366,10 +366,14 @@ BEGIN
         RAISE EXCEPTION 'force merge increased segment count: before %, after %',
                         deep_before, deep_summary;
     END IF;
-    IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') >
-       regexp_count(mixed_before, 'L[0-7] Segment [0-9]+:') THEN
-        RAISE EXCEPTION 'force merge increased segment count: before %, after %',
-                        mixed_before, mixed_summary;
+    -- The mixed fixture is the multi-segment case, so force merge must
+    -- actually combine its L0 and L7 segments.  Asserting only that the
+    -- count did not increase would also accept a no-op.
+    IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') <> 1
+       OR mixed_summary !~ 'L0 Segment 1:' THEN
+        RAISE EXCEPTION
+            'force merge did not combine the mixed layout: before %, after %',
+            mixed_before, mixed_summary;
     END IF;
     IF regexp_count(memtable_summary, 'L[0-7] Segment [0-9]+:') >
        regexp_count(memtable_before, 'L[0-7] Segment [0-9]+:') THEN

--- a/test/expected/force_merge.out
+++ b/test/expected/force_merge.out
@@ -242,6 +242,11 @@ $$;
 DROP TABLE force_spill_cascade CASCADE;
 --------------------------------------------------------------------------------
 -- Force merge is bounded best-effort compaction, not forceMerge(1).
+--
+-- Four top-level layouts: a single L7 segment, a deeper cascade that
+-- still settles at one L7 segment because the top level compacts into
+-- itself, a mixed L0+L7 pair (the multi-segment case), and an L7
+-- segment with a pending memtable.
 --------------------------------------------------------------------------------
 SET pg_textsearch.segments_per_level = 2;
 CREATE TABLE force_l7_single (id serial PRIMARY KEY, content text);
@@ -251,10 +256,10 @@ NOTICE:  BM25 index build started for relation force_l7_single_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
-CREATE TABLE force_l7_multiple (id serial PRIMARY KEY, content text);
-CREATE INDEX force_l7_multiple_idx ON force_l7_multiple USING bm25(content)
+CREATE TABLE force_l7_deep (id serial PRIMARY KEY, content text);
+CREATE INDEX force_l7_deep_idx ON force_l7_deep USING bm25(content)
   WITH (text_config='english');
-NOTICE:  BM25 index build started for relation force_l7_multiple_idx
+NOTICE:  BM25 index build started for relation force_l7_deep_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
@@ -277,9 +282,9 @@ DECLARE
     n integer;
 BEGIN
     FOR n IN 1..256 LOOP
-        INSERT INTO force_l7_multiple (content)
+        INSERT INTO force_l7_deep (content)
         VALUES (format('multiple terminal %s filler', n));
-        PERFORM bm25_spill_index('force_l7_multiple_idx');
+        PERFORM bm25_spill_index('force_l7_deep_idx');
 
         IF n <= 128 THEN
             INSERT INTO force_l7_single (content)
@@ -302,7 +307,7 @@ $$;
 DO $$
 DECLARE
     single_summary text := bm25_summarize_index('force_l7_single_idx');
-    multiple_summary text := bm25_summarize_index('force_l7_multiple_idx');
+    deep_summary text := bm25_summarize_index('force_l7_deep_idx');
     mixed_summary text := bm25_summarize_index('force_l7_mixed_idx');
     memtable_summary text := bm25_summarize_index('force_l7_memtable_idx');
 BEGIN
@@ -311,10 +316,10 @@ BEGIN
         RAISE EXCEPTION 'single L7 layout was not constructed: %',
                         single_summary;
     END IF;
-    IF regexp_count(multiple_summary, 'L[0-7] Segment [0-9]+:') <> 2
-       OR multiple_summary !~ 'L7 Segment 2:' THEN
-        RAISE EXCEPTION 'multiple L7 layout was not constructed: %',
-                        multiple_summary;
+    IF regexp_count(deep_summary, 'L[0-7] Segment [0-9]+:') <> 1
+       OR deep_summary !~ 'L7 Segment 1:' THEN
+        RAISE EXCEPTION 'deep cascade did not settle at one L7 segment: %',
+                        deep_summary;
     END IF;
     IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') <> 2
        OR mixed_summary !~ 'L0 Segment 1:'
@@ -333,21 +338,21 @@ $$;
 DO $$
 DECLARE
     single_before text := bm25_summarize_index('force_l7_single_idx');
-    multiple_before text := bm25_summarize_index('force_l7_multiple_idx');
+    deep_before text := bm25_summarize_index('force_l7_deep_idx');
     mixed_before text := bm25_summarize_index('force_l7_mixed_idx');
     memtable_before text := bm25_summarize_index('force_l7_memtable_idx');
     single_summary text;
-    multiple_summary text;
+    deep_summary text;
     mixed_summary text;
     memtable_summary text;
 BEGIN
     PERFORM bm25_force_merge('force_l7_single_idx');
-    PERFORM bm25_force_merge('force_l7_multiple_idx');
+    PERFORM bm25_force_merge('force_l7_deep_idx');
     PERFORM bm25_force_merge('force_l7_mixed_idx');
     PERFORM bm25_force_merge('force_l7_memtable_idx');
 
     single_summary := bm25_summarize_index('force_l7_single_idx');
-    multiple_summary := bm25_summarize_index('force_l7_multiple_idx');
+    deep_summary := bm25_summarize_index('force_l7_deep_idx');
     mixed_summary := bm25_summarize_index('force_l7_mixed_idx');
     memtable_summary := bm25_summarize_index('force_l7_memtable_idx');
 
@@ -356,10 +361,10 @@ BEGIN
         RAISE EXCEPTION 'force merge increased segment count: before %, after %',
                         single_before, single_summary;
     END IF;
-    IF regexp_count(multiple_summary, 'L[0-7] Segment [0-9]+:') >
-       regexp_count(multiple_before, 'L[0-7] Segment [0-9]+:') THEN
+    IF regexp_count(deep_summary, 'L[0-7] Segment [0-9]+:') >
+       regexp_count(deep_before, 'L[0-7] Segment [0-9]+:') THEN
         RAISE EXCEPTION 'force merge increased segment count: before %, after %',
-                        multiple_before, multiple_summary;
+                        deep_before, deep_summary;
     END IF;
     IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') >
        regexp_count(mixed_before, 'L[0-7] Segment [0-9]+:') THEN
@@ -382,9 +387,9 @@ BEGIN
                      to_bm25query('filler', 'force_l7_single_idx')
         ) ranked) <> 128
        OR (SELECT count(*) FROM (
-               SELECT 1 FROM force_l7_multiple
+               SELECT 1 FROM force_l7_deep
                ORDER BY content <@>
-                        to_bm25query('filler', 'force_l7_multiple_idx')
+                        to_bm25query('filler', 'force_l7_deep_idx')
            ) ranked) <> 256
        OR (SELECT count(*) FROM (
                SELECT 1 FROM force_l7_mixed
@@ -446,7 +451,7 @@ BEGIN
 END
 $$;
 DROP TABLE force_l7_single CASCADE;
-DROP TABLE force_l7_multiple CASCADE;
+DROP TABLE force_l7_deep CASCADE;
 DROP TABLE force_l7_mixed CASCADE;
 DROP TABLE force_l7_memtable CASCADE;
 --------------------------------------------------------------------------------

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -421,7 +421,7 @@ BEGIN
         PERFORM bm25_spill_index('merge_starve_idx');
     END LOOP;
     -- Each of these alone exceeds the budget, so L0 becomes an
-    -- indivisible run while staying below the level threshold.
+    -- uncombinable run while staying below the level threshold.
     FOR batch IN 8..11 LOOP
         INSERT INTO merge_starve
         SELECT batch * 2000 + gs,
@@ -451,7 +451,7 @@ DECLARE
 BEGIN
     IF regexp_count(summary, 'L1 Segment [0-9]+:') <> 0
        OR regexp_count(summary, 'L2 Segment [0-9]+:') = 0 THEN
-        RAISE EXCEPTION 'indivisible L0 starved a compactable L1: %',
+        RAISE EXCEPTION 'uncombinable L0 starved a compactable L1: %',
                         summary;
     END IF;
 END

--- a/test/scripts/compaction_ownercheck_source.sh
+++ b/test/scripts/compaction_ownercheck_source.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Verify that public compaction mutators reject nonowners before requesting a
+# heavyweight relation lock, then recheck ownership after locking.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SOURCE_FILE="${REPO_ROOT}/src/access/compaction_api.c"
+
+open_body="$(
+    sed -n '/^tp_open_bm25_index(Oid indexoid, LOCKMODE lockmode, bool need_owner)$/,/^}$/p' \
+        "${SOURCE_FILE}"
+)"
+
+mapfile -t ownercheck_lines < <(
+    grep -n "object_ownercheck(RelationRelationId, indexoid, GetUserId())" \
+        <<<"${open_body}" |
+        cut -d: -f1
+)
+relation_open_line="$(
+    grep -n "index_rel = relation_open(indexoid, lockmode);" \
+        <<<"${open_body}" |
+        cut -d: -f1
+)"
+
+if [[ "${#ownercheck_lines[@]}" -ne 2 ]]; then
+    echo "expected two compaction ownership checks, found ${#ownercheck_lines[@]}" >&2
+    exit 1
+fi
+
+if [[ -z "${relation_open_line}" ||
+      "${ownercheck_lines[0]}" -ge "${relation_open_line}" ||
+      "${ownercheck_lines[1]}" -le "${relation_open_line}" ]]; then
+    echo "compaction ownership checks must bracket relation_open" >&2
+    exit 1
+fi
+
+echo "Compaction ownership check ordering passed"

--- a/test/scripts/compaction_recovery.sh
+++ b/test/scripts/compaction_recovery.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Verify that per-index compaction mutators reject execution on a
+# physical standby before opening or changing the index.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY_PORT=55464
+STANDBY_PORT=55465
+TEST_DB=compaction_recovery_test
+PRIMARY_DIR="${SCRIPT_DIR}/../tmp_compaction_recovery_primary"
+STANDBY_DIR="${SCRIPT_DIR}/../tmp_compaction_recovery_standby"
+
+# Avoid Unix-socket path limits in deeply nested worktrees.
+REPL_HOST=127.0.0.1
+REPL_SOCKET_DIR=
+
+# shellcheck source=replication_lib.sh
+source "${SCRIPT_DIR}/replication_lib.sh"
+
+trap repl_cleanup EXIT INT TERM
+
+expect_recovery_rejection() {
+    local function_name=$1
+    local output
+    local expected_message="cannot compact a bm25 index during recovery"
+
+    if output=$(psql -v ON_ERROR_STOP=1 -v VERBOSITY=verbose \
+        -p "${STANDBY_PORT}" -d "${TEST_DB}" \
+        -c "SELECT ${function_name}(
+                'compaction_recovery_idx'::regclass);" 2>&1); then
+        error "${function_name} unexpectedly succeeded during recovery"
+    fi
+
+    if [[ "${output}" != *"25006"* ]] ||
+       [[ "${output}" != *"${expected_message}"* ]]; then
+        error "${function_name} returned the wrong recovery error: ${output}"
+    fi
+
+    log "PASS: ${function_name} rejected execution during recovery"
+}
+
+main() {
+    log "Starting per-index compaction recovery-guard test..."
+    check_required_tools
+    setup_primary
+
+    primary_sql "
+        CREATE TABLE compaction_recovery (
+            id integer PRIMARY KEY,
+            body text
+        );
+        INSERT INTO compaction_recovery
+        VALUES (1, 'standby compaction guard');
+        CREATE INDEX compaction_recovery_idx
+            ON compaction_recovery USING bm25(body)
+            WITH (text_config = 'english');
+    " >/dev/null
+
+    setup_standby
+    wait_for_standby_catchup
+
+    expect_recovery_rejection bm25_compact
+    expect_recovery_rejection bm25_compact_step
+
+    log "Per-index compaction recovery-guard test PASSED"
+}
+
+main "$@"

--- a/test/scripts/replication_lib.sh
+++ b/test/scripts/replication_lib.sh
@@ -30,12 +30,10 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 # Route all psql / pg_basebackup connections through a writable
-# socket directory. The Ubuntu apt postgresql package's default
-# unix_socket_directories (/var/run/postgresql) is owned by the
-# postgres user, so a non-root CI runner cannot create sockets
-# there. /tmp is writable for any user and is also the default
-# psql socket dir on macOS, so this works on every platform.
-export PGHOST=/tmp
+# socket directory by default. Callers may select TCP and disable
+# Unix sockets when their workspace path exceeds the platform limit.
+REPL_SOCKET_DIR=${REPL_SOCKET_DIR-/tmp}
+export PGHOST=${REPL_HOST:-${REPL_SOCKET_DIR}}
 
 log() {
     echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"
@@ -183,7 +181,7 @@ setup_primary() {
 
     cat >> "${PRIMARY_DIR}/postgresql.conf" <<EOF
 port = ${PRIMARY_PORT}
-unix_socket_directories = '/tmp'
+unix_socket_directories = '${REPL_SOCKET_DIR}'
 shared_buffers = 128MB
 max_connections = 30
 log_min_messages = notice
@@ -217,7 +215,7 @@ setup_standby() {
 
     cat >> "${STANDBY_DIR}/postgresql.conf" <<EOF
 port = ${STANDBY_PORT}
-unix_socket_directories = '/tmp'
+unix_socket_directories = '${REPL_SOCKET_DIR}'
 EOF
 
     pg_ctl start -D "${STANDBY_DIR}" \
@@ -243,7 +241,7 @@ setup_standby2() {
 
     cat >> "${STANDBY2_DIR}/postgresql.conf" <<EOF
 port = ${STANDBY2_PORT}
-unix_socket_directories = '/tmp'
+unix_socket_directories = '${REPL_SOCKET_DIR}'
 EOF
 
     pg_ctl start -D "${STANDBY2_DIR}" \

--- a/test/sql/compaction.sql
+++ b/test/sql/compaction.sql
@@ -1,0 +1,342 @@
+CREATE EXTENSION IF NOT EXISTS pg_textsearch;
+
+\pset format unaligned
+SET client_min_messages = warning;
+SET pg_textsearch.segments_per_level = 64;
+
+CREATE TABLE compaction_step (id serial PRIMARY KEY, body text);
+CREATE TABLE compaction_full (id serial PRIMARY KEY, body text);
+CREATE INDEX compaction_step_idx ON compaction_step
+    USING bm25(body) WITH (text_config = 'english');
+CREATE INDEX compaction_full_idx ON compaction_full
+    USING bm25(body) WITH (text_config = 'english');
+CREATE INDEX compaction_btree_idx ON compaction_step(id);
+CREATE TABLE compaction_partitioned (id integer, body text)
+    PARTITION BY RANGE (id);
+CREATE TABLE compaction_partitioned_leaf
+    PARTITION OF compaction_partitioned FOR VALUES FROM (0) TO (10);
+CREATE INDEX compaction_partitioned_idx ON compaction_partitioned
+    USING bm25(body) WITH (text_config = 'english');
+
+-- New indexes expose all levels and have no compaction debt.
+SELECT array_length(
+           bm25_level_counts('compaction_step_idx'::regclass), 1) = 8
+       AS has_all_levels;
+SELECT bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS new_index_needs_compaction;
+
+-- Non-bm25 relations are rejected.
+SELECT bm25_level_counts('compaction_btree_idx'::regclass);
+SELECT bm25_level_counts('compaction_step'::regclass);
+
+-- Partitioned parents have no storage; their physical leaves remain usable.
+SELECT bm25_level_counts('compaction_partitioned_idx'::regclass);
+SELECT bm25_compact('compaction_partitioned_idx'::regclass);
+SELECT bm25_compact_step('compaction_partitioned_idx'::regclass);
+SELECT bm25_needs_compaction('compaction_partitioned_idx'::regclass);
+SELECT array_length(bm25_level_counts(i.inhrelid), 1) = 8
+       AS partition_leaf_counts_supported
+FROM pg_inherits i
+WHERE i.inhparent = 'compaction_partitioned_idx'::regclass;
+SELECT bm25_compact(i.inhrelid)
+FROM pg_inherits i
+WHERE i.inhparent = 'compaction_partitioned_idx'::regclass;
+SELECT NOT bm25_compact_step(i.inhrelid)
+       AND NOT bm25_needs_compaction(i.inhrelid)
+       AS partition_leaf_compaction_supported
+FROM pg_inherits i
+WHERE i.inhparent = 'compaction_partitioned_idx'::regclass;
+
+-- Construct identical four-segment layouts without inline compaction.
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..4 LOOP
+        INSERT INTO compaction_step (body)
+        SELECT format('step batch %s document %s filler', n, i)
+        FROM generate_series(1, 20) i;
+        INSERT INTO compaction_full (body)
+        SELECT format('full batch %s document %s filler', n, i)
+        FROM generate_series(1, 20) i;
+        PERFORM bm25_spill_index('compaction_step_idx');
+        PERFORM bm25_spill_index('compaction_full_idx');
+    END LOOP;
+END
+$$;
+
+SET pg_textsearch.segments_per_level = 2;
+SELECT bm25_level_counts('compaction_step_idx'::regclass) =
+           ARRAY[4, 0, 0, 0, 0, 0, 0, 0]
+       AND bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS step_starts_with_debt;
+
+-- Permanent-index mutators reject read-only transactions.
+BEGIN READ ONLY;
+SELECT bm25_compact('compaction_step_idx'::regclass);
+ROLLBACK;
+BEGIN READ ONLY;
+SELECT bm25_compact_step('compaction_step_idx'::regclass);
+ROLLBACK;
+
+-- One step merges exactly one batch and reports that work was performed.
+SELECT bm25_compact_step('compaction_step_idx'::regclass)
+       AS one_batch_ran;
+SELECT bm25_level_counts('compaction_step_idx'::regclass) =
+           ARRAY[2, 1, 0, 0, 0, 0, 0, 0]
+       AND bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS one_batch_only;
+
+-- Repeated steps converge, then report that no batch ran.
+CREATE TEMP TABLE compaction_step_result (steps integer);
+DO $$
+DECLARE
+    step_count integer := 0;
+BEGIN
+    WHILE bm25_needs_compaction('compaction_step_idx'::regclass) LOOP
+        step_count := step_count + 1;
+        IF step_count > 100 THEN
+            RAISE EXCEPTION 'bm25_compact_step did not terminate';
+        END IF;
+        IF NOT bm25_compact_step('compaction_step_idx'::regclass) THEN
+            RAISE EXCEPTION 'bm25_needs_compaction disagrees with step';
+        END IF;
+    END LOOP;
+    INSERT INTO compaction_step_result VALUES (step_count);
+END
+$$;
+SELECT steps = 2 AS step_split_cascade
+FROM compaction_step_result;
+SELECT NOT bm25_needs_compaction('compaction_step_idx'::regclass)
+       AND NOT bm25_compact_step('compaction_step_idx'::regclass)
+       AS step_converged;
+
+-- Whole-index compaction reaches the same terminal layout.
+SELECT bm25_compact('compaction_full_idx'::regclass);
+SELECT NOT bm25_needs_compaction('compaction_full_idx'::regclass)
+       AND bm25_level_counts('compaction_step_idx'::regclass) =
+           bm25_level_counts('compaction_full_idx'::regclass)
+       AS full_compaction_converged;
+SELECT count(*) = 80 AS step_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_step
+    ORDER BY body <@> to_bm25query('filler', 'compaction_step_idx')
+) ranked;
+SELECT count(*) = 80 AS full_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_full
+    ORDER BY body <@> to_bm25query('filler', 'compaction_full_idx')
+) ranked;
+
+-- Inspection is public, but only the index owner may mutate it.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'compaction_user') THEN
+        EXECUTE 'REASSIGN OWNED BY compaction_user TO CURRENT_USER';
+        EXECUTE 'DROP OWNED BY compaction_user CASCADE';
+        DROP ROLE compaction_user;
+    END IF;
+END
+$$;
+CREATE ROLE compaction_user LOGIN;
+GRANT USAGE ON SCHEMA public TO compaction_user;
+SET ROLE compaction_user;
+SELECT array_length(
+           bm25_level_counts('compaction_step_idx'::regclass), 1) = 8
+       AS nonowner_can_inspect;
+SELECT bm25_needs_compaction('compaction_step_idx'::regclass)
+       AS nonowner_can_check;
+SELECT bm25_compact('compaction_step_idx'::regclass);
+SELECT bm25_compact_step('compaction_step_idx'::regclass);
+RESET ROLE;
+DROP OWNED BY compaction_user CASCADE;
+DROP ROLE compaction_user;
+
+-- Local temporary indexes remain mutable in read-only transactions.
+SET pg_textsearch.segments_per_level = 64;
+CREATE TEMP TABLE compaction_temp_step (id serial, body text);
+CREATE TEMP TABLE compaction_temp_full (id serial, body text);
+CREATE INDEX compaction_temp_step_idx ON compaction_temp_step
+    USING bm25(body) WITH (text_config = 'english');
+CREATE INDEX compaction_temp_full_idx ON compaction_temp_full
+    USING bm25(body) WITH (text_config = 'english');
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..2 LOOP
+        INSERT INTO compaction_temp_step (body)
+        VALUES (format('temporary step document %s filler', n));
+        INSERT INTO compaction_temp_full (body)
+        VALUES (format('temporary full document %s filler', n));
+        PERFORM bm25_spill_index('compaction_temp_step_idx');
+        PERFORM bm25_spill_index('compaction_temp_full_idx');
+    END LOOP;
+END
+$$;
+SET pg_textsearch.segments_per_level = 2;
+BEGIN READ ONLY;
+SELECT bm25_compact_step('compaction_temp_step_idx'::regclass)
+       AS temp_step_ran;
+SELECT bm25_compact('compaction_temp_full_idx'::regclass);
+COMMIT;
+SELECT NOT bm25_needs_compaction('compaction_temp_step_idx'::regclass)
+       AND NOT bm25_needs_compaction(
+           'compaction_temp_full_idx'::regclass)
+       AS temp_indexes_converged;
+
+-- A level can carry threshold debt the engine cannot reduce: every
+-- candidate group already exceeds max_segment_size, and an over-budget
+-- segment is an indivisible singleton.  bm25_needs_compaction() is a
+-- count-only signal, so it reports debt that bm25_compact_step()
+-- correctly declines to act on.  A scheduler that retried on a false
+-- return would spin here.
+CREATE TABLE compaction_unreducible (id bigint PRIMARY KEY, body text);
+CREATE INDEX compaction_unreducible_idx ON compaction_unreducible
+    USING bm25(body) WITH (text_config = 'simple');
+SET pg_textsearch.max_segment_size = '1MB';
+SET pg_textsearch.memtable_pages_threshold = 0;
+SET pg_textsearch.bulk_load_threshold = 0;
+SET pg_textsearch.segments_per_level = 2;
+DO $$
+DECLARE
+    batch integer;
+BEGIN
+    FOR batch IN 0..1 LOOP
+        INSERT INTO compaction_unreducible
+        SELECT batch * 2000 + gs,
+               'common ' || repeat(md5((batch * 2000 + gs)::text), 32)
+        FROM generate_series(1, 2000) gs;
+        PERFORM bm25_spill_index('compaction_unreducible_idx');
+    END LOOP;
+END
+$$;
+SELECT bm25_level_counts('compaction_unreducible_idx'::regclass) =
+           ARRAY[2, 0, 0, 0, 0, 0, 0, 0]
+       AS unreducible_level_is_at_threshold;
+SELECT bm25_needs_compaction('compaction_unreducible_idx'::regclass)
+       AS unreducible_reports_debt;
+SELECT bm25_compact_step('compaction_unreducible_idx'::regclass)
+       AS unreducible_step_declines;
+SELECT bm25_compact('compaction_unreducible_idx'::regclass);
+SELECT bm25_level_counts('compaction_unreducible_idx'::regclass) =
+           ARRAY[2, 0, 0, 0, 0, 0, 0, 0]
+       AS unreducible_full_is_a_noop;
+SELECT count(*) = 4000 AS unreducible_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_unreducible
+    ORDER BY body <@> to_bm25query('common', 'compaction_unreducible_idx')
+    LIMIT 5000
+) ranked;
+RESET pg_textsearch.max_segment_size;
+RESET pg_textsearch.memtable_pages_threshold;
+RESET pg_textsearch.bulk_load_threshold;
+DROP TABLE compaction_unreducible CASCADE;
+
+-- A full L7 blocks L6 promotion without mutating the index.
+CREATE TABLE compaction_terminal (id serial PRIMARY KEY, body text);
+CREATE INDEX compaction_terminal_idx ON compaction_terminal
+    USING bm25(body) WITH (text_config = 'english');
+SET pg_textsearch.debug_segment_count_limit = 2;
+DO $$
+DECLARE
+    counts int[];
+    n integer;
+BEGIN
+    FOR n IN 1..384 LOOP
+        PERFORM set_config(
+            'pg_textsearch.segments_per_level', '64', true);
+        INSERT INTO compaction_terminal (body)
+        VALUES (format('terminal segment document %s filler', n));
+        PERFORM bm25_spill_index('compaction_terminal_idx');
+        PERFORM set_config(
+            'pg_textsearch.segments_per_level', '2', true);
+
+        WHILE bm25_needs_compaction(
+                  'compaction_terminal_idx'::regclass) LOOP
+            counts :=
+                bm25_level_counts('compaction_terminal_idx'::regclass);
+            EXIT WHEN counts = ARRAY[0, 0, 0, 0, 0, 0, 2, 2];
+
+            IF NOT bm25_compact_step(
+                       'compaction_terminal_idx'::regclass) THEN
+                RAISE EXCEPTION
+                    'terminal setup stopped after source segment %', n;
+            END IF;
+        END LOOP;
+    END LOOP;
+END
+$$;
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           ARRAY[0, 0, 0, 0, 0, 0, 2, 2]
+       AND bm25_needs_compaction('compaction_terminal_idx'::regclass)
+       AS terminal_starts_blocked;
+CREATE TEMP TABLE compaction_terminal_before AS
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
+SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           before.counts
+       AS terminal_step_fails_closed
+FROM compaction_terminal_before before;
+SELECT bm25_compact('compaction_terminal_idx'::regclass);
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           before.counts
+       AS terminal_full_fails_closed
+FROM compaction_terminal_before before;
+
+-- Lower-level debt still compacts when a terminal conflict is present.
+-- The bounded planner validates each pass in full before publishing it,
+-- so every pass that runs is complete and durable; only the pass whose
+-- output cannot fit reports the capacity limit.
+SET pg_textsearch.segments_per_level = 64;
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..2 LOOP
+        INSERT INTO compaction_terminal (body)
+        VALUES (format('mixed lower segment document %s filler', n));
+        PERFORM bm25_spill_index('compaction_terminal_idx');
+    END LOOP;
+END
+$$;
+SET pg_textsearch.segments_per_level = 2;
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           ARRAY[2, 0, 0, 0, 0, 0, 2, 2]
+       AS mixed_terminal_starts_blocked;
+SELECT bm25_compact('compaction_terminal_idx'::regclass);
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           ARRAY[0, 1, 0, 0, 0, 0, 2, 2]
+       AS mixed_full_compacts_legal_debt;
+SELECT count(*) = 386 AS mixed_rejection_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_terminal
+    ORDER BY body <@> to_bm25query('filler', 'compaction_terminal_idx')
+) ranked;
+-- No legal pass remains, so a step reports the same conflict and
+-- leaves the layout untouched.
+CREATE TEMP TABLE compaction_mixed_after AS
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
+SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
+SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
+           after.counts
+       AS mixed_step_fails_closed
+FROM compaction_mixed_after after;
+SELECT count(*) = 386 AS terminal_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_terminal
+    ORDER BY body <@> to_bm25query('filler', 'compaction_terminal_idx')
+) ranked;
+
+RESET pg_textsearch.debug_segment_count_limit;
+RESET pg_textsearch.segments_per_level;
+DROP TABLE compaction_terminal CASCADE;
+DROP TABLE compaction_partitioned CASCADE;
+DROP TABLE compaction_full CASCADE;
+DROP TABLE compaction_step CASCADE;
+DROP EXTENSION pg_textsearch CASCADE;

--- a/test/sql/compaction.sql
+++ b/test/sql/compaction.sql
@@ -79,7 +79,9 @@ BEGIN READ ONLY;
 SELECT bm25_compact_step('compaction_step_idx'::regclass);
 ROLLBACK;
 
--- One step merges exactly one batch and reports that work was performed.
+-- In this layout one pass happens to merge exactly one batch.  A pass is
+-- not limited to one batch in general; it may span several, and may pull
+-- in further batches to unblock a destination level.
 SELECT bm25_compact_step('compaction_step_idx'::regclass)
        AS one_batch_ran;
 SELECT bm25_level_counts('compaction_step_idx'::regclass) =
@@ -187,6 +189,36 @@ SELECT NOT bm25_needs_compaction('compaction_temp_step_idx'::regclass)
            'compaction_temp_full_idx'::regclass)
        AS temp_indexes_converged;
 
+-- A published pass is a physical change, so ROLLBACK does not undo it.
+-- A caller must not treat a step as transactional work.
+CREATE TABLE compaction_rollback (id serial, body text);
+CREATE INDEX compaction_rollback_idx ON compaction_rollback
+    USING bm25(body) WITH (text_config = 'english');
+SET pg_textsearch.segments_per_level = 64;
+DO $$
+DECLARE
+    n integer;
+BEGIN
+    FOR n IN 1..4 LOOP
+        INSERT INTO compaction_rollback (body)
+        VALUES (format('rollback document %s filler', n));
+        PERFORM bm25_spill_index('compaction_rollback_idx');
+    END LOOP;
+END
+$$;
+SET pg_textsearch.segments_per_level = 2;
+CREATE TEMP TABLE compaction_rollback_before AS
+SELECT bm25_level_counts('compaction_rollback_idx'::regclass) AS counts;
+BEGIN;
+SELECT bm25_compact_step('compaction_rollback_idx'::regclass)
+       AS rollback_step_ran;
+ROLLBACK;
+SELECT bm25_level_counts('compaction_rollback_idx'::regclass)
+           <> before.counts
+       AS rollback_does_not_undo_a_published_pass
+FROM compaction_rollback_before before;
+DROP TABLE compaction_rollback CASCADE;
+
 -- A level can carry threshold debt the engine cannot reduce: every
 -- candidate group already exceeds max_segment_size, and an over-budget
 -- segment is an indivisible singleton.  bm25_needs_compaction() is a
@@ -236,7 +268,9 @@ RESET pg_textsearch.memtable_pages_threshold;
 RESET pg_textsearch.bulk_load_threshold;
 DROP TABLE compaction_unreducible CASCADE;
 
--- A full L7 blocks L6 promotion without mutating the index.
+-- A full L7 blocks L6 promotion without changing the segment layout.
+-- (Reclaim of already-parked pages may still run; only the published
+-- level counts are asserted here.)
 CREATE TABLE compaction_terminal (id serial PRIMARY KEY, body text);
 CREATE INDEX compaction_terminal_idx ON compaction_terminal
     USING bm25(body) WITH (text_config = 'english');

--- a/test/sql/compaction.sql
+++ b/test/sql/compaction.sql
@@ -219,10 +219,12 @@ SELECT bm25_level_counts('compaction_rollback_idx'::regclass)
 FROM compaction_rollback_before before;
 DROP TABLE compaction_rollback CASCADE;
 
--- A level can carry threshold debt the engine cannot reduce: every
--- candidate group already exceeds max_segment_size, and an over-budget
--- segment is an indivisible singleton.  bm25_needs_compaction() is a
--- count-only signal, so it reports debt that bm25_compact_step()
+-- A level can sit at the segment threshold with nothing to compact:
+-- every candidate group already exceeds max_segment_size, and an
+-- over-budget segment is an uncombinable singleton.  This is not
+-- compaction debt -- no pass would reduce it -- but
+-- bm25_needs_compaction() is a count-only signal and cannot tell the
+-- two apart, so it reports the full level that bm25_compact_step()
 -- correctly declines to act on.  A scheduler that retried on a false
 -- return would spin here.
 CREATE TABLE compaction_unreducible (id bigint PRIMARY KEY, body text);
@@ -249,7 +251,7 @@ SELECT bm25_level_counts('compaction_unreducible_idx'::regclass) =
            ARRAY[2, 0, 0, 0, 0, 0, 0, 0]
        AS unreducible_level_is_at_threshold;
 SELECT bm25_needs_compaction('compaction_unreducible_idx'::regclass)
-       AS unreducible_reports_debt;
+       AS unreducible_reports_full_level;
 SELECT bm25_compact_step('compaction_unreducible_idx'::regclass)
        AS unreducible_step_declines;
 SELECT bm25_compact('compaction_unreducible_idx'::regclass);
@@ -268,7 +270,65 @@ RESET pg_textsearch.memtable_pages_threshold;
 RESET pg_textsearch.bulk_load_threshold;
 DROP TABLE compaction_unreducible CASCADE;
 
--- The top level is a terminal bucket, not a wall.  When promotion out
+-- A pass must not copy segments it cannot combine.  Spills prepend, so
+-- a level reads newest-first and its oldest, largest runs sit at the
+-- tail.  Here two fresh small segments head a 2MB run that is already
+-- over max_segment_size: the pair merges, and the run is handed back
+-- instead of being rewritten to say the same thing in a new place.
+--
+-- The handback is visible as a level count: a retained segment keeps
+-- its level, while a rewritten one is promoted.  Without the trim this
+-- ends at [0, 2, ...] with the run copied to a fresh block, and the
+-- index grows by the full size of the run rather than by the pair.
+CREATE TABLE compaction_uncombinable_tail (id bigint PRIMARY KEY, body text);
+CREATE INDEX compaction_uncombinable_tail_idx ON compaction_uncombinable_tail
+    USING bm25(body) WITH (text_config = 'simple');
+SET pg_textsearch.memtable_pages_threshold = 0;
+SET pg_textsearch.bulk_load_threshold = 0;
+SET pg_textsearch.max_segment_size = '1MB';
+-- Build the layout with a fanout no spill can reach, so that the only
+-- compaction in this fixture is the one under test.
+SET pg_textsearch.segments_per_level = 64;
+INSERT INTO compaction_uncombinable_tail
+SELECT gs, 'common ' || repeat(md5(gs::text), 32)
+FROM generate_series(1, 2000) gs;
+SELECT bm25_spill_index('compaction_uncombinable_tail_idx') > 0
+       AS tail_run_spilled;
+INSERT INTO compaction_uncombinable_tail
+SELECT 100000 + gs, 'common small ' || gs FROM generate_series(1, 20) gs;
+SELECT bm25_spill_index('compaction_uncombinable_tail_idx') > 0
+       AS head_pair_first_spilled;
+INSERT INTO compaction_uncombinable_tail
+SELECT 200000 + gs, 'common small ' || gs FROM generate_series(1, 20) gs;
+SELECT bm25_spill_index('compaction_uncombinable_tail_idx') > 0
+       AS head_pair_second_spilled;
+SET pg_textsearch.segments_per_level = 3;
+SELECT bm25_level_counts('compaction_uncombinable_tail_idx'::regclass) =
+           ARRAY[3, 0, 0, 0, 0, 0, 0, 0]
+       AS tail_level_is_at_threshold;
+CREATE TEMP TABLE compaction_tail_before AS
+SELECT pg_relation_size('compaction_uncombinable_tail_idx') AS bytes;
+SELECT bm25_compact('compaction_uncombinable_tail_idx'::regclass);
+SELECT bm25_level_counts('compaction_uncombinable_tail_idx'::regclass) =
+           ARRAY[1, 1, 0, 0, 0, 0, 0, 0]
+       AS tail_run_retained_at_its_level;
+SELECT pg_relation_size('compaction_uncombinable_tail_idx') - before.bytes
+           < 1024 * 1024
+       AS tail_run_was_not_copied
+FROM compaction_tail_before before;
+SELECT count(*) = 2040 AS tail_preserves_documents
+FROM (
+    SELECT 1
+    FROM compaction_uncombinable_tail
+    ORDER BY body <@> to_bm25query(
+        'common', 'compaction_uncombinable_tail_idx')
+    LIMIT 5000
+) ranked;
+RESET pg_textsearch.max_segment_size;
+RESET pg_textsearch.memtable_pages_threshold;
+RESET pg_textsearch.bulk_load_threshold;
+DROP TABLE compaction_uncombinable_tail CASCADE;
+
 -- The top level is a terminal bucket, not a wall.  With a per-level
 -- count limit of 2, driving 384 segments up the ladder once failed
 -- closed with "segment count limit reached at level 7", because the

--- a/test/sql/compaction.sql
+++ b/test/sql/compaction.sql
@@ -268,16 +268,20 @@ RESET pg_textsearch.memtable_pages_threshold;
 RESET pg_textsearch.bulk_load_threshold;
 DROP TABLE compaction_unreducible CASCADE;
 
--- A full L7 blocks L6 promotion without changing the segment layout.
--- (Reclaim of already-parked pages may still run; only the published
--- level counts are asserted here.)
+-- The top level is a terminal bucket, not a wall.  When promotion out
+-- The top level is a terminal bucket, not a wall.  With a per-level
+-- count limit of 2, driving 384 segments up the ladder once failed
+-- closed with "segment count limit reached at level 7", because the
+-- top level was never a compaction candidate and so could never make
+-- room for a promotion out of L6.  It now compacts into itself, so
+-- the ladder drains instead of jamming.  (Reclaim of already-parked
+-- pages may also run; only the published level counts are asserted.)
 CREATE TABLE compaction_terminal (id serial PRIMARY KEY, body text);
 CREATE INDEX compaction_terminal_idx ON compaction_terminal
     USING bm25(body) WITH (text_config = 'english');
 SET pg_textsearch.debug_segment_count_limit = 2;
 DO $$
 DECLARE
-    counts int[];
     n integer;
 BEGIN
     FOR n IN 1..384 LOOP
@@ -289,42 +293,32 @@ BEGIN
         PERFORM set_config(
             'pg_textsearch.segments_per_level', '2', true);
 
+        -- The documented driver shape: stop on the step's own report
+        -- rather than on bm25_needs_compaction, which stays true on
+        -- debt no pass can reduce.
         WHILE bm25_needs_compaction(
                   'compaction_terminal_idx'::regclass) LOOP
-            counts :=
-                bm25_level_counts('compaction_terminal_idx'::regclass);
-            EXIT WHEN counts = ARRAY[0, 0, 0, 0, 0, 0, 2, 2];
-
-            IF NOT bm25_compact_step(
-                       'compaction_terminal_idx'::regclass) THEN
-                RAISE EXCEPTION
-                    'terminal setup stopped after source segment %', n;
-            END IF;
+            EXIT WHEN NOT bm25_compact_step(
+                              'compaction_terminal_idx'::regclass);
         END LOOP;
     END LOOP;
 END
 $$;
+SET pg_textsearch.segments_per_level = 2;
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           ARRAY[0, 0, 0, 0, 0, 0, 2, 2]
-       AND bm25_needs_compaction('compaction_terminal_idx'::regclass)
-       AS terminal_starts_blocked;
-CREATE TEMP TABLE compaction_terminal_before AS
-SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
+           ARRAY[0, 0, 0, 0, 0, 0, 0, 1]
+       AND NOT bm25_needs_compaction(
+                   'compaction_terminal_idx'::regclass)
+       AS top_level_drains;
+-- The ladder has settled: both entry points report no work rather
+-- than raising a capacity error.
 SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
-SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           before.counts
-       AS terminal_step_fails_closed
-FROM compaction_terminal_before before;
 SELECT bm25_compact('compaction_terminal_idx'::regclass);
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           before.counts
-       AS terminal_full_fails_closed
-FROM compaction_terminal_before before;
+           ARRAY[0, 0, 0, 0, 0, 0, 0, 1]
+       AS terminal_is_settled;
 
--- Lower-level debt still compacts when a terminal conflict is present.
--- The bounded planner validates each pass in full before publishing it,
--- so every pass that runs is complete and durable; only the pass whose
--- output cannot fit reports the capacity limit.
+-- Lower-level debt compacts normally against a populated top level.
 SET pg_textsearch.segments_per_level = 64;
 DO $$
 DECLARE
@@ -339,26 +333,25 @@ END
 $$;
 SET pg_textsearch.segments_per_level = 2;
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           ARRAY[2, 0, 0, 0, 0, 0, 2, 2]
-       AS mixed_terminal_starts_blocked;
+           ARRAY[2, 0, 0, 0, 0, 0, 0, 1]
+       AS mixed_lower_debt_starts;
 SELECT bm25_compact('compaction_terminal_idx'::regclass);
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
-           ARRAY[0, 1, 0, 0, 0, 0, 2, 2]
-       AS mixed_full_compacts_legal_debt;
-SELECT count(*) = 386 AS mixed_rejection_preserves_documents
+           ARRAY[0, 1, 0, 0, 0, 0, 0, 1]
+       AS mixed_full_compacts_lower_debt;
+SELECT count(*) = 386 AS mixed_compaction_preserves_documents
 FROM (
     SELECT 1
     FROM compaction_terminal
     ORDER BY body <@> to_bm25query('filler', 'compaction_terminal_idx')
 ) ranked;
--- No legal pass remains, so a step reports the same conflict and
--- leaves the layout untouched.
+-- With every level under threshold a step is a no-op, not an error.
 CREATE TEMP TABLE compaction_mixed_after AS
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) AS counts;
 SELECT bm25_compact_step('compaction_terminal_idx'::regclass);
 SELECT bm25_level_counts('compaction_terminal_idx'::regclass) =
            after.counts
-       AS mixed_step_fails_closed
+       AS mixed_step_is_a_noop
 FROM compaction_mixed_after after;
 SELECT count(*) = 386 AS terminal_preserves_documents
 FROM (

--- a/test/sql/force_merge.sql
+++ b/test/sql/force_merge.sql
@@ -209,6 +209,11 @@ DROP TABLE force_spill_cascade CASCADE;
 
 --------------------------------------------------------------------------------
 -- Force merge is bounded best-effort compaction, not forceMerge(1).
+--
+-- Four top-level layouts: a single L7 segment, a deeper cascade that
+-- still settles at one L7 segment because the top level compacts into
+-- itself, a mixed L0+L7 pair (the multi-segment case), and an L7
+-- segment with a pending memtable.
 --------------------------------------------------------------------------------
 
 SET pg_textsearch.segments_per_level = 2;
@@ -216,8 +221,8 @@ SET pg_textsearch.segments_per_level = 2;
 CREATE TABLE force_l7_single (id serial PRIMARY KEY, content text);
 CREATE INDEX force_l7_single_idx ON force_l7_single USING bm25(content)
   WITH (text_config='english');
-CREATE TABLE force_l7_multiple (id serial PRIMARY KEY, content text);
-CREATE INDEX force_l7_multiple_idx ON force_l7_multiple USING bm25(content)
+CREATE TABLE force_l7_deep (id serial PRIMARY KEY, content text);
+CREATE INDEX force_l7_deep_idx ON force_l7_deep USING bm25(content)
   WITH (text_config='english');
 CREATE TABLE force_l7_mixed (id serial PRIMARY KEY, content text);
 CREATE INDEX force_l7_mixed_idx ON force_l7_mixed USING bm25(content)
@@ -231,9 +236,9 @@ DECLARE
     n integer;
 BEGIN
     FOR n IN 1..256 LOOP
-        INSERT INTO force_l7_multiple (content)
+        INSERT INTO force_l7_deep (content)
         VALUES (format('multiple terminal %s filler', n));
-        PERFORM bm25_spill_index('force_l7_multiple_idx');
+        PERFORM bm25_spill_index('force_l7_deep_idx');
 
         IF n <= 128 THEN
             INSERT INTO force_l7_single (content)
@@ -257,7 +262,7 @@ $$;
 DO $$
 DECLARE
     single_summary text := bm25_summarize_index('force_l7_single_idx');
-    multiple_summary text := bm25_summarize_index('force_l7_multiple_idx');
+    deep_summary text := bm25_summarize_index('force_l7_deep_idx');
     mixed_summary text := bm25_summarize_index('force_l7_mixed_idx');
     memtable_summary text := bm25_summarize_index('force_l7_memtable_idx');
 BEGIN
@@ -266,10 +271,10 @@ BEGIN
         RAISE EXCEPTION 'single L7 layout was not constructed: %',
                         single_summary;
     END IF;
-    IF regexp_count(multiple_summary, 'L[0-7] Segment [0-9]+:') <> 2
-       OR multiple_summary !~ 'L7 Segment 2:' THEN
-        RAISE EXCEPTION 'multiple L7 layout was not constructed: %',
-                        multiple_summary;
+    IF regexp_count(deep_summary, 'L[0-7] Segment [0-9]+:') <> 1
+       OR deep_summary !~ 'L7 Segment 1:' THEN
+        RAISE EXCEPTION 'deep cascade did not settle at one L7 segment: %',
+                        deep_summary;
     END IF;
     IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') <> 2
        OR mixed_summary !~ 'L0 Segment 1:'
@@ -289,21 +294,21 @@ $$;
 DO $$
 DECLARE
     single_before text := bm25_summarize_index('force_l7_single_idx');
-    multiple_before text := bm25_summarize_index('force_l7_multiple_idx');
+    deep_before text := bm25_summarize_index('force_l7_deep_idx');
     mixed_before text := bm25_summarize_index('force_l7_mixed_idx');
     memtable_before text := bm25_summarize_index('force_l7_memtable_idx');
     single_summary text;
-    multiple_summary text;
+    deep_summary text;
     mixed_summary text;
     memtable_summary text;
 BEGIN
     PERFORM bm25_force_merge('force_l7_single_idx');
-    PERFORM bm25_force_merge('force_l7_multiple_idx');
+    PERFORM bm25_force_merge('force_l7_deep_idx');
     PERFORM bm25_force_merge('force_l7_mixed_idx');
     PERFORM bm25_force_merge('force_l7_memtable_idx');
 
     single_summary := bm25_summarize_index('force_l7_single_idx');
-    multiple_summary := bm25_summarize_index('force_l7_multiple_idx');
+    deep_summary := bm25_summarize_index('force_l7_deep_idx');
     mixed_summary := bm25_summarize_index('force_l7_mixed_idx');
     memtable_summary := bm25_summarize_index('force_l7_memtable_idx');
 
@@ -312,10 +317,10 @@ BEGIN
         RAISE EXCEPTION 'force merge increased segment count: before %, after %',
                         single_before, single_summary;
     END IF;
-    IF regexp_count(multiple_summary, 'L[0-7] Segment [0-9]+:') >
-       regexp_count(multiple_before, 'L[0-7] Segment [0-9]+:') THEN
+    IF regexp_count(deep_summary, 'L[0-7] Segment [0-9]+:') >
+       regexp_count(deep_before, 'L[0-7] Segment [0-9]+:') THEN
         RAISE EXCEPTION 'force merge increased segment count: before %, after %',
-                        multiple_before, multiple_summary;
+                        deep_before, deep_summary;
     END IF;
     IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') >
        regexp_count(mixed_before, 'L[0-7] Segment [0-9]+:') THEN
@@ -338,9 +343,9 @@ BEGIN
                      to_bm25query('filler', 'force_l7_single_idx')
         ) ranked) <> 128
        OR (SELECT count(*) FROM (
-               SELECT 1 FROM force_l7_multiple
+               SELECT 1 FROM force_l7_deep
                ORDER BY content <@>
-                        to_bm25query('filler', 'force_l7_multiple_idx')
+                        to_bm25query('filler', 'force_l7_deep_idx')
            ) ranked) <> 256
        OR (SELECT count(*) FROM (
                SELECT 1 FROM force_l7_mixed
@@ -405,7 +410,7 @@ END
 $$;
 
 DROP TABLE force_l7_single CASCADE;
-DROP TABLE force_l7_multiple CASCADE;
+DROP TABLE force_l7_deep CASCADE;
 DROP TABLE force_l7_mixed CASCADE;
 DROP TABLE force_l7_memtable CASCADE;
 

--- a/test/sql/force_merge.sql
+++ b/test/sql/force_merge.sql
@@ -322,10 +322,14 @@ BEGIN
         RAISE EXCEPTION 'force merge increased segment count: before %, after %',
                         deep_before, deep_summary;
     END IF;
-    IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') >
-       regexp_count(mixed_before, 'L[0-7] Segment [0-9]+:') THEN
-        RAISE EXCEPTION 'force merge increased segment count: before %, after %',
-                        mixed_before, mixed_summary;
+    -- The mixed fixture is the multi-segment case, so force merge must
+    -- actually combine its L0 and L7 segments.  Asserting only that the
+    -- count did not increase would also accept a no-op.
+    IF regexp_count(mixed_summary, 'L[0-7] Segment [0-9]+:') <> 1
+       OR mixed_summary !~ 'L0 Segment 1:' THEN
+        RAISE EXCEPTION
+            'force merge did not combine the mixed layout: before %, after %',
+            mixed_before, mixed_summary;
     END IF;
     IF regexp_count(memtable_summary, 'L[0-7] Segment [0-9]+:') >
        regexp_count(memtable_before, 'L[0-7] Segment [0-9]+:') THEN

--- a/test/sql/merge.sql
+++ b/test/sql/merge.sql
@@ -346,7 +346,7 @@ BEGIN
         PERFORM bm25_spill_index('merge_starve_idx');
     END LOOP;
     -- Each of these alone exceeds the budget, so L0 becomes an
-    -- indivisible run while staying below the level threshold.
+    -- uncombinable run while staying below the level threshold.
     FOR batch IN 8..11 LOOP
         INSERT INTO merge_starve
         SELECT batch * 2000 + gs,
@@ -373,7 +373,7 @@ DECLARE
 BEGIN
     IF regexp_count(summary, 'L1 Segment [0-9]+:') <> 0
        OR regexp_count(summary, 'L2 Segment [0-9]+:') = 0 THEN
-        RAISE EXCEPTION 'indivisible L0 starved a compactable L1: %',
+        RAISE EXCEPTION 'uncombinable L0 starved a compactable L1: %',
                         summary;
     END IF;
 END


### PR DESCRIPTION
## Summary

Expose scheduler-independent SQL controls for inspecting and compacting one
BM25 index. This layer makes compaction usable by administrators and future
scheduler adapters without introducing a dependency on pg_durable or any
other job runner.

## Why

The storage layer compacts automatically during a spill, but background
workers and operators need a stable way to inspect the segment layout and
work off outstanding compaction in bounded transactions. Those entry points must preserve the same
capacity, locking, ownership, recovery, and relation-lifecycle guarantees as
inline compaction.

## APIs

- `bm25_level_counts(regclass)` returns the persisted segment count for each
  of the eight LSM levels.
- `bm25_needs_compaction(regclass)` reports whether any level holds at least
  `segments_per_level` segments.
- `bm25_compact(regclass)` runs compaction passes to completion under one
  per-index exclusive lock.
- `bm25_compact_step(regclass)` runs at most one pass and reports whether one
  ran, allowing callers to split a cascade across transactions.

## One pass, one publication

Both mutating functions drive the size-bounded engine from #474 through a new
`tp_compact_step`, so the stepped and full paths cannot diverge in capacity
checking or level selection.

A pass is the engine's unit of work and of publication. The planner picks the
lowest triggered level, groups its segments into batches that fit
`max_segment_size`, and recursively plans whatever additional compaction is
needed to make room at the destination levels. The whole plan is validated
against the per-level segment capacity before any output is merged, and every
output a pass produces becomes visible in one metapage update, so a pass that
fails leaves the segment layout it started from. That is what makes stopping
between passes safe, and it is why `bm25_compact()` and repeated
`bm25_compact_step()` calls converge on the same layout.

The guarantee covers the visible layout, not every physical page: a pass
drains the deferred-free tombstone chain before planning and merges its
outputs before publishing, so a failed pass can leave pages reclaimed and
unpublished output pages allocated but unreachable. `VACUUM` does not recover
those — it reclaims dead memtable pages and past-horizon tombstones, not pages
a failed pass never linked — so `REINDEX` is the remedy. A published pass is a
physical change and is **not undone by `ROLLBACK`**.

A pass is not a bounded amount of work, and neither function is cancellable
while one runs: holding an `LWLock` also holds off interrupts.

## Not rewriting what cannot be combined

Batching is greedy over a head prefix of the level, and a batch that ends up
holding a single segment combines nothing: merging it rewrites the whole
segment to produce a segment of the same size. Spills prepend, so a level
reads newest-first and its oldest, largest runs — the ones already past
`max_segment_size` — sit at the tail. One pairable pair at the head of a level
therefore authorized rewriting every over-budget segment behind it.

A pass now hands the trailing run of single-segment batches back to the level
before planning further, and leaves those segments where they are, at the
level they were already on. That is cheap precisely because the selection is a
head prefix: the chain behind it is untouched, so returning segments is just
moving the level's head pointer back, and nothing on disk changes.
Copy-on-write is preserved — no segment header is patched, which is what makes
a failed pass leave the old layout intact, and those writes would not fit
alongside the metapage update that publishes the pass in any case.

Two limits are deliberate. A single-segment batch in the *middle* of a prefix
is still rewritten, because excising one would mean repointing its
predecessor. And the trim applies only to the level a pass chose to compact:
in the capacity recourse a pass compacts a level to make room for its own
output, and there promoting a single-segment batch is what makes that room, so
handing those back would leave the level exactly as full and turn a wasteful
pass into a failed one.

On a level holding a 2MB over-budget run behind two small segments, a pass
previously copied the run to a fresh block and grew the index by 2.2MB; it now
merges only the pair and grows it by 32KB.

## The top level is not a wall

Previously the engine treated L7 as terminal: it was never a compaction
candidate, so a pass that wanted to promote a run out of a full L6 into a full
L7 had no way to make room and planning failed with `bm25 segment count limit
reached at level 7`. Because nothing could ever reduce L7, that error was a
one-way ratchet — an index that reached it could not compact again.

This PR makes the top level an ordinary level. A run that would promote past
it stays there and the level compacts into itself under the same size budget,
so its count is always reducible and it needs no special ceiling. The capacity
check now applies one rule everywhere: a level is over capacity only when it
also holds too few segments to compact. `bm25_needs_compaction()` counts every
level to match.

A level is a hybrid rank, not a pure size class: a pass places its output at
whichever is higher, the output's size class or one level above its sources.
The forced promotion is what drains a level to zero instead of rewriting the
same segments in place, so it stays.

A level's ceiling is `8MB * segments_per_level^level`: `tp_size_class()`
scales by the session's `pg_textsearch.segments_per_level`, which ranges from
2 to 64, so the ladder's shape is not fixed. At the default
fanout of 8 the L3 ceiling is 4096MB and `max_segment_size` caps a combined
segment at 4095MB, so under default settings no merge emits a segment above
size class 3 and L4 through L7 are reached only by promotion — but that is a
property of the default, not of the design. At fanout 2 the L6 ceiling is
512MB and a 4095MB output lands at L7 on size alone. `max_segment_size` also
bounds only segments a pass *combines*; a larger existing segment stays a
valid uncombinable singleton, so a segment at any level may exceed it.
"Uncombinable" is the property that it cannot be combined any further, not
that it cannot be split.

## Safety and behavior

- Both mutating APIs require ownership of the physical BM25 index, and
  recheck it after opening the relation because `ALTER OWNER` can complete
  while a caller waits for the lock.
- Partitioned parent indexes are rejected because they have no physical index
  storage; callers operate on each partition's index instead.
- Permanent and unlogged indexes cannot be compacted in read-only
  transactions, and no index can be compacted during recovery.
- A backend may compact its own temporary index in a read-only transaction.
- `bm25_needs_compaction()` is derived from level counts alone and is
  therefore advisory: it answers "is any level at its segment threshold", not
  "is there work to do". A level whose every candidate group already exceeds
  `max_segment_size` is not carrying compaction debt — no pass would reduce
  it — but a count-only signal cannot tell the two apart, so it reports true
  while `bm25_compact_step()` returns false. It does **not** go false on such
  an index, so it must not be used on its own as a loop or retry condition;
  drive the loop from `bm25_compact_step()`'s return value instead.
- `bm25_level_counts()` is `PARALLEL RESTRICTED` because it opens the index
  relation, which may be a local temporary index. `bm25_needs_compaction()`
  is `VOLATILE` and `STRICT` because it reads live metapage state.
- Fresh-install and upgrade SQL expose the same functions and privileges.

## Test coverage

Regression coverage exercises threshold detection, full and stepped cascades and
their convergence, ownership checks, partitioned and temporary relations,
read-only and recovery restrictions, and top-level behavior. New coverage
pins the advisory pairing — full level reported, pass declined, full
compaction a terminating no-op — and that `ROLLBACK` does not undo a published pass. Those
tests record the contract; they do not prevent a caller from misusing it, so a
scheduler that loops on `bm25_needs_compaction()` alone will still spin. A
source guard preserves the ownership check ordering around `relation_open`.
Both new shell tests run in the blocking CI shell-test step.

`compaction_terminal` now asserts a deep cascade drains to a single top-level
segment and settles, and that lower-level debt beside an occupied top level
still compacts with every document preserved. It was verified to fail without
the engine change.

`force_merge.sql`'s `force_l7_multiple` fixture built two top-level segments
only because the top level never compacted. It is renamed `force_l7_deep` and
retargeted at the property that now holds: a deeper cascade still settles at
one top-level segment. Multi-segment force merge stays covered by
`force_l7_mixed`, whose post-merge assertion is tightened from "the segment
count did not increase" — which a no-op would satisfy — to the exact combined
layout.

`compaction_uncombinable_tail` builds a level holding a 2MB over-budget run
behind two small segments and asserts that compacting it merges only the pair:
the run keeps its level rather than being promoted, and the index grows by far
less than the run's size. It was verified to fail on both assertions without
the engine change.

## Stack position

This is the second independently reviewable layer of GitHub stack #479. It
builds on the size-bounded engine in #474; later layers add transaction
dispatch and optional scheduler integration.

