### PR TITLE
Add pg_durable compaction adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ REGRESS = abort aerodocs basic binary_io bmw bmw_skip_advance bulk_load cache_ap
 REGRESS_OPTS = --inputdir=test --outputdir=test
 
 PG_CONFIG ?= pg_config
-PGXS := $(shell $(PG_CONFIG) --pgxs)
+PG_CONFIG_PATH := $(realpath $(shell command -v $(PG_CONFIG) 2>/dev/null))
+PGXS := $(shell $(PG_CONFIG_PATH) --pgxs)
 include $(PGXS)
 
 # SQL regression tests
@@ -158,6 +159,25 @@ test-segment:
 test-stress:
 	@echo "Running stress tests..."
 	@cd test/scripts && ./stress.sh
+
+# Background compaction via pg_durable. This is separate from test-all
+# because the normal CI image does not install pg_durable.
+test-durable:
+	@echo "Running pg_durable background compaction tests..."
+	@expected="$$($(PG_CONFIG_PATH) --bindir)|$$($(PG_CONFIG_PATH) --pkglibdir)"; \
+		actual="$$(cd test/scripts && \
+			PATH="$$PWD/fixtures:$$PATH" \
+			PG_CONFIG="$(PG_CONFIG_PATH)" \
+			DURABLE_PG_CONFIG_PROBE=1 ./durable_compaction.sh)"; \
+		test "$$actual" = "$$expected" || { \
+			echo "PG_CONFIG propagation failed: expected '$$expected', got '$$actual'"; \
+			exit 1; \
+		}
+	@cd test/scripts && \
+		PG_CONFIG="$(PG_CONFIG_PATH)" ./durable_compaction.sh
+
+test-durable-static:
+	@cd test/scripts && DURABLE_STATIC_ONLY=1 ./durable_compaction.sh
 
 test-cic:
 	@echo "Running CREATE INDEX CONCURRENTLY tests..."
@@ -367,6 +387,8 @@ help:
 	@echo "  make test-recovery    - Run crash recovery tests"
 	@echo "  make test-segment     - Run multi-backend segment tests"
 	@echo "  make test-stress      - Run long-running stress tests"
+	@echo "  make test-durable     - Run pg_durable compaction tests"
+	@echo "  make test-durable-static - Check the pg_durable adapter shape"
 	@echo "  make test-cic         - Run CREATE INDEX CONCURRENTLY tests"
 	@echo "  make test-chinese     - Run Chinese tokenization test (needs zhparser)"
 	@echo "  make test-reindex     - Run multi-backend reindex regression tests (issue #390)"
@@ -393,4 +415,4 @@ help:
 	@echo "  make test-all"
 	@echo "  make format"
 
-.PHONY: test test-compaction-ownercheck test-compaction-request-source clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help
+.PHONY: test test-compaction-ownercheck test-compaction-request-source clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-durable test-durable-static test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,10 @@ test-compaction-request-source:
 
 # These guards cover invariants the SQL suite cannot observe, so they must
 # gate every way the suite is run, not just `make test`.
-installcheck: test-compaction-ownercheck test-compaction-request-source
-test-local: test-compaction-ownercheck test-compaction-request-source
+installcheck: test-compaction-ownercheck test-compaction-request-source \
+	test-durable-static
+test-local: test-compaction-ownercheck test-compaction-request-source \
+	test-durable-static
 
 # Custom local test target with dedicated PostgreSQL instance
 test-local: install

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -247,18 +247,20 @@ The adapter's loop is equivalent to:
 df.start(
     df.loop(
         '<schema>.bm25_compact_step_if_current(...)',
-        '<schema>.bm25_needs_compaction_if_current(...)',
-        on_error => 'continue'),
+        '<schema>.bm25_needs_compaction_if_current(...)'),
     label => 'bm25-compact-<index-oid>',
-    transaction_mode => 'new')
+    transaction_mode => 'new',
+    max_attempts => 5,
+    max_backoff => '16 seconds',
+    on_failure => 'continue')
 ```
 
 Each body and condition execution runs in its own worker transaction, so the
 per-index `LW_EXCLUSIVE` lock is released between merge batches.
 `transaction_mode => 'new'` also persists submission independently of the
-writer transaction. The loop's `on_error => 'continue'` policy returns
-ordinary step failures to the physical-state condition rather than
-immediately stranding the request.
+writer transaction. The instance policy from microsoft/pg_durable#354 retries
+failed nodes, then `on_failure => 'continue'` returns an exhausted failure to
+the next physical-state loop iteration rather than stranding the request.
 
 The wrapper is `SECURITY DEFINER`, owned by the passwordless
 `textsearch_compactor` login role, and fixes `search_path` to
@@ -274,12 +276,17 @@ properties, and ACL grant options before granting or replacing anything. A
 committed `SELECT 1` canary additionally proves the worker can connect and
 execute as the compactor.
 
-The adapter currently requires the unreleased three-argument
-`df.loop(text, text, text)` capability. Its exact catalog check is localized
-at the start of each operator script so the first released version can be
-recorded without changing adapter behavior. See
+**Merge is blocked on a pg_durable release containing
+[microsoft/pg_durable#354](https://github.com/microsoft/pg_durable/pull/354).**
+That draft targets 0.2.7; released v0.2.6 and current `main` do not provide
+failure-resilient recurrence. The adapter keeps the existing two-argument
+`df.loop` and applies `max_attempts`, `max_backoff`, and `on_failure` through
+the exact seven-argument `df.start` signature introduced by #354. Its catalog
+check is localized at the start of each operator script so the released
+version floor can be recorded without changing adapter behavior. See
 `scripts/durable_compaction/README.md` for installation, authentication, and
 validation instructions.
 
 This slice intentionally has no recurring schedule, cross-index sweep, or
-extension packaging.
+extension packaging. The later recurring-registration PR must apply #354's
+failure policy through `df.start`, not through a new `df.loop` signature.

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -278,14 +278,14 @@ execute as the compactor.
 
 **Merge is blocked on a pg_durable release containing
 [microsoft/pg_durable#354](https://github.com/microsoft/pg_durable/pull/354).**
-That draft targets 0.2.7; released v0.2.6 and current `main` do not provide
-failure-resilient recurrence. The adapter keeps the existing two-argument
-`df.loop` and applies `max_attempts`, `max_backoff`, and `on_failure` through
-the exact seven-argument `df.start` signature introduced by #354. Its catalog
-check is localized at the start of each operator script so the released
-version floor can be recorded without changing adapter behavior. See
-`scripts/durable_compaction/README.md` for installation, authentication, and
-validation instructions.
+v0.2.7 shipped without it and #354 is still an open draft, so no released
+pg_durable provides failure-resilient recurrence. The adapter keeps the
+existing two-argument `df.loop` and applies `max_attempts`, `max_backoff`,
+and `on_failure` through the seven-argument `df.start` signature that #354
+adds. Its catalog check is localized at the start of each operator script so
+the released version floor can be recorded without changing adapter behavior.
+See `scripts/durable_compaction/README.md` for installation, authentication,
+and validation instructions.
 
 This slice intentionally has no recurring schedule, cross-index sweep, or
 extension packaging. The later recurring-registration PR must apply #354's

--- a/docs/background_compaction.md
+++ b/docs/background_compaction.md
@@ -213,3 +213,73 @@ rollback. Ordinary lookup or callback errors produce a warning and do not
 abort the writer. Cancellation and shutdown errors are rethrown, so a callback
 that cancels the backend fails the commit it was invoked from.
 This interface is scheduler-neutral and has no pg_durable dependency.
+
+## pg_durable per-index adapter
+
+The optional adapter in `scripts/durable_compaction/` converts one physical
+BM25 index request into a durable stepped loop. It remains operator-managed:
+`CREATE EXTENSION pg_textsearch` does not install pg_durable, create a cluster
+role, change authentication, or expose the request wrapper.
+
+The wrapper records four identifiers:
+
+- the index relation OID;
+- the current database OID;
+- the effective tablespace OID; and
+- the relation's relfilenumber.
+
+The worker passes those values to the private
+`bm25_compact_step_if_current(oid, oid, oid, oid)` and
+`bm25_needs_compaction_if_current(oid, oid, oid, oid)` entry points. They open
+and lock the relation, validate the complete physical identity, reject local
+or foreign temporary relations, confirm the BM25 access method, and enforce
+index ownership. A stale target returns `false`; a live target error remains
+an error.
+
+Both helpers are extension members so schema relocation remains safe, but
+their install and upgrade SQL revokes every non-owner ACL copied from named
+default privileges. `PUBLIC` has no access. `01_setup_role.sql` grants them
+only to the dedicated compactor after validating the role.
+
+The adapter's loop is equivalent to:
+
+```sql
+df.start(
+    df.loop(
+        '<schema>.bm25_compact_step_if_current(...)',
+        '<schema>.bm25_needs_compaction_if_current(...)',
+        on_error => 'continue'),
+    label => 'bm25-compact-<index-oid>',
+    transaction_mode => 'new')
+```
+
+Each body and condition execution runs in its own worker transaction, so the
+per-index `LW_EXCLUSIVE` lock is released between merge batches.
+`transaction_mode => 'new'` also persists submission independently of the
+writer transaction. The loop's `on_error => 'continue'` policy returns
+ordinary step failures to the physical-state condition rather than
+immediately stranding the request.
+
+The wrapper is `SECURITY DEFINER`, owned by the passwordless
+`textsearch_compactor` login role, and fixes `search_path` to
+`pg_catalog, pg_temp`. It accepts only a BM25 index, rejects temporary
+indexes, and authorizes the caller's login identity by `INSERT` privilege on
+the indexed table or a partition ancestor. Its generated SQL contains only
+the extension schema, fixed helper names, and numeric OIDs.
+
+Role and wrapper reuse fail closed. The setup scripts authenticate the exact
+role attributes, membership direction and options, unsafe role settings,
+cluster-wide ownership dependencies, wrapper body hash and security
+properties, and ACL grant options before granting or replacing anything. A
+committed `SELECT 1` canary additionally proves the worker can connect and
+execute as the compactor.
+
+The adapter currently requires the unreleased three-argument
+`df.loop(text, text, text)` capability. Its exact catalog check is localized
+at the start of each operator script so the first released version can be
+recorded without changing adapter behavior. See
+`scripts/durable_compaction/README.md` for installation, authentication, and
+validation instructions.
+
+This slice intentionally has no recurring schedule, cross-index sweep, or
+extension packaging.

--- a/scripts/durable_compaction/01_setup_role.sql
+++ b/scripts/durable_compaction/01_setup_role.sql
@@ -70,6 +70,23 @@ BEGIN
               AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
         WHERE procedure.oid OPERATOR(pg_catalog.=)
                   pg_catalog.to_regprocedure(
+                      'df.loop(pg_catalog.text,pg_catalog.text)')
+          AND procedure.prorettype OPERATOR(pg_catalog.=)
+                  'pg_catalog.text'::pg_catalog.regtype
+          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 1)
+       OR NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc procedure
+             JOIN pg_catalog.pg_depend dependency
+               ON dependency.classid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.objid OPERATOR(pg_catalog.=) procedure.oid
+              AND dependency.refclassid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_extension'::pg_catalog.regclass
+              AND dependency.refobjid OPERATOR(pg_catalog.=) durable_oid
+              AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
+        WHERE procedure.oid OPERATOR(pg_catalog.=)
+                  pg_catalog.to_regprocedure(
                       'df.start(pg_catalog.text,pg_catalog.text,'
                       'pg_catalog.text,pg_catalog.text,pg_catalog.int4,'
                       'pg_catalog.interval,pg_catalog.text)')
@@ -87,8 +104,8 @@ BEGIN
                       'on_failure']::pg_catalog.text[])
     THEN
         RAISE EXCEPTION
-            'pg_durable API is incomplete: df.grant_usage() and '
-            'df.start() with the node failure policy are required'
+            'pg_durable API is incomplete: df.grant_usage(), df.loop(), '
+            'and df.start() with the node failure policy are required'
             USING HINT =
                 'Install the release containing microsoft/pg_durable#354, '
                 'then rerun this script.';
@@ -159,6 +176,123 @@ BEGIN
 END
 $$;
 \endif
+
+-- TP_MANAGED_WRAPPER_PRECHECK
+-- Validate the managed-name wrapper independently of its current owner.
+-- The same block then uses cluster-wide pg_shdepend to reject every other
+-- object already owned by the compactor.
+DO $$
+DECLARE
+    compactor_oid pg_catalog.oid;
+    database_oid  pg_catalog.oid;
+    wrapper_oid   pg_catalog.oid;
+BEGIN
+    SELECT oid
+    INTO compactor_oid
+    FROM pg_catalog.pg_roles
+    WHERE rolname OPERATOR(pg_catalog.=) 'textsearch_compactor';
+
+    wrapper_oid := pg_catalog.to_regprocedure(
+        'public.bm25_request_compaction(pg_catalog.regclass)');
+
+    IF wrapper_oid IS NOT NULL
+       AND (
+           compactor_oid IS NULL
+           OR NOT EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_proc procedure
+                JOIN pg_catalog.pg_namespace namespace
+                  ON namespace.oid OPERATOR(pg_catalog.=)
+                         procedure.pronamespace
+                JOIN pg_catalog.pg_language language
+                  ON language.oid OPERATOR(pg_catalog.=) procedure.prolang
+           WHERE procedure.oid OPERATOR(pg_catalog.=) wrapper_oid
+             AND namespace.nspname OPERATOR(pg_catalog.=) 'public'
+             AND procedure.proname OPERATOR(pg_catalog.=)
+                     'bm25_request_compaction'
+             AND procedure.proowner OPERATOR(pg_catalog.=) compactor_oid
+             AND procedure.prokind OPERATOR(pg_catalog.=) 'f'
+             AND procedure.pronargs OPERATOR(pg_catalog.=) 1
+             AND procedure.proargtypes[0] OPERATOR(pg_catalog.=)
+                     'pg_catalog.regclass'::pg_catalog.regtype
+             AND procedure.provariadic OPERATOR(pg_catalog.=) 0
+             AND procedure.prorettype OPERATOR(pg_catalog.=)
+                     'pg_catalog.text'::pg_catalog.regtype
+             AND NOT procedure.proretset
+             AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 0
+             AND procedure.proallargtypes IS NULL
+             AND procedure.proargmodes IS NULL
+             AND procedure.proargnames OPERATOR(pg_catalog.=)
+                     ARRAY['idx']::pg_catalog.text[]
+             AND language.lanname OPERATOR(pg_catalog.=) 'plpgsql'
+             AND procedure.prosecdef
+             AND NOT procedure.proleakproof
+             AND NOT procedure.proisstrict
+             AND procedure.provolatile OPERATOR(pg_catalog.=) 'v'
+             AND procedure.proparallel OPERATOR(pg_catalog.=) 'u'
+             AND procedure.prosupport OPERATOR(pg_catalog.=) 0
+             AND procedure.proconfig OPERATOR(pg_catalog.=)
+                     ARRAY['search_path=pg_catalog, pg_temp']
+                         ::pg_catalog.text[]
+             AND pg_catalog.md5(procedure.prosrc)
+                     OPERATOR(pg_catalog.=)
+                     '39b927569e6b4a2d24e1999627993a6d'
+             AND NOT EXISTS (
+                 SELECT 1
+                 FROM pg_catalog.aclexplode(
+                     coalesce(
+                         procedure.proacl,
+                         pg_catalog.acldefault(
+                             'f', procedure.proowner))) acl
+                 WHERE (
+                     acl.grantee OPERATOR(pg_catalog.=) 0
+                     AND acl.privilege_type
+                             OPERATOR(pg_catalog.=) 'EXECUTE')
+                    OR (
+                     acl.grantee OPERATOR(pg_catalog.<>)
+                             procedure.proowner
+                     AND acl.is_grantable))))
+    THEN
+        RAISE EXCEPTION
+            'existing bm25_request_compaction wrapper is not the managed '
+            'definition'
+            USING HINT =
+                'Inspect and remove the hostile, drifted, or foreign-owned '
+                'wrapper manually.';
+    END IF;
+
+    IF compactor_oid IS NULL THEN
+        RETURN;
+    END IF;
+
+    SELECT oid
+    INTO database_oid
+    FROM pg_catalog.pg_database
+    WHERE datname OPERATOR(pg_catalog.=) pg_catalog.current_database();
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_shdepend dependency
+        WHERE dependency.refclassid OPERATOR(pg_catalog.=)
+                  'pg_catalog.pg_authid'::pg_catalog.regclass
+          AND dependency.refobjid OPERATOR(pg_catalog.=) compactor_oid
+          AND dependency.deptype OPERATOR(pg_catalog.=) 'o'
+          AND NOT (
+              wrapper_oid IS NOT NULL
+              AND dependency.dbid OPERATOR(pg_catalog.=) database_oid
+              AND dependency.classid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.objid OPERATOR(pg_catalog.=) wrapper_oid
+              AND dependency.objsubid OPERATOR(pg_catalog.=) 0))
+    THEN
+        RAISE EXCEPTION
+            'existing textsearch_compactor role owns unexpected objects'
+            USING HINT =
+                'Drop or reassign every object except the exact managed '
+                'public.bm25_request_compaction(regclass) wrapper.';
+    END IF;
+END
+$$;
 
 -- Validate every security-relevant property before changing memberships or
 -- granting access. Existing hostile state is never normalized implicitly.
@@ -234,113 +368,6 @@ BEGIN
     THEN
         RAISE EXCEPTION
             'existing textsearch_compactor role has unexpected memberships';
-    END IF;
-END
-$$;
-
--- pg_shdepend is cluster-wide. The exact managed wrapper in this database is
--- the only object the role may own on a clean rerun.
-DO $$
-DECLARE
-    compactor_oid pg_catalog.oid;
-    database_oid  pg_catalog.oid;
-    wrapper_oid   pg_catalog.oid;
-BEGIN
-    SELECT oid
-    INTO compactor_oid
-    FROM pg_catalog.pg_roles
-    WHERE rolname OPERATOR(pg_catalog.=) 'textsearch_compactor';
-
-    IF compactor_oid IS NULL THEN
-        RETURN;
-    END IF;
-
-    SELECT oid
-    INTO database_oid
-    FROM pg_catalog.pg_database
-    WHERE datname OPERATOR(pg_catalog.=) pg_catalog.current_database();
-
-    wrapper_oid := pg_catalog.to_regprocedure(
-        'public.bm25_request_compaction(pg_catalog.regclass)');
-
-    IF EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_shdepend dependency
-        WHERE dependency.refclassid OPERATOR(pg_catalog.=)
-                  'pg_catalog.pg_authid'::pg_catalog.regclass
-          AND dependency.refobjid OPERATOR(pg_catalog.=) compactor_oid
-          AND dependency.deptype OPERATOR(pg_catalog.=) 'o'
-          AND NOT (
-              wrapper_oid IS NOT NULL
-              AND dependency.dbid OPERATOR(pg_catalog.=) database_oid
-              AND dependency.classid OPERATOR(pg_catalog.=)
-                      'pg_catalog.pg_proc'::pg_catalog.regclass
-              AND dependency.objid OPERATOR(pg_catalog.=) wrapper_oid
-              AND dependency.objsubid OPERATOR(pg_catalog.=) 0
-              AND EXISTS (
-                  SELECT 1
-                  FROM pg_catalog.pg_proc procedure
-                       JOIN pg_catalog.pg_namespace namespace
-                         ON namespace.oid OPERATOR(pg_catalog.=)
-                                procedure.pronamespace
-                       JOIN pg_catalog.pg_language language
-                         ON language.oid OPERATOR(pg_catalog.=)
-                                procedure.prolang
-                  WHERE procedure.oid OPERATOR(pg_catalog.=) wrapper_oid
-                    AND namespace.nspname OPERATOR(pg_catalog.=) 'public'
-                    AND procedure.proname OPERATOR(pg_catalog.=)
-                            'bm25_request_compaction'
-                    AND procedure.proowner OPERATOR(pg_catalog.=)
-                            compactor_oid
-                    AND procedure.prokind OPERATOR(pg_catalog.=) 'f'
-                    AND procedure.pronargs OPERATOR(pg_catalog.=) 1
-                    AND procedure.proargtypes[0]
-                            OPERATOR(pg_catalog.=)
-                            'pg_catalog.regclass'::pg_catalog.regtype
-                    AND procedure.provariadic OPERATOR(pg_catalog.=) 0
-                    AND procedure.prorettype OPERATOR(pg_catalog.=)
-                            'pg_catalog.text'::pg_catalog.regtype
-                    AND NOT procedure.proretset
-                    AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 0
-                    AND procedure.proallargtypes IS NULL
-                    AND procedure.proargmodes IS NULL
-                    AND procedure.proargnames OPERATOR(pg_catalog.=)
-                            ARRAY['idx']::pg_catalog.text[]
-                    AND language.lanname OPERATOR(pg_catalog.=) 'plpgsql'
-                    AND procedure.prosecdef
-                    AND NOT procedure.proleakproof
-                    AND NOT procedure.proisstrict
-                    AND procedure.provolatile OPERATOR(pg_catalog.=) 'v'
-                    AND procedure.proparallel OPERATOR(pg_catalog.=) 'u'
-                    AND procedure.prosupport OPERATOR(pg_catalog.=) 0
-                    AND procedure.proconfig OPERATOR(pg_catalog.=)
-                            ARRAY['search_path=pg_catalog, pg_temp']
-                                ::pg_catalog.text[]
-                    AND pg_catalog.md5(procedure.prosrc)
-                            OPERATOR(pg_catalog.=)
-                            '39b927569e6b4a2d24e1999627993a6d'
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM pg_catalog.aclexplode(
-                            coalesce(
-                                procedure.proacl,
-                                pg_catalog.acldefault(
-                                    'f', procedure.proowner))) acl
-                        WHERE (
-                            acl.grantee OPERATOR(pg_catalog.=) 0
-                            AND acl.privilege_type
-                                    OPERATOR(pg_catalog.=) 'EXECUTE')
-                           OR (
-                            acl.grantee OPERATOR(pg_catalog.<>)
-                                    procedure.proowner
-                            AND acl.is_grantable)))
-          ))
-    THEN
-        RAISE EXCEPTION
-            'existing textsearch_compactor role owns unexpected objects'
-            USING HINT =
-                'Drop or reassign every object except the exact managed '
-                'public.bm25_request_compaction(regclass) wrapper.';
     END IF;
 END
 $$;

--- a/scripts/durable_compaction/01_setup_role.sql
+++ b/scripts/durable_compaction/01_setup_role.sql
@@ -308,7 +308,7 @@ BEGIN
                                 ::pg_catalog.text[]
                     AND pg_catalog.md5(procedure.prosrc)
                             OPERATOR(pg_catalog.=)
-                            'c2980482b2b93b9e53511146f1fa8b47'
+                            '9546a8ef400bdc5eeb9dbed13aad6bdc'
                     AND NOT EXISTS (
                         SELECT 1
                         FROM pg_catalog.aclexplode(

--- a/scripts/durable_compaction/01_setup_role.sql
+++ b/scripts/durable_compaction/01_setup_role.sql
@@ -1,0 +1,431 @@
+-- Create or validate the dedicated pg_durable compactor role.
+--
+-- Run as a superuser in pg_durable.database:
+--
+--   psql -f 01_setup_role.sql -v index_owner=app_owner
+--
+-- Cluster authentication remains an operator responsibility. The role is
+-- deliberately passwordless and must connect through a scoped peer/ident
+-- rule or an equivalent passwordless authenticated route.
+
+\set ON_ERROR_STOP on
+
+\if :{?index_owner}
+\else
+\set index_owner ''
+\endif
+
+BEGIN;
+
+SET LOCAL search_path = pg_catalog, pg_temp;
+
+-- Keep the unreleased loop-policy dependency in this one preflight block.
+-- Replace the capability-only error with a version floor once a release
+-- contains df.loop(text, text, text).
+DO $$
+DECLARE
+    durable_oid pg_catalog.oid;
+BEGIN
+    SELECT extension.oid
+    INTO durable_oid
+    FROM pg_catalog.pg_extension extension
+    WHERE extension.extname OPERATOR(pg_catalog.=) 'pg_durable';
+
+    IF durable_oid IS NULL THEN
+        RAISE EXCEPTION
+            'pg_durable with df.loop(..., on_error) is required'
+            USING HINT =
+                'Install the released pg_durable loop-policy build, then '
+                'rerun this script.';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc procedure
+             JOIN pg_catalog.pg_depend dependency
+               ON dependency.classid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.objid OPERATOR(pg_catalog.=) procedure.oid
+              AND dependency.refclassid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_extension'::pg_catalog.regclass
+              AND dependency.refobjid OPERATOR(pg_catalog.=) durable_oid
+              AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
+        WHERE procedure.oid OPERATOR(pg_catalog.=)
+                  pg_catalog.to_regprocedure(
+                      'df.grant_usage(pg_catalog.text,pg_catalog.bool,'
+                      'pg_catalog.bool)')
+          AND procedure.prorettype OPERATOR(pg_catalog.=)
+                  'pg_catalog.void'::pg_catalog.regtype
+          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 2)
+       OR NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc procedure
+             JOIN pg_catalog.pg_depend dependency
+               ON dependency.classid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.objid OPERATOR(pg_catalog.=) procedure.oid
+              AND dependency.refclassid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_extension'::pg_catalog.regclass
+              AND dependency.refobjid OPERATOR(pg_catalog.=) durable_oid
+              AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
+        WHERE procedure.oid OPERATOR(pg_catalog.=)
+                  pg_catalog.to_regprocedure(
+                      'df.loop(pg_catalog.text,pg_catalog.text,'
+                      'pg_catalog.text)')
+          AND procedure.prorettype OPERATOR(pg_catalog.=)
+                  'pg_catalog.text'::pg_catalog.regtype
+          AND procedure.proargnames[3] OPERATOR(pg_catalog.=) 'on_error')
+    THEN
+        RAISE EXCEPTION
+            'pg_durable API is incomplete: df.grant_usage() and '
+            'df.loop(text, text, text) with on_error are required'
+            USING HINT =
+                'Install the released pg_durable loop-policy build, then '
+                'rerun this script.';
+    END IF;
+END
+$$;
+
+SELECT nullif(:'index_owner', '') IS NOT NULL AS have_index_owner
+\gset
+
+\if :have_index_owner
+\else
+DO $$
+BEGIN
+    RAISE EXCEPTION 'index_owner is required';
+END
+$$;
+\endif
+
+SELECT EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_roles
+           WHERE rolname OPERATOR(pg_catalog.=) :'index_owner'
+       ) AS index_owner_exists,
+       coalesce((
+           SELECT rolsuper
+           FROM pg_catalog.pg_roles
+           WHERE rolname OPERATOR(pg_catalog.=) :'index_owner'
+       ), false) AS index_owner_is_superuser
+\gset
+
+\if :index_owner_exists
+\else
+DO $$
+BEGIN
+    RAISE EXCEPTION 'index_owner role does not exist';
+END
+$$;
+\endif
+
+\if :index_owner_is_superuser
+DO $$
+BEGIN
+    RAISE EXCEPTION 'index_owner must not be a superuser';
+END
+$$;
+\endif
+
+SELECT EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_namespace namespace
+                CROSS JOIN LATERAL pg_catalog.aclexplode(
+                    coalesce(
+                        namespace.nspacl,
+                        pg_catalog.acldefault(
+                            'n', namespace.nspowner))) acl
+           WHERE namespace.nspname OPERATOR(pg_catalog.=) 'public'
+             AND acl.grantee OPERATOR(pg_catalog.=) 0
+             AND acl.privilege_type OPERATOR(pg_catalog.=) 'CREATE'
+       ) AS public_can_create_wrapper
+\gset
+
+\if :public_can_create_wrapper
+DO $$
+BEGIN
+    RAISE EXCEPTION
+        'PUBLIC must not have CREATE on wrapper schema public';
+END
+$$;
+\endif
+
+-- Validate every security-relevant property before changing memberships or
+-- granting access. Existing hostile state is never normalized implicitly.
+DO $$
+DECLARE
+    compactor_oid pg_catalog.oid;
+BEGIN
+    SELECT oid
+    INTO compactor_oid
+    FROM pg_catalog.pg_roles
+    WHERE rolname OPERATOR(pg_catalog.=) 'textsearch_compactor';
+
+    IF compactor_oid IS NULL THEN
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_authid
+        WHERE oid OPERATOR(pg_catalog.=) compactor_oid
+          AND rolpassword IS NOT NULL)
+    THEN
+        RAISE EXCEPTION
+            'existing textsearch_compactor role must not have credentials';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_authid
+        WHERE oid OPERATOR(pg_catalog.=) compactor_oid
+          AND (NOT rolcanlogin
+               OR NOT rolinherit
+               OR rolsuper
+               OR rolcreatedb
+               OR rolcreaterole
+               OR rolreplication
+               OR rolbypassrls
+               OR rolconnlimit OPERATOR(pg_catalog.<>) -1))
+    THEN
+        RAISE EXCEPTION
+            'existing textsearch_compactor role has unsafe attributes';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_db_role_setting setting
+             CROSS JOIN LATERAL
+                 pg_catalog.unnest(setting.setconfig) config(value)
+        WHERE setting.setrole OPERATOR(pg_catalog.=) compactor_oid
+          AND setting.setdatabase IN (
+                  0,
+                  (SELECT oid
+                   FROM pg_catalog.pg_database
+                   WHERE datname OPERATOR(pg_catalog.=)
+                           pg_catalog.current_database()))
+          AND pg_catalog.split_part(config.value, '=', 1) IN
+                  ('search_path', 'role', 'session_authorization'))
+    THEN
+        RAISE EXCEPTION
+            'existing textsearch_compactor role has unsafe settings';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members member
+             JOIN pg_catalog.pg_roles grantor
+               ON grantor.oid OPERATOR(pg_catalog.=) member.grantor
+        WHERE member.member OPERATOR(pg_catalog.=) compactor_oid
+          AND (member.admin_option
+               OR NOT member.inherit_option
+               OR member.set_option
+               OR NOT grantor.rolsuper))
+    THEN
+        RAISE EXCEPTION
+            'existing textsearch_compactor role has unexpected memberships';
+    END IF;
+END
+$$;
+
+-- pg_shdepend is cluster-wide. The exact managed wrapper in this database is
+-- the only object the role may own on a clean rerun.
+DO $$
+DECLARE
+    compactor_oid pg_catalog.oid;
+    database_oid  pg_catalog.oid;
+    wrapper_oid   pg_catalog.oid;
+BEGIN
+    SELECT oid
+    INTO compactor_oid
+    FROM pg_catalog.pg_roles
+    WHERE rolname OPERATOR(pg_catalog.=) 'textsearch_compactor';
+
+    IF compactor_oid IS NULL THEN
+        RETURN;
+    END IF;
+
+    SELECT oid
+    INTO database_oid
+    FROM pg_catalog.pg_database
+    WHERE datname OPERATOR(pg_catalog.=) pg_catalog.current_database();
+
+    wrapper_oid := pg_catalog.to_regprocedure(
+        'public.bm25_request_compaction(pg_catalog.regclass)');
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_shdepend dependency
+        WHERE dependency.refclassid OPERATOR(pg_catalog.=)
+                  'pg_catalog.pg_authid'::pg_catalog.regclass
+          AND dependency.refobjid OPERATOR(pg_catalog.=) compactor_oid
+          AND dependency.deptype OPERATOR(pg_catalog.=) 'o'
+          AND NOT (
+              wrapper_oid IS NOT NULL
+              AND dependency.dbid OPERATOR(pg_catalog.=) database_oid
+              AND dependency.classid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.objid OPERATOR(pg_catalog.=) wrapper_oid
+              AND dependency.objsubid OPERATOR(pg_catalog.=) 0
+              AND EXISTS (
+                  SELECT 1
+                  FROM pg_catalog.pg_proc procedure
+                       JOIN pg_catalog.pg_namespace namespace
+                         ON namespace.oid OPERATOR(pg_catalog.=)
+                                procedure.pronamespace
+                       JOIN pg_catalog.pg_language language
+                         ON language.oid OPERATOR(pg_catalog.=)
+                                procedure.prolang
+                  WHERE procedure.oid OPERATOR(pg_catalog.=) wrapper_oid
+                    AND namespace.nspname OPERATOR(pg_catalog.=) 'public'
+                    AND procedure.proname OPERATOR(pg_catalog.=)
+                            'bm25_request_compaction'
+                    AND procedure.proowner OPERATOR(pg_catalog.=)
+                            compactor_oid
+                    AND procedure.prokind OPERATOR(pg_catalog.=) 'f'
+                    AND procedure.pronargs OPERATOR(pg_catalog.=) 1
+                    AND procedure.proargtypes[0]
+                            OPERATOR(pg_catalog.=)
+                            'pg_catalog.regclass'::pg_catalog.regtype
+                    AND procedure.provariadic OPERATOR(pg_catalog.=) 0
+                    AND procedure.prorettype OPERATOR(pg_catalog.=)
+                            'pg_catalog.text'::pg_catalog.regtype
+                    AND NOT procedure.proretset
+                    AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 0
+                    AND procedure.proallargtypes IS NULL
+                    AND procedure.proargmodes IS NULL
+                    AND procedure.proargnames OPERATOR(pg_catalog.=)
+                            ARRAY['idx']::pg_catalog.text[]
+                    AND language.lanname OPERATOR(pg_catalog.=) 'plpgsql'
+                    AND procedure.prosecdef
+                    AND NOT procedure.proleakproof
+                    AND NOT procedure.proisstrict
+                    AND procedure.provolatile OPERATOR(pg_catalog.=) 'v'
+                    AND procedure.proparallel OPERATOR(pg_catalog.=) 'u'
+                    AND procedure.prosupport OPERATOR(pg_catalog.=) 0
+                    AND procedure.proconfig OPERATOR(pg_catalog.=)
+                            ARRAY['search_path=pg_catalog, pg_temp']
+                                ::pg_catalog.text[]
+                    AND pg_catalog.md5(procedure.prosrc)
+                            OPERATOR(pg_catalog.=)
+                            'c2980482b2b93b9e53511146f1fa8b47'
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM pg_catalog.aclexplode(
+                            coalesce(
+                                procedure.proacl,
+                                pg_catalog.acldefault(
+                                    'f', procedure.proowner))) acl
+                        WHERE (
+                            acl.grantee OPERATOR(pg_catalog.=) 0
+                            AND acl.privilege_type
+                                    OPERATOR(pg_catalog.=) 'EXECUTE')
+                           OR (
+                            acl.grantee OPERATOR(pg_catalog.<>)
+                                    procedure.proowner
+                            AND acl.is_grantable)))
+          ))
+    THEN
+        RAISE EXCEPTION
+            'existing textsearch_compactor role owns unexpected objects'
+            USING HINT =
+                'Drop or reassign every object except the exact managed '
+                'public.bm25_request_compaction(regclass) wrapper.';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_roles
+        WHERE rolname OPERATOR(pg_catalog.=) 'textsearch_compactor')
+    THEN
+        CREATE ROLE textsearch_compactor
+            LOGIN NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE
+            NOREPLICATION NOBYPASSRLS CONNECTION LIMIT -1 PASSWORD NULL;
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_roles granted_role
+        WHERE granted_role.rolsuper
+          AND pg_catalog.pg_has_role(
+                  'textsearch_compactor',
+                  granted_role.oid,
+                  'MEMBER'))
+    THEN
+        RAISE EXCEPTION
+            'textsearch_compactor must not belong to a superuser role';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members member
+        WHERE member.roleid OPERATOR(pg_catalog.=)
+                  'textsearch_compactor'::pg_catalog.regrole)
+    THEN
+        RAISE EXCEPTION
+            'textsearch_compactor must not be granted to another role';
+    END IF;
+END
+$$;
+
+SELECT df.grant_usage('textsearch_compactor');
+
+GRANT :"index_owner" TO textsearch_compactor
+    WITH INHERIT TRUE, SET FALSE;
+
+SELECT pg_catalog.pg_has_role(
+           'textsearch_compactor',
+           :'index_owner',
+           'SET') AS compactor_can_set_owner
+\gset
+
+\if :compactor_can_set_owner
+DO $$
+BEGIN
+    RAISE EXCEPTION
+        'textsearch_compactor must not SET ROLE to index_owner';
+END
+$$;
+\endif
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_roles granted_role
+        WHERE granted_role.rolsuper
+          AND pg_catalog.pg_has_role(
+                  'textsearch_compactor',
+                  granted_role.oid,
+                  'MEMBER'))
+    THEN
+        RAISE EXCEPTION
+            'index_owner creates a transitive superuser membership';
+    END IF;
+END
+$$;
+
+SELECT namespace.nspname AS ext_schema
+FROM pg_catalog.pg_extension extension
+     JOIN pg_catalog.pg_namespace namespace
+       ON namespace.oid OPERATOR(pg_catalog.=) extension.extnamespace
+WHERE extension.extname OPERATOR(pg_catalog.=) 'pg_textsearch'
+\gset
+
+GRANT USAGE ON SCHEMA :"ext_schema" TO textsearch_compactor;
+GRANT EXECUTE ON FUNCTION
+    :"ext_schema".bm25_compact_step_if_current(oid, oid, oid, oid),
+    :"ext_schema".bm25_needs_compaction_if_current(oid, oid, oid, oid)
+TO textsearch_compactor;
+
+COMMIT;
+
+\echo 'textsearch_compactor ready.'

--- a/scripts/durable_compaction/01_setup_role.sql
+++ b/scripts/durable_compaction/01_setup_role.sql
@@ -19,9 +19,9 @@ BEGIN;
 
 SET LOCAL search_path = pg_catalog, pg_temp;
 
--- Keep the unreleased loop-policy dependency in this one preflight block.
--- Replace the capability-only error with a version floor once a release
--- contains df.loop(text, text, text).
+-- Keep the unreleased failure-policy dependency in this one preflight block.
+-- Replace the capability-only error with a version floor once the release
+-- containing microsoft/pg_durable#354 is available.
 DO $$
 DECLARE
     durable_oid pg_catalog.oid;
@@ -33,10 +33,10 @@ BEGIN
 
     IF durable_oid IS NULL THEN
         RAISE EXCEPTION
-            'pg_durable with df.loop(..., on_error) is required'
+            'pg_durable with the df.start() failure policy is required'
             USING HINT =
-                'Install the released pg_durable loop-policy build, then '
-                'rerun this script.';
+                'Install the release containing microsoft/pg_durable#354, '
+                'then rerun this script.';
     END IF;
 
     IF NOT EXISTS (
@@ -70,18 +70,28 @@ BEGIN
               AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
         WHERE procedure.oid OPERATOR(pg_catalog.=)
                   pg_catalog.to_regprocedure(
-                      'df.loop(pg_catalog.text,pg_catalog.text,'
-                      'pg_catalog.text)')
+                      'df.start(pg_catalog.text,pg_catalog.text,'
+                      'pg_catalog.text,pg_catalog.text,pg_catalog.int4,'
+                      'pg_catalog.interval,pg_catalog.text)')
           AND procedure.prorettype OPERATOR(pg_catalog.=)
                   'pg_catalog.text'::pg_catalog.regtype
-          AND procedure.proargnames[3] OPERATOR(pg_catalog.=) 'on_error')
+          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 6
+          AND procedure.proargnames OPERATOR(pg_catalog.=)
+                  ARRAY[
+                      'fut',
+                      'label',
+                      'database',
+                      'transaction_mode',
+                      'max_attempts',
+                      'max_backoff',
+                      'on_failure']::pg_catalog.text[])
     THEN
         RAISE EXCEPTION
             'pg_durable API is incomplete: df.grant_usage() and '
-            'df.loop(text, text, text) with on_error are required'
+            'df.start() with the node failure policy are required'
             USING HINT =
-                'Install the released pg_durable loop-policy build, then '
-                'rerun this script.';
+                'Install the release containing microsoft/pg_durable#354, '
+                'then rerun this script.';
     END IF;
 END
 $$;
@@ -308,7 +318,7 @@ BEGIN
                                 ::pg_catalog.text[]
                     AND pg_catalog.md5(procedure.prosrc)
                             OPERATOR(pg_catalog.=)
-                            '9546a8ef400bdc5eeb9dbed13aad6bdc'
+                            '39b927569e6b4a2d24e1999627993a6d'
                     AND NOT EXISTS (
                         SELECT 1
                         FROM pg_catalog.aclexplode(

--- a/scripts/durable_compaction/02_wrapper.sql
+++ b/scripts/durable_compaction/02_wrapper.sql
@@ -305,6 +305,9 @@ SELECT pg_catalog.set_config(
 RESET ROLE;
 COMMIT;
 
+BEGIN;
+SET LOCAL search_path = pg_catalog, pg_temp;
+
 DO $$
 DECLARE
     canary_id      pg_catalog.text :=
@@ -313,7 +316,8 @@ DECLARE
     instance_state pg_catalog.text;
     node_result    pg_catalog.text;
     deadline       pg_catalog.timestamptz :=
-        pg_catalog.clock_timestamp() + interval '60 seconds';
+        pg_catalog.clock_timestamp() OPERATOR(pg_catalog.+)
+            '60 seconds'::pg_catalog.interval;
 BEGIN
     LOOP
         SELECT instance.status
@@ -321,7 +325,8 @@ BEGIN
         FROM df.instances instance
         WHERE instance.id OPERATOR(pg_catalog.=) canary_id;
 
-        EXIT WHEN instance_state IN ('completed', 'failed', 'cancelled');
+        EXIT WHEN instance_state OPERATOR(pg_catalog.=) ANY (ARRAY[
+            'completed', 'failed', 'cancelled']);
 
         IF pg_catalog.clock_timestamp() OPERATOR(pg_catalog.>=) deadline THEN
             RAISE EXCEPTION
@@ -337,7 +342,7 @@ BEGIN
     END LOOP;
 
     IF instance_state OPERATOR(pg_catalog.<>) 'completed' THEN
-        SELECT node.result #>> '{}'
+        SELECT node.result OPERATOR(pg_catalog.#>>) '{}'
         INTO node_result
         FROM df.nodes node
         WHERE node.instance_id OPERATOR(pg_catalog.=) canary_id
@@ -354,6 +359,8 @@ BEGIN
     END IF;
 END
 $$;
+
+COMMIT;
 
 BEGIN;
 

--- a/scripts/durable_compaction/02_wrapper.sql
+++ b/scripts/durable_compaction/02_wrapper.sql
@@ -249,7 +249,7 @@ BEGIN
                          ::pg_catalog.text[]
              AND pg_catalog.md5(procedure.prosrc)
                      OPERATOR(pg_catalog.=)
-                     'c2980482b2b93b9e53511146f1fa8b47'
+                     '9546a8ef400bdc5eeb9dbed13aad6bdc'
              AND NOT EXISTS (
                  SELECT 1
                  FROM pg_catalog.aclexplode(
@@ -365,46 +365,54 @@ DECLARE
     database_oid   pg_catalog.text;
     tablespace_oid pg_catalog.text;
     relfilenumber  pg_catalog.text;
+    persistence    pg_catalog.text;
+    authorized     pg_catalog.bool;
     body           pg_catalog.text;
     cond           pg_catalog.text;
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class relation
-             JOIN pg_catalog.pg_am access_method
-               ON access_method.oid = relation.relam
-        WHERE relation.oid = idx
-          AND relation.relkind = 'i'
-          AND access_method.amname = 'bm25')
-    THEN
-        RAISE EXCEPTION '"%" is not a bm25 index', idx::pg_catalog.text;
+    SELECT idx::pg_catalog.oid::pg_catalog.text,
+           database.oid::pg_catalog.text,
+           coalesce(
+               nullif(relation.reltablespace, 0),
+               database.dattablespace)::pg_catalog.text,
+           pg_catalog.pg_relation_filenode(idx)::pg_catalog.text,
+           relation.relpersistence::pg_catalog.text,
+           pg_catalog.has_table_privilege(
+               session_user, index_catalog.indrelid, 'INSERT')
+           OR EXISTS (
+               SELECT 1
+               FROM pg_catalog.pg_partition_ancestors(
+                        index_catalog.indrelid) ancestor(relid)
+               WHERE pg_catalog.has_table_privilege(
+                         session_user, ancestor.relid, 'INSERT'))
+    INTO idx_oid, database_oid, tablespace_oid, relfilenumber,
+         persistence, authorized
+    FROM pg_catalog.pg_class relation
+         JOIN pg_catalog.pg_am access_method
+           ON access_method.oid = relation.relam
+         JOIN pg_catalog.pg_index index_catalog
+           ON index_catalog.indexrelid = relation.oid
+         JOIN pg_catalog.pg_database database
+           ON database.datname = pg_catalog.current_database()
+    WHERE relation.oid = idx
+      AND relation.relkind = 'i'
+      AND access_method.amname = 'bm25'
+      AND index_catalog.indisvalid
+      AND index_catalog.indisready
+      AND index_catalog.indislive;
+
+    IF NOT FOUND OR relfilenumber IS NULL THEN
+        RAISE EXCEPTION
+            '"%" is not a current bm25 index', idx::pg_catalog.text;
     END IF;
 
-    IF EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class relation
-        WHERE relation.oid = idx
-          AND relation.relpersistence = 't')
-    THEN
+    IF persistence = 't' THEN
         RAISE EXCEPTION
             'temporary bm25 indexes cannot use background compaction'
             USING ERRCODE = 'feature_not_supported';
     END IF;
 
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_index index_catalog
-        WHERE index_catalog.indexrelid = idx
-          AND (
-              pg_catalog.has_table_privilege(
-                  session_user, index_catalog.indrelid, 'INSERT')
-              OR EXISTS (
-                  SELECT 1
-                  FROM pg_catalog.pg_partition_ancestors(
-                           index_catalog.indrelid) ancestor(relid)
-                  WHERE pg_catalog.has_table_privilege(
-                            session_user, ancestor.relid, 'INSERT'))))
-    THEN
+    IF NOT authorized THEN
         RAISE EXCEPTION
             'permission denied to request compaction for %', idx
             USING ERRCODE = 'insufficient_privilege';
@@ -420,18 +428,6 @@ BEGIN
     IF ext_schema IS NULL THEN
         RAISE EXCEPTION 'extension pg_textsearch is not installed here';
     END IF;
-
-    SELECT idx::pg_catalog.oid::pg_catalog.text,
-           database.oid::pg_catalog.text,
-           coalesce(
-               nullif(relation.reltablespace, 0),
-               database.dattablespace)::pg_catalog.text,
-           pg_catalog.pg_relation_filenode(idx)::pg_catalog.text
-    INTO idx_oid, database_oid, tablespace_oid, relfilenumber
-    FROM pg_catalog.pg_class relation
-         JOIN pg_catalog.pg_database database
-           ON database.datname = pg_catalog.current_database()
-    WHERE relation.oid = idx;
 
     body := pg_catalog.format(
         'SELECT %I.bm25_compact_step_if_current('
@@ -528,7 +524,7 @@ BEGIN
                       ::pg_catalog.text[]
           AND pg_catalog.md5(procedure.prosrc)
                   OPERATOR(pg_catalog.=)
-                  'c2980482b2b93b9e53511146f1fa8b47'
+                  '9546a8ef400bdc5eeb9dbed13aad6bdc'
           AND NOT EXISTS (
               SELECT 1
               FROM pg_catalog.aclexplode(

--- a/scripts/durable_compaction/02_wrapper.sql
+++ b/scripts/durable_compaction/02_wrapper.sql
@@ -15,9 +15,9 @@ BEGIN;
 
 SET LOCAL search_path = pg_catalog, pg_temp;
 
--- Keep the unreleased loop-policy dependency in this one preflight block.
--- Replace the capability-only error with a version floor once a release
--- contains df.loop(text, text, text).
+-- Keep the unreleased failure-policy dependency in this one preflight block.
+-- Replace the capability-only error with a version floor once the release
+-- containing microsoft/pg_durable#354 is available.
 DO $$
 DECLARE
     durable_oid pg_catalog.oid;
@@ -29,10 +29,10 @@ BEGIN
 
     IF durable_oid IS NULL THEN
         RAISE EXCEPTION
-            'pg_durable with df.loop(..., on_error) is required'
+            'pg_durable with the df.start() failure policy is required'
             USING HINT =
-                'Install the released pg_durable loop-policy build, then '
-                'rerun this script.';
+                'Install the release containing microsoft/pg_durable#354, '
+                'then rerun this script.';
     END IF;
 
     IF NOT EXISTS (
@@ -49,12 +49,20 @@ BEGIN
         WHERE procedure.oid OPERATOR(pg_catalog.=)
                   pg_catalog.to_regprocedure(
                       'df.start(pg_catalog.text,pg_catalog.text,'
-                      'pg_catalog.text,pg_catalog.text)')
+                      'pg_catalog.text,pg_catalog.text,pg_catalog.int4,'
+                      'pg_catalog.interval,pg_catalog.text)')
           AND procedure.prorettype OPERATOR(pg_catalog.=)
                   'pg_catalog.text'::pg_catalog.regtype
-          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 3
+          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 6
           AND procedure.proargnames OPERATOR(pg_catalog.=)
-                  ARRAY['fut', 'label', 'database', 'transaction_mode'])
+                  ARRAY[
+                      'fut',
+                      'label',
+                      'database',
+                      'transaction_mode',
+                      'max_attempts',
+                      'max_backoff',
+                      'on_failure']::pg_catalog.text[])
        OR NOT EXISTS (
         SELECT 1
         FROM pg_catalog.pg_proc procedure
@@ -68,11 +76,10 @@ BEGIN
               AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
         WHERE procedure.oid OPERATOR(pg_catalog.=)
                   pg_catalog.to_regprocedure(
-                      'df.loop(pg_catalog.text,pg_catalog.text,'
-                      'pg_catalog.text)')
+                      'df.loop(pg_catalog.text,pg_catalog.text)')
           AND procedure.prorettype OPERATOR(pg_catalog.=)
                   'pg_catalog.text'::pg_catalog.regtype
-          AND procedure.proargnames[3] OPERATOR(pg_catalog.=) 'on_error')
+          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 1)
        OR pg_catalog.to_regclass('df.instances') IS NULL
        OR pg_catalog.to_regclass('df.nodes') IS NULL
        OR (
@@ -114,10 +121,10 @@ BEGIN
     THEN
         RAISE EXCEPTION
             'pg_durable API is incomplete: df.start(), '
-            'df.loop(..., on_error), df.instances, and df.nodes are required'
+            'df.loop(), df.instances, and df.nodes are required'
             USING HINT =
-                'Install the released pg_durable loop-policy build, then '
-                'rerun this script.';
+                'Install the release containing microsoft/pg_durable#354, '
+                'then rerun this script.';
     END IF;
 END
 $$;
@@ -249,7 +256,7 @@ BEGIN
                          ::pg_catalog.text[]
              AND pg_catalog.md5(procedure.prosrc)
                      OPERATOR(pg_catalog.=)
-                     '9546a8ef400bdc5eeb9dbed13aad6bdc'
+                     '39b927569e6b4a2d24e1999627993a6d'
              AND NOT EXISTS (
                  SELECT 1
                  FROM pg_catalog.aclexplode(
@@ -290,7 +297,9 @@ SELECT pg_catalog.set_config(
     df.start(
         'SELECT 1 AS pg_textsearch_canary',
         label => 'bm25-compaction-canary',
-        transaction_mode => 'new'),
+        transaction_mode => 'new',
+        max_attempts     => 1,
+        on_failure      => 'fail'),
     false);
 
 RESET ROLE;
@@ -441,9 +450,12 @@ BEGIN
         ext_schema, idx_oid, database_oid, tablespace_oid, relfilenumber);
 
     RETURN df.start(
-        df.loop(body, cond, on_error => 'continue'),
+        df.loop(body, cond),
         label            => 'bm25-compact-' || idx_oid,
-        transaction_mode => 'new');
+        transaction_mode => 'new',
+        max_attempts     => 5,
+        max_backoff      => '16 seconds'::pg_catalog.interval,
+        on_failure      => 'continue');
 END;
 $fn$;
 
@@ -527,7 +539,7 @@ BEGIN
                       ::pg_catalog.text[]
           AND pg_catalog.md5(procedure.prosrc)
                   OPERATOR(pg_catalog.=)
-                  '9546a8ef400bdc5eeb9dbed13aad6bdc'
+                  '39b927569e6b4a2d24e1999627993a6d'
           AND NOT EXISTS (
               SELECT 1
               FROM pg_catalog.aclexplode(

--- a/scripts/durable_compaction/02_wrapper.sql
+++ b/scripts/durable_compaction/02_wrapper.sql
@@ -506,10 +506,13 @@ BEGIN
           AND procedure.pronargs OPERATOR(pg_catalog.=) 1
           AND procedure.proargtypes[0] OPERATOR(pg_catalog.=)
                   'pg_catalog.regclass'::pg_catalog.regtype
+          AND procedure.provariadic OPERATOR(pg_catalog.=) 0
           AND procedure.prorettype OPERATOR(pg_catalog.=)
                   'pg_catalog.text'::pg_catalog.regtype
           AND NOT procedure.proretset
           AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 0
+          AND procedure.proallargtypes IS NULL
+          AND procedure.proargmodes IS NULL
           AND procedure.proargnames OPERATOR(pg_catalog.=)
                   ARRAY['idx']::pg_catalog.text[]
           AND language.lanname OPERATOR(pg_catalog.=) 'plpgsql'

--- a/scripts/durable_compaction/02_wrapper.sql
+++ b/scripts/durable_compaction/02_wrapper.sql
@@ -1,0 +1,555 @@
+-- Install the SECURITY DEFINER pg_durable request wrapper.
+--
+-- Run as a superuser in pg_durable.database, after 01_setup_role.sql:
+--
+--   psql -f 02_wrapper.sql -v writer_role=app_writer
+
+\set ON_ERROR_STOP on
+
+\if :{?writer_role}
+\else
+\set writer_role ''
+\endif
+
+BEGIN;
+
+SET LOCAL search_path = pg_catalog, pg_temp;
+
+-- Keep the unreleased loop-policy dependency in this one preflight block.
+-- Replace the capability-only error with a version floor once a release
+-- contains df.loop(text, text, text).
+DO $$
+DECLARE
+    durable_oid pg_catalog.oid;
+BEGIN
+    SELECT extension.oid
+    INTO durable_oid
+    FROM pg_catalog.pg_extension extension
+    WHERE extension.extname OPERATOR(pg_catalog.=) 'pg_durable';
+
+    IF durable_oid IS NULL THEN
+        RAISE EXCEPTION
+            'pg_durable with df.loop(..., on_error) is required'
+            USING HINT =
+                'Install the released pg_durable loop-policy build, then '
+                'rerun this script.';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc procedure
+             JOIN pg_catalog.pg_depend dependency
+               ON dependency.classid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.objid OPERATOR(pg_catalog.=) procedure.oid
+              AND dependency.refclassid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_extension'::pg_catalog.regclass
+              AND dependency.refobjid OPERATOR(pg_catalog.=) durable_oid
+              AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
+        WHERE procedure.oid OPERATOR(pg_catalog.=)
+                  pg_catalog.to_regprocedure(
+                      'df.start(pg_catalog.text,pg_catalog.text,'
+                      'pg_catalog.text,pg_catalog.text)')
+          AND procedure.prorettype OPERATOR(pg_catalog.=)
+                  'pg_catalog.text'::pg_catalog.regtype
+          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 3
+          AND procedure.proargnames OPERATOR(pg_catalog.=)
+                  ARRAY['fut', 'label', 'database', 'transaction_mode'])
+       OR NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc procedure
+             JOIN pg_catalog.pg_depend dependency
+               ON dependency.classid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.objid OPERATOR(pg_catalog.=) procedure.oid
+              AND dependency.refclassid OPERATOR(pg_catalog.=)
+                      'pg_catalog.pg_extension'::pg_catalog.regclass
+              AND dependency.refobjid OPERATOR(pg_catalog.=) durable_oid
+              AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
+        WHERE procedure.oid OPERATOR(pg_catalog.=)
+                  pg_catalog.to_regprocedure(
+                      'df.loop(pg_catalog.text,pg_catalog.text,'
+                      'pg_catalog.text)')
+          AND procedure.prorettype OPERATOR(pg_catalog.=)
+                  'pg_catalog.text'::pg_catalog.regtype
+          AND procedure.proargnames[3] OPERATOR(pg_catalog.=) 'on_error')
+       OR pg_catalog.to_regclass('df.instances') IS NULL
+       OR pg_catalog.to_regclass('df.nodes') IS NULL
+       OR (
+        SELECT pg_catalog.count(*)
+        FROM pg_catalog.pg_attribute attribute
+        WHERE attribute.attrelid OPERATOR(pg_catalog.=)
+                  pg_catalog.to_regclass('df.instances')
+          AND attribute.attnum OPERATOR(pg_catalog.>) 0
+          AND NOT attribute.attisdropped
+          AND (
+              (attribute.attname OPERATOR(pg_catalog.=) 'id'
+               AND attribute.atttypid OPERATOR(pg_catalog.=)
+                       'pg_catalog.varchar'::pg_catalog.regtype)
+              OR (attribute.attname OPERATOR(pg_catalog.=) 'status'
+                  AND attribute.atttypid OPERATOR(pg_catalog.=)
+                          'pg_catalog.text'::pg_catalog.regtype)))
+           OPERATOR(pg_catalog.<>) 2
+       OR (
+        SELECT pg_catalog.count(*)
+        FROM pg_catalog.pg_attribute attribute
+        WHERE attribute.attrelid OPERATOR(pg_catalog.=)
+                  pg_catalog.to_regclass('df.nodes')
+          AND attribute.attnum OPERATOR(pg_catalog.>) 0
+          AND NOT attribute.attisdropped
+          AND (
+              (attribute.attname OPERATOR(pg_catalog.=) 'instance_id'
+               AND attribute.atttypid OPERATOR(pg_catalog.=)
+                       'pg_catalog.varchar'::pg_catalog.regtype)
+              OR (attribute.attname OPERATOR(pg_catalog.=) 'status'
+                  AND attribute.atttypid OPERATOR(pg_catalog.=)
+                          'pg_catalog.text'::pg_catalog.regtype)
+              OR (attribute.attname OPERATOR(pg_catalog.=) 'result'
+                  AND attribute.atttypid OPERATOR(pg_catalog.=)
+                          'pg_catalog.jsonb'::pg_catalog.regtype)
+              OR (attribute.attname OPERATOR(pg_catalog.=) 'updated_at'
+                  AND attribute.atttypid OPERATOR(pg_catalog.=)
+                          'pg_catalog.timestamptz'::pg_catalog.regtype)))
+           OPERATOR(pg_catalog.<>) 4
+    THEN
+        RAISE EXCEPTION
+            'pg_durable API is incomplete: df.start(), '
+            'df.loop(..., on_error), df.instances, and df.nodes are required'
+            USING HINT =
+                'Install the released pg_durable loop-policy build, then '
+                'rerun this script.';
+    END IF;
+END
+$$;
+
+SELECT nullif(:'writer_role', '') IS NOT NULL AS have_writer,
+       coalesce(nullif(:'writer_role', ''), 'none') AS writer
+\gset
+
+\if :have_writer
+SELECT EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_roles
+           WHERE rolname OPERATOR(pg_catalog.=) :'writer'
+       ) AS writer_exists,
+       coalesce((
+           SELECT rolsuper
+           FROM pg_catalog.pg_roles
+           WHERE rolname OPERATOR(pg_catalog.=) :'writer'
+       ), false) AS writer_is_superuser
+\gset
+
+\if :writer_exists
+\else
+DO $$
+BEGIN
+    RAISE EXCEPTION 'writer_role does not exist';
+END
+$$;
+\endif
+
+\if :writer_is_superuser
+DO $$
+BEGIN
+    RAISE EXCEPTION 'writer_role must not be a superuser';
+END
+$$;
+\endif
+\endif
+
+DO $$
+DECLARE
+    compactor_oid pg_catalog.oid;
+    wrapper_oid   pg_catalog.oid;
+BEGIN
+    SELECT oid
+    INTO compactor_oid
+    FROM pg_catalog.pg_roles
+    WHERE rolname OPERATOR(pg_catalog.=) 'textsearch_compactor';
+
+    IF compactor_oid IS NULL THEN
+        RAISE EXCEPTION
+            'textsearch_compactor does not exist'
+            USING HINT = 'Run 01_setup_role.sql first.';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_authid
+        WHERE oid OPERATOR(pg_catalog.=) compactor_oid
+          AND (rolpassword IS NOT NULL
+               OR NOT rolcanlogin
+               OR NOT rolinherit
+               OR rolsuper
+               OR rolcreatedb
+               OR rolcreaterole
+               OR rolreplication
+               OR rolbypassrls
+               OR rolconnlimit OPERATOR(pg_catalog.<>) -1))
+    THEN
+        RAISE EXCEPTION
+            'textsearch_compactor has unsafe credentials or attributes';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_namespace namespace
+             CROSS JOIN LATERAL pg_catalog.aclexplode(
+                 coalesce(
+                     namespace.nspacl,
+                     pg_catalog.acldefault(
+                         'n', namespace.nspowner))) acl
+        WHERE namespace.nspname OPERATOR(pg_catalog.=) 'public'
+          AND acl.grantee OPERATOR(pg_catalog.=) 0
+          AND acl.privilege_type OPERATOR(pg_catalog.=) 'CREATE')
+    THEN
+        RAISE EXCEPTION
+            'PUBLIC must not have CREATE on wrapper schema public';
+    END IF;
+
+    wrapper_oid := pg_catalog.to_regprocedure(
+        'public.bm25_request_compaction(pg_catalog.regclass)');
+
+    IF wrapper_oid IS NOT NULL
+       AND NOT EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_proc procedure
+                JOIN pg_catalog.pg_namespace namespace
+                  ON namespace.oid OPERATOR(pg_catalog.=)
+                         procedure.pronamespace
+                JOIN pg_catalog.pg_language language
+                  ON language.oid OPERATOR(pg_catalog.=) procedure.prolang
+           WHERE procedure.oid OPERATOR(pg_catalog.=) wrapper_oid
+             AND namespace.nspname OPERATOR(pg_catalog.=) 'public'
+             AND procedure.proname OPERATOR(pg_catalog.=)
+                     'bm25_request_compaction'
+             AND procedure.proowner OPERATOR(pg_catalog.=) compactor_oid
+             AND procedure.prokind OPERATOR(pg_catalog.=) 'f'
+             AND procedure.pronargs OPERATOR(pg_catalog.=) 1
+             AND procedure.proargtypes[0] OPERATOR(pg_catalog.=)
+                     'pg_catalog.regclass'::pg_catalog.regtype
+             AND procedure.provariadic OPERATOR(pg_catalog.=) 0
+             AND procedure.prorettype OPERATOR(pg_catalog.=)
+                     'pg_catalog.text'::pg_catalog.regtype
+             AND NOT procedure.proretset
+             AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 0
+             AND procedure.proallargtypes IS NULL
+             AND procedure.proargmodes IS NULL
+             AND procedure.proargnames OPERATOR(pg_catalog.=)
+                     ARRAY['idx']::pg_catalog.text[]
+             AND language.lanname OPERATOR(pg_catalog.=) 'plpgsql'
+             AND procedure.prosecdef
+             AND NOT procedure.proleakproof
+             AND NOT procedure.proisstrict
+             AND procedure.provolatile OPERATOR(pg_catalog.=) 'v'
+             AND procedure.proparallel OPERATOR(pg_catalog.=) 'u'
+             AND procedure.prosupport OPERATOR(pg_catalog.=) 0
+             AND procedure.proconfig OPERATOR(pg_catalog.=)
+                     ARRAY['search_path=pg_catalog, pg_temp']
+                         ::pg_catalog.text[]
+             AND pg_catalog.md5(procedure.prosrc)
+                     OPERATOR(pg_catalog.=)
+                     'c2980482b2b93b9e53511146f1fa8b47'
+             AND NOT EXISTS (
+                 SELECT 1
+                 FROM pg_catalog.aclexplode(
+                     coalesce(
+                         procedure.proacl,
+                         pg_catalog.acldefault(
+                             'f', procedure.proowner))) acl
+                 WHERE (
+                     acl.grantee OPERATOR(pg_catalog.=) 0
+                     AND acl.privilege_type
+                             OPERATOR(pg_catalog.=) 'EXECUTE')
+                    OR (
+                     acl.grantee OPERATOR(pg_catalog.<>)
+                             procedure.proowner
+                     AND acl.is_grantable)))
+    THEN
+        RAISE EXCEPTION
+            'existing bm25_request_compaction wrapper is not the managed '
+            'definition'
+            USING HINT =
+                'Inspect and remove the hostile or drifted wrapper manually.';
+    END IF;
+END
+$$;
+
+COMMIT;
+
+-- Commit a real task before replacing the wrapper. This validates that the
+-- worker can connect as textsearch_compactor, not merely that SQL objects
+-- have the expected catalog shape.
+BEGIN;
+
+SET LOCAL search_path = pg_catalog, pg_temp;
+SET LOCAL ROLE textsearch_compactor;
+
+SELECT pg_catalog.set_config(
+    'pg_textsearch_compaction.canary_instance',
+    df.start(
+        'SELECT 1 AS pg_textsearch_canary',
+        label => 'bm25-compaction-canary',
+        transaction_mode => 'new'),
+    false);
+
+RESET ROLE;
+COMMIT;
+
+DO $$
+DECLARE
+    canary_id      pg_catalog.text :=
+        pg_catalog.current_setting(
+            'pg_textsearch_compaction.canary_instance');
+    instance_state pg_catalog.text;
+    node_result    pg_catalog.text;
+    deadline       pg_catalog.timestamptz :=
+        pg_catalog.clock_timestamp() + interval '60 seconds';
+BEGIN
+    LOOP
+        SELECT instance.status
+        INTO instance_state
+        FROM df.instances instance
+        WHERE instance.id OPERATOR(pg_catalog.=) canary_id;
+
+        EXIT WHEN instance_state IN ('completed', 'failed', 'cancelled');
+
+        IF pg_catalog.clock_timestamp() OPERATOR(pg_catalog.>=) deadline THEN
+            RAISE EXCEPTION
+                'compactor execution canary % did not finish; status %',
+                canary_id,
+                coalesce(instance_state, '<missing>')
+                USING HINT =
+                    'Check pg_durable worker readiness, PGHOST, pg_hba.conf, '
+                    'and PostgreSQL logs.';
+        END IF;
+
+        PERFORM pg_catalog.pg_sleep(0.25);
+    END LOOP;
+
+    IF instance_state OPERATOR(pg_catalog.<>) 'completed' THEN
+        SELECT node.result #>> '{}'
+        INTO node_result
+        FROM df.nodes node
+        WHERE node.instance_id OPERATOR(pg_catalog.=) canary_id
+          AND node.status OPERATOR(pg_catalog.=) 'failed'
+        ORDER BY node.updated_at DESC
+        LIMIT 1;
+
+        RAISE EXCEPTION
+            'compactor execution canary % failed: %',
+            canary_id,
+            coalesce(node_result, '<no node diagnostic>')
+            USING HINT =
+                'Check textsearch_compactor authentication and server logs.';
+    END IF;
+END
+$$;
+
+BEGIN;
+
+SET LOCAL search_path = pg_catalog, pg_temp;
+
+DROP FUNCTION IF EXISTS
+    public.bm25_request_compaction(pg_catalog.regclass);
+
+CREATE FUNCTION public.bm25_request_compaction(idx pg_catalog.regclass)
+RETURNS pg_catalog.text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+DECLARE
+    ext_schema     pg_catalog.text;
+    idx_oid        pg_catalog.text;
+    database_oid   pg_catalog.text;
+    tablespace_oid pg_catalog.text;
+    relfilenumber  pg_catalog.text;
+    body           pg_catalog.text;
+    cond           pg_catalog.text;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class relation
+             JOIN pg_catalog.pg_am access_method
+               ON access_method.oid = relation.relam
+        WHERE relation.oid = idx
+          AND relation.relkind = 'i'
+          AND access_method.amname = 'bm25')
+    THEN
+        RAISE EXCEPTION '"%" is not a bm25 index', idx::pg_catalog.text;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class relation
+        WHERE relation.oid = idx
+          AND relation.relpersistence = 't')
+    THEN
+        RAISE EXCEPTION
+            'temporary bm25 indexes cannot use background compaction'
+            USING ERRCODE = 'feature_not_supported';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_index index_catalog
+        WHERE index_catalog.indexrelid = idx
+          AND (
+              pg_catalog.has_table_privilege(
+                  session_user, index_catalog.indrelid, 'INSERT')
+              OR EXISTS (
+                  SELECT 1
+                  FROM pg_catalog.pg_partition_ancestors(
+                           index_catalog.indrelid) ancestor(relid)
+                  WHERE pg_catalog.has_table_privilege(
+                            session_user, ancestor.relid, 'INSERT'))))
+    THEN
+        RAISE EXCEPTION
+            'permission denied to request compaction for %', idx
+            USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    SELECT namespace.nspname
+    INTO ext_schema
+    FROM pg_catalog.pg_extension extension
+         JOIN pg_catalog.pg_namespace namespace
+           ON namespace.oid = extension.extnamespace
+    WHERE extension.extname = 'pg_textsearch';
+
+    IF ext_schema IS NULL THEN
+        RAISE EXCEPTION 'extension pg_textsearch is not installed here';
+    END IF;
+
+    SELECT idx::pg_catalog.oid::pg_catalog.text,
+           database.oid::pg_catalog.text,
+           coalesce(
+               nullif(relation.reltablespace, 0),
+               database.dattablespace)::pg_catalog.text,
+           pg_catalog.pg_relation_filenode(idx)::pg_catalog.text
+    INTO idx_oid, database_oid, tablespace_oid, relfilenumber
+    FROM pg_catalog.pg_class relation
+         JOIN pg_catalog.pg_database database
+           ON database.datname = pg_catalog.current_database()
+    WHERE relation.oid = idx;
+
+    body := pg_catalog.format(
+        'SELECT %I.bm25_compact_step_if_current('
+        '%s::pg_catalog.oid, %s::pg_catalog.oid, '
+        '%s::pg_catalog.oid, %s::pg_catalog.oid)',
+        ext_schema, idx_oid, database_oid, tablespace_oid, relfilenumber);
+    cond := pg_catalog.format(
+        'SELECT %I.bm25_needs_compaction_if_current('
+        '%s::pg_catalog.oid, %s::pg_catalog.oid, '
+        '%s::pg_catalog.oid, %s::pg_catalog.oid)',
+        ext_schema, idx_oid, database_oid, tablespace_oid, relfilenumber);
+
+    RETURN df.start(
+        df.loop(body, cond, on_error => 'continue'),
+        label            => 'bm25-compact-' || idx_oid,
+        transaction_mode => 'new');
+END;
+$fn$;
+
+ALTER FUNCTION public.bm25_request_compaction(pg_catalog.regclass)
+    OWNER TO textsearch_compactor;
+
+REVOKE ALL ON FUNCTION
+    public.bm25_request_compaction(pg_catalog.regclass)
+FROM PUBLIC CASCADE;
+
+-- A named ALTER DEFAULT PRIVILEGES grant is copied onto CREATE FUNCTION.
+-- Remove every non-owner entry before adding the selected writer.
+DO $$
+DECLARE
+    grantee_name pg_catalog.name;
+BEGIN
+    FOR grantee_name IN
+        SELECT DISTINCT role.rolname
+        FROM pg_catalog.pg_proc procedure
+             CROSS JOIN LATERAL pg_catalog.aclexplode(
+                 coalesce(
+                     procedure.proacl,
+                     pg_catalog.acldefault(
+                         'f', procedure.proowner))) acl
+             JOIN pg_catalog.pg_roles role ON role.oid = acl.grantee
+        WHERE procedure.oid =
+                  'public.bm25_request_compaction(pg_catalog.regclass)'
+                      ::pg_catalog.regprocedure
+          AND acl.grantee <> procedure.proowner
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON FUNCTION '
+            'public.bm25_request_compaction(pg_catalog.regclass) '
+            'FROM %I CASCADE',
+            grantee_name);
+    END LOOP;
+END
+$$;
+
+\if :have_writer
+GRANT EXECUTE ON FUNCTION
+    public.bm25_request_compaction(pg_catalog.regclass)
+TO :"writer";
+\endif
+
+-- Keep this body hash synchronized with 01_setup_role.sql.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc procedure
+             JOIN pg_catalog.pg_language language
+               ON language.oid OPERATOR(pg_catalog.=) procedure.prolang
+        WHERE procedure.oid OPERATOR(pg_catalog.=)
+                  'public.bm25_request_compaction(pg_catalog.regclass)'
+                      ::pg_catalog.regprocedure
+          AND procedure.proowner OPERATOR(pg_catalog.=)
+                  'textsearch_compactor'::pg_catalog.regrole
+          AND procedure.prokind OPERATOR(pg_catalog.=) 'f'
+          AND procedure.pronargs OPERATOR(pg_catalog.=) 1
+          AND procedure.proargtypes[0] OPERATOR(pg_catalog.=)
+                  'pg_catalog.regclass'::pg_catalog.regtype
+          AND procedure.prorettype OPERATOR(pg_catalog.=)
+                  'pg_catalog.text'::pg_catalog.regtype
+          AND NOT procedure.proretset
+          AND procedure.pronargdefaults OPERATOR(pg_catalog.=) 0
+          AND procedure.proargnames OPERATOR(pg_catalog.=)
+                  ARRAY['idx']::pg_catalog.text[]
+          AND language.lanname OPERATOR(pg_catalog.=) 'plpgsql'
+          AND procedure.prosecdef
+          AND NOT procedure.proleakproof
+          AND NOT procedure.proisstrict
+          AND procedure.provolatile OPERATOR(pg_catalog.=) 'v'
+          AND procedure.proparallel OPERATOR(pg_catalog.=) 'u'
+          AND procedure.prosupport OPERATOR(pg_catalog.=) 0
+          AND procedure.proconfig OPERATOR(pg_catalog.=)
+                  ARRAY['search_path=pg_catalog, pg_temp']
+                      ::pg_catalog.text[]
+          AND pg_catalog.md5(procedure.prosrc)
+                  OPERATOR(pg_catalog.=)
+                  'c2980482b2b93b9e53511146f1fa8b47'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM pg_catalog.aclexplode(
+                  coalesce(
+                      procedure.proacl,
+                      pg_catalog.acldefault(
+                          'f', procedure.proowner))) acl
+              WHERE (
+                  acl.grantee OPERATOR(pg_catalog.=) 0
+                  AND acl.privilege_type OPERATOR(pg_catalog.=) 'EXECUTE')
+                 OR (
+                  acl.grantee OPERATOR(pg_catalog.<>)
+                          procedure.proowner
+                  AND acl.is_grantable)))
+    THEN
+        RAISE EXCEPTION
+            'managed bm25_request_compaction wrapper definition mismatch';
+    END IF;
+END
+$$;
+
+COMMIT;
+
+\echo 'bm25_request_compaction() ready.'

--- a/scripts/durable_compaction/README.md
+++ b/scripts/durable_compaction/README.md
@@ -5,18 +5,27 @@ callback to [pg_durable](https://github.com/microsoft/pg_durable). The
 extension does not create cluster roles, change authentication, or depend on
 pg_durable at build or install time.
 
-This adapter requires a released pg_durable build that provides:
+> **Merge blocker:** do not merge this adapter until
+> [microsoft/pg_durable#354](https://github.com/microsoft/pg_durable/pull/354)
+> lands in a release. That change currently targets pg_durable 0.2.7.
+
+The required pg_durable build provides:
 
 ```sql
-df.loop(body text, condition text, on_error text)
-df.start(..., transaction_mode => 'new')
+df.loop(body text, condition text)
+df.start(
+    ...,
+    transaction_mode => 'new',
+    max_attempts => 5,
+    max_backoff => '16 seconds',
+    on_failure => 'continue')
 ```
 
-No released pg_durable version contains the three-argument `df.loop` at the
-time this draft was created. Both scripts check the exact extension-owned
-catalog signature before any managed side effect. Once upstream publishes
-the capability, update the localized preflight comments and add the released
-minimum version without changing the wrapper body.
+Released pg_durable v0.2.6 and current upstream `main` do not contain the
+failure policy. Both scripts check the exact seven-argument,
+extension-owned `df.start` catalog signature before any managed side effect.
+Once #354 is released, replace the localized capability-only message with the
+released minimum version.
 
 ## Prerequisites
 
@@ -111,21 +120,28 @@ The wrapper submits:
 
 ```sql
 df.start(
-    df.loop(body, condition, on_error => 'continue'),
+    df.loop(body, condition),
     label => 'bm25-compact-' || index_oid,
-    transaction_mode => 'new')
+    transaction_mode => 'new',
+    max_attempts => 5,
+    max_backoff => '16 seconds',
+    on_failure => 'continue')
 ```
 
 `transaction_mode => 'new'` persists the request in an independent
 transaction, which is required because pg_textsearch invokes callbacks from a
 late transaction callback and discards their local transactional effects.
-`on_error => 'continue'` lets a concurrent compactor, transient lock error,
-or other failed step return to the physical-state condition instead of
-stranding the loop immediately. Every iteration revalidates physical
-identity and compaction debt.
+The #354 instance policy retries a failed node up to five times with capped
+exponential backoff. Once those attempts are exhausted,
+`on_failure => 'continue'` abandons that iteration and starts the next one.
+Every iteration revalidates physical identity and compaction debt.
 
 This slice provides per-index submission only. It does not install a
 recurring schedule or fleet-wide sweep.
+
+The recurring registration planned for the next PR must use the same #354
+`df.start(..., on_failure => 'continue')` policy. It must not add policy
+arguments to `df.loop`.
 
 ## Test
 

--- a/scripts/durable_compaction/README.md
+++ b/scripts/durable_compaction/README.md
@@ -7,7 +7,8 @@ pg_durable at build or install time.
 
 > **Merge blocker:** do not merge this adapter until
 > [microsoft/pg_durable#354](https://github.com/microsoft/pg_durable/pull/354)
-> lands in a release. That change currently targets pg_durable 0.2.7.
+> lands in a release. v0.2.7 shipped without it and #354 is still an open
+> draft.
 
 The required pg_durable build provides:
 
@@ -21,11 +22,10 @@ df.start(
     on_failure => 'continue')
 ```
 
-Released pg_durable v0.2.6 and current upstream `main` do not contain the
-failure policy. Both scripts check the exact seven-argument,
-extension-owned `df.start` catalog signature before any managed side effect.
-Once #354 is released, replace the localized capability-only message with the
-released minimum version.
+No released pg_durable contains the failure policy. Both scripts check the
+exact seven-argument, extension-owned `df.start` catalog signature before any
+managed side effect. Once #354 is released, replace the localized
+capability-only message with the released minimum version.
 
 ## Prerequisites
 
@@ -88,14 +88,20 @@ the selected writer. Omit `writer_role` to grant no writer.
 
 ## Configure
 
-After the callback-dispatch branch is present, configure settings at a scope
-visible to both writers and worker sessions:
+Set the callback and threshold at a scope visible to both writers and worker
+sessions:
 
 ```conf
-pg_textsearch.compaction_mode = 'background'
 pg_textsearch.compaction_request_function = \
     'public.bm25_request_compaction'
 pg_textsearch.segments_per_level = 8
+```
+
+Background dispatch is a per-index option, so enable it on each index that
+should use the adapter:
+
+```sql
+ALTER INDEX docs_idx SET (compaction = 'background');
 ```
 
 The wrapper accepts only BM25 indexes. It rejects temporary indexes and
@@ -131,8 +137,8 @@ df.start(
 `transaction_mode => 'new'` persists the request in an independent
 transaction, which is required because pg_textsearch invokes callbacks from a
 late transaction callback and discards their local transactional effects.
-The #354 instance policy retries a failed node up to five times with capped
-exponential backoff. Once those attempts are exhausted,
+The #354 instance policy allows a failed node five attempts total, with
+capped exponential backoff. Once those attempts are exhausted,
 `on_failure => 'continue'` abandons that iteration and starts the next one.
 Every iteration revalidates physical identity and compaction debt.
 

--- a/scripts/durable_compaction/README.md
+++ b/scripts/durable_compaction/README.md
@@ -1,0 +1,149 @@
+# Per-index background compaction with pg_durable
+
+These operator-managed scripts adapt pg_textsearch's per-index compaction
+callback to [pg_durable](https://github.com/microsoft/pg_durable). The
+extension does not create cluster roles, change authentication, or depend on
+pg_durable at build or install time.
+
+This adapter requires a released pg_durable build that provides:
+
+```sql
+df.loop(body text, condition text, on_error text)
+df.start(..., transaction_mode => 'new')
+```
+
+No released pg_durable version contains the three-argument `df.loop` at the
+time this draft was created. Both scripts check the exact extension-owned
+catalog signature before any managed side effect. Once upstream publishes
+the capability, update the localized preflight comments and add the released
+minimum version without changing the wrapper body.
+
+## Prerequisites
+
+Preload both libraries, select the application database for pg_durable, and
+restart PostgreSQL:
+
+```conf
+shared_preload_libraries = 'pg_durable,pg_textsearch'
+pg_durable.database = 'application_database'
+```
+
+Install both extensions and the BM25 indexes in that database. Choose a
+non-superuser role that owns the indexes and one or more non-superuser writer
+roles.
+
+pg_durable opens worker connections as the submitted role without supplying
+a password. `textsearch_compactor` is intentionally passwordless. Configure
+a scoped peer/ident mapping (or an equivalent authenticated passwordless
+route) and set `PGHOST` in the PostgreSQL service environment to the socket
+directory. Do not use `trust` outside a disposable test cluster.
+
+Revoke `CREATE` on `public` from every untrusted role before running the
+scripts. The request wrapper is a `SECURITY DEFINER` function in that schema.
+
+## Install
+
+Run both scripts as a database superuser in `pg_durable.database`:
+
+```sh
+psql -d application_database \
+  -f scripts/durable_compaction/01_setup_role.sql \
+  -v index_owner=app_owner
+
+psql -d application_database \
+  -f scripts/durable_compaction/02_wrapper.sql \
+  -v writer_role=app_writer
+```
+
+Run `01_setup_role.sql` once for every role that owns BM25 indexes. It creates
+`textsearch_compactor` only when absent, then grants inherited owner
+membership with `SET FALSE`. Existing roles fail closed if they have
+credentials, privileged attributes, an unsafe connection limit or role
+setting, unexpected membership paths, inbound members, or unexpected owned
+objects anywhere in the cluster.
+
+A clean rerun permits only the exact managed
+`public.bm25_request_compaction(regclass)` ownership dependency. The
+allowlist authenticates its body hash, language, signature, owner,
+`SECURITY DEFINER` flag, fixed `search_path`, volatility, parallel safety,
+leakproof state, and ACL. `PUBLIC` execution and non-owner grant options are
+rejected rather than silently repaired.
+
+`02_wrapper.sql` also fails closed on a hostile or drifted existing wrapper.
+Before replacing an absent or exact managed wrapper, it commits a real
+`SELECT 1` task as `textsearch_compactor` and waits for completion. This
+checks worker authentication and execution, not just catalog shape.
+Reinstallation then recreates the wrapper to discard stale ACLs, removes
+named default-privilege grants, and grants non-delegable `EXECUTE` only to
+the selected writer. Omit `writer_role` to grant no writer.
+
+## Configure
+
+After the callback-dispatch branch is present, configure settings at a scope
+visible to both writers and worker sessions:
+
+```conf
+pg_textsearch.compaction_mode = 'background'
+pg_textsearch.compaction_request_function = \
+    'public.bm25_request_compaction'
+pg_textsearch.segments_per_level = 8
+```
+
+The wrapper accepts only BM25 indexes. It rejects temporary indexes and
+requires `session_user` to have `INSERT` on the indexed table or one of its
+partition ancestors. Approved writers receive wrapper execution only; they
+do not receive `df` schema access or execution on the private physical-target
+helpers.
+
+Each request captures the database OID, relation OID, tablespace OID, and
+relfilenumber. The durable loop calls only:
+
+```sql
+bm25_compact_step_if_current(oid, oid, oid, oid)
+bm25_needs_compaction_if_current(oid, oid, oid, oid)
+```
+
+A dropped, recreated, reindexed, moved, temporary, or wrong-access-method
+target returns `false` without touching replacement storage. A live target
+still enforces index ownership.
+
+The wrapper submits:
+
+```sql
+df.start(
+    df.loop(body, condition, on_error => 'continue'),
+    label => 'bm25-compact-' || index_oid,
+    transaction_mode => 'new')
+```
+
+`transaction_mode => 'new'` persists the request in an independent
+transaction, which is required because pg_textsearch invokes callbacks from a
+late transaction callback and discards their local transactional effects.
+`on_error => 'continue'` lets a concurrent compactor, transient lock error,
+or other failed step return to the physical-state condition instead of
+stranding the loop immediately. Every iteration revalidates physical
+identity and compaction debt.
+
+This slice provides per-index submission only. It does not install a
+recurring schedule or fleet-wide sweep.
+
+## Test
+
+The static shape checks require only the source tree:
+
+```sh
+make test-durable-static
+```
+
+The live harness creates a disposable local cluster and requires compatible
+pg_durable and pg_textsearch libraries installed for the selected
+`PG_CONFIG`:
+
+```sh
+make install
+make test-durable
+```
+
+The harness pins every PostgreSQL binary to that `PG_CONFIG`, checks role and
+wrapper fail-closed behavior, verifies owner-only helper ACLs, and confirms
+that a direct request survives caller rollback.

--- a/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
@@ -57,7 +57,7 @@ CREATE FUNCTION @extschema@.bm25_needs_compaction_if_current(
     relfilenumber oid)
 RETURNS boolean
 AS 'MODULE_PATHNAME', 'tp_needs_compaction_if_current'
-LANGUAGE C STABLE STRICT;
+LANGUAGE C VOLATILE STRICT;
 
 REVOKE ALL ON FUNCTION
     @extschema@.bm25_compact_step_if_current(oid, oid, oid, oid),

--- a/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
@@ -77,29 +77,30 @@ BEGIN
                grantee.rolname AS grantee_name
         FROM pg_catalog.pg_extension extension
              JOIN pg_catalog.pg_depend dependency
-               ON dependency.refclassid =
+               ON dependency.refclassid OPERATOR(pg_catalog.=)
                       'pg_catalog.pg_extension'::pg_catalog.regclass
-              AND dependency.refobjid = extension.oid
-              AND dependency.classid =
+              AND dependency.refobjid OPERATOR(pg_catalog.=) extension.oid
+              AND dependency.classid OPERATOR(pg_catalog.=)
                       'pg_catalog.pg_proc'::pg_catalog.regclass
-              AND dependency.deptype = 'e'
+              AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
              JOIN pg_catalog.pg_proc procedure
-               ON procedure.oid = dependency.objid
+               ON procedure.oid OPERATOR(pg_catalog.=) dependency.objid
              JOIN pg_catalog.pg_namespace namespace
-               ON namespace.oid = procedure.pronamespace
+               ON namespace.oid OPERATOR(pg_catalog.=)
+                      procedure.pronamespace
              CROSS JOIN LATERAL pg_catalog.aclexplode(
                  coalesce(
                      procedure.proacl,
                      pg_catalog.acldefault(
                          'f', procedure.proowner))) acl
              JOIN pg_catalog.pg_roles grantee
-               ON grantee.oid = acl.grantee
-        WHERE extension.extname = 'pg_textsearch'
-          AND procedure.proname IN (
+               ON grantee.oid OPERATOR(pg_catalog.=) acl.grantee
+        WHERE extension.extname OPERATOR(pg_catalog.=) 'pg_textsearch'
+          AND procedure.proname OPERATOR(pg_catalog.=) ANY (ARRAY[
                   'bm25_compact_step_if_current',
-                  'bm25_needs_compaction_if_current')
-          AND procedure.pronargs = 4
-          AND acl.grantee <> procedure.proowner
+                  'bm25_needs_compaction_if_current'])
+          AND procedure.pronargs OPERATOR(pg_catalog.=) 4
+          AND acl.grantee OPERATOR(pg_catalog.<>) procedure.proowner
     LOOP
         EXECUTE pg_catalog.format(
             'REVOKE ALL ON FUNCTION %I.%I('

--- a/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.4.0--1.5.0-dev.sql
@@ -41,6 +41,77 @@ LANGUAGE C VOLATILE STRICT;
 COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
     'Run at most one compaction pass and report whether one ran, letting a caller spread a cascade over several transactions. A published pass is not undone by ROLLBACK.';
 
+CREATE FUNCTION @extschema@.bm25_compact_step_if_current(
+    index_oid oid,
+    database_oid oid,
+    tablespace_oid oid,
+    relfilenumber oid)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tp_compact_index_step_if_current'
+LANGUAGE C VOLATILE STRICT;
+
+CREATE FUNCTION @extschema@.bm25_needs_compaction_if_current(
+    index_oid oid,
+    database_oid oid,
+    tablespace_oid oid,
+    relfilenumber oid)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tp_needs_compaction_if_current'
+LANGUAGE C STABLE STRICT;
+
+REVOKE ALL ON FUNCTION
+    @extschema@.bm25_compact_step_if_current(oid, oid, oid, oid),
+    @extschema@.bm25_needs_compaction_if_current(oid, oid, oid, oid)
+FROM PUBLIC;
+
+-- Named default privileges are copied onto new functions and survive a
+-- PUBLIC-only revoke. Keep these worker helpers owner-only until the
+-- operator explicitly grants the dedicated compactor role.
+DO $$
+DECLARE
+    helper record;
+BEGIN
+    FOR helper IN
+        SELECT namespace.nspname,
+               procedure.proname,
+               grantee.rolname AS grantee_name
+        FROM pg_catalog.pg_extension extension
+             JOIN pg_catalog.pg_depend dependency
+               ON dependency.refclassid =
+                      'pg_catalog.pg_extension'::pg_catalog.regclass
+              AND dependency.refobjid = extension.oid
+              AND dependency.classid =
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.deptype = 'e'
+             JOIN pg_catalog.pg_proc procedure
+               ON procedure.oid = dependency.objid
+             JOIN pg_catalog.pg_namespace namespace
+               ON namespace.oid = procedure.pronamespace
+             CROSS JOIN LATERAL pg_catalog.aclexplode(
+                 coalesce(
+                     procedure.proacl,
+                     pg_catalog.acldefault(
+                         'f', procedure.proowner))) acl
+             JOIN pg_catalog.pg_roles grantee
+               ON grantee.oid = acl.grantee
+        WHERE extension.extname = 'pg_textsearch'
+          AND procedure.proname IN (
+                  'bm25_compact_step_if_current',
+                  'bm25_needs_compaction_if_current')
+          AND procedure.pronargs = 4
+          AND acl.grantee <> procedure.proowner
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON FUNCTION %I.%I('
+            'pg_catalog.oid, pg_catalog.oid, pg_catalog.oid, pg_catalog.oid'
+            ') FROM %I CASCADE',
+            helper.nspname,
+            helper.proname,
+            helper.grantee_name);
+    END LOOP;
+END
+$$;
+
 -- VOLATILE because it reads live metapage state, and PARALLEL
 -- RESTRICTED to match bm25_level_counts.  Every level counts: the top
 -- level compacts into itself, so its debt is reducible like any

--- a/sql/pg_textsearch--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.5.0-dev.sql
@@ -281,6 +281,77 @@ LANGUAGE C VOLATILE STRICT;
 COMMENT ON FUNCTION @extschema@.bm25_compact_step(regclass) IS
     'Run at most one compaction pass and report whether one ran, letting a caller spread a cascade over several transactions. A published pass is not undone by ROLLBACK.';
 
+CREATE FUNCTION @extschema@.bm25_compact_step_if_current(
+    index_oid oid,
+    database_oid oid,
+    tablespace_oid oid,
+    relfilenumber oid)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tp_compact_index_step_if_current'
+LANGUAGE C VOLATILE STRICT;
+
+CREATE FUNCTION @extschema@.bm25_needs_compaction_if_current(
+    index_oid oid,
+    database_oid oid,
+    tablespace_oid oid,
+    relfilenumber oid)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'tp_needs_compaction_if_current'
+LANGUAGE C STABLE STRICT;
+
+REVOKE ALL ON FUNCTION
+    @extschema@.bm25_compact_step_if_current(oid, oid, oid, oid),
+    @extschema@.bm25_needs_compaction_if_current(oid, oid, oid, oid)
+FROM PUBLIC;
+
+-- Named default privileges are copied onto new functions and survive a
+-- PUBLIC-only revoke. Keep these worker helpers owner-only until the
+-- operator explicitly grants the dedicated compactor role.
+DO $$
+DECLARE
+    helper record;
+BEGIN
+    FOR helper IN
+        SELECT namespace.nspname,
+               procedure.proname,
+               grantee.rolname AS grantee_name
+        FROM pg_catalog.pg_extension extension
+             JOIN pg_catalog.pg_depend dependency
+               ON dependency.refclassid =
+                      'pg_catalog.pg_extension'::pg_catalog.regclass
+              AND dependency.refobjid = extension.oid
+              AND dependency.classid =
+                      'pg_catalog.pg_proc'::pg_catalog.regclass
+              AND dependency.deptype = 'e'
+             JOIN pg_catalog.pg_proc procedure
+               ON procedure.oid = dependency.objid
+             JOIN pg_catalog.pg_namespace namespace
+               ON namespace.oid = procedure.pronamespace
+             CROSS JOIN LATERAL pg_catalog.aclexplode(
+                 coalesce(
+                     procedure.proacl,
+                     pg_catalog.acldefault(
+                         'f', procedure.proowner))) acl
+             JOIN pg_catalog.pg_roles grantee
+               ON grantee.oid = acl.grantee
+        WHERE extension.extname = 'pg_textsearch'
+          AND procedure.proname IN (
+                  'bm25_compact_step_if_current',
+                  'bm25_needs_compaction_if_current')
+          AND procedure.pronargs = 4
+          AND acl.grantee <> procedure.proowner
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON FUNCTION %I.%I('
+            'pg_catalog.oid, pg_catalog.oid, pg_catalog.oid, pg_catalog.oid'
+            ') FROM %I CASCADE',
+            helper.nspname,
+            helper.proname,
+            helper.grantee_name);
+    END LOOP;
+END
+$$;
+
 -- VOLATILE because it reads live metapage state, and PARALLEL
 -- RESTRICTED to match bm25_level_counts.  Every level counts: the top
 -- level compacts into itself, so its debt is reducible like any

--- a/sql/pg_textsearch--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.5.0-dev.sql
@@ -317,29 +317,30 @@ BEGIN
                grantee.rolname AS grantee_name
         FROM pg_catalog.pg_extension extension
              JOIN pg_catalog.pg_depend dependency
-               ON dependency.refclassid =
+               ON dependency.refclassid OPERATOR(pg_catalog.=)
                       'pg_catalog.pg_extension'::pg_catalog.regclass
-              AND dependency.refobjid = extension.oid
-              AND dependency.classid =
+              AND dependency.refobjid OPERATOR(pg_catalog.=) extension.oid
+              AND dependency.classid OPERATOR(pg_catalog.=)
                       'pg_catalog.pg_proc'::pg_catalog.regclass
-              AND dependency.deptype = 'e'
+              AND dependency.deptype OPERATOR(pg_catalog.=) 'e'
              JOIN pg_catalog.pg_proc procedure
-               ON procedure.oid = dependency.objid
+               ON procedure.oid OPERATOR(pg_catalog.=) dependency.objid
              JOIN pg_catalog.pg_namespace namespace
-               ON namespace.oid = procedure.pronamespace
+               ON namespace.oid OPERATOR(pg_catalog.=)
+                      procedure.pronamespace
              CROSS JOIN LATERAL pg_catalog.aclexplode(
                  coalesce(
                      procedure.proacl,
                      pg_catalog.acldefault(
                          'f', procedure.proowner))) acl
              JOIN pg_catalog.pg_roles grantee
-               ON grantee.oid = acl.grantee
-        WHERE extension.extname = 'pg_textsearch'
-          AND procedure.proname IN (
+               ON grantee.oid OPERATOR(pg_catalog.=) acl.grantee
+        WHERE extension.extname OPERATOR(pg_catalog.=) 'pg_textsearch'
+          AND procedure.proname OPERATOR(pg_catalog.=) ANY (ARRAY[
                   'bm25_compact_step_if_current',
-                  'bm25_needs_compaction_if_current')
-          AND procedure.pronargs = 4
-          AND acl.grantee <> procedure.proowner
+                  'bm25_needs_compaction_if_current'])
+          AND procedure.pronargs OPERATOR(pg_catalog.=) 4
+          AND acl.grantee OPERATOR(pg_catalog.<>) procedure.proowner
     LOOP
         EXECUTE pg_catalog.format(
             'REVOKE ALL ON FUNCTION %I.%I('

--- a/sql/pg_textsearch--1.5.0-dev.sql
+++ b/sql/pg_textsearch--1.5.0-dev.sql
@@ -297,7 +297,7 @@ CREATE FUNCTION @extschema@.bm25_needs_compaction_if_current(
     relfilenumber oid)
 RETURNS boolean
 AS 'MODULE_PATHNAME', 'tp_needs_compaction_if_current'
-LANGUAGE C STABLE STRICT;
+LANGUAGE C VOLATILE STRICT;
 
 REVOKE ALL ON FUNCTION
     @extschema@.bm25_compact_step_if_current(oid, oid, oid, oid),

--- a/src/access/compaction_api.c
+++ b/src/access/compaction_api.c
@@ -107,6 +107,8 @@ tp_open_current_bm25_index(
 	if (RelationUsesLocalBuffers(index_rel) ||
 		RELATION_IS_OTHER_TEMP(index_rel) || index_rel->rd_indam == NULL ||
 		index_rel->rd_indam->ambuild != tp_build ||
+		index_rel->rd_index == NULL || !index_rel->rd_index->indisvalid ||
+		!index_rel->rd_index->indisready || !index_rel->rd_index->indislive ||
 		index_rel->rd_locator.spcOid != tablespaceoid ||
 		index_rel->rd_locator.dbOid != databaseoid ||
 		index_rel->rd_locator.relNumber != relfilenumber)

--- a/src/access/compaction_api.c
+++ b/src/access/compaction_api.c
@@ -83,6 +83,49 @@ tp_open_bm25_index(Oid indexoid, LOCKMODE lockmode, bool need_owner)
 	return index_rel;
 }
 
+/*
+ * Durable tasks carry both the catalog OID and physical locator. Return NULL
+ * when the target is stale; errors from a live target still propagate.
+ */
+static Relation
+tp_open_current_bm25_index(
+		Oid			  indexoid,
+		Oid			  databaseoid,
+		Oid			  tablespaceoid,
+		RelFileNumber relfilenumber,
+		LOCKMODE	  lockmode)
+{
+	Relation index_rel;
+
+	if (databaseoid != MyDatabaseId)
+		return NULL;
+
+	index_rel = try_relation_open(indexoid, lockmode);
+	if (index_rel == NULL)
+		return NULL;
+
+	if (RelationUsesLocalBuffers(index_rel) ||
+		RELATION_IS_OTHER_TEMP(index_rel) || index_rel->rd_indam == NULL ||
+		index_rel->rd_indam->ambuild != tp_build ||
+		index_rel->rd_locator.spcOid != tablespaceoid ||
+		index_rel->rd_locator.dbOid != databaseoid ||
+		index_rel->rd_locator.relNumber != relfilenumber)
+	{
+		relation_close(index_rel, lockmode);
+		return NULL;
+	}
+
+	if (!object_ownercheck(RelationRelationId, indexoid, GetUserId()))
+	{
+		char *relname = pstrdup(RelationGetRelationName(index_rel));
+
+		relation_close(index_rel, lockmode);
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_INDEX, relname);
+	}
+
+	return index_rel;
+}
+
 PG_FUNCTION_INFO_V1(tp_level_counts);
 
 Datum
@@ -198,4 +241,86 @@ tp_compact_index_step(PG_FUNCTION_ARGS)
 	PG_END_TRY();
 
 	PG_RETURN_BOOL(pass_ran);
+}
+
+PG_FUNCTION_INFO_V1(tp_compact_index_step_if_current);
+
+Datum
+tp_compact_index_step_if_current(PG_FUNCTION_ARGS)
+{
+	Oid				   indexoid		 = PG_GETARG_OID(0);
+	Oid				   databaseoid	 = PG_GETARG_OID(1);
+	Oid				   tablespaceoid = PG_GETARG_OID(2);
+	RelFileNumber	   relfilenumber = PG_GETARG_OID(3);
+	Relation		   index_rel;
+	TpLocalIndexState *index_state;
+	bool			   pass_ran;
+
+	if (RecoveryInProgress())
+		ereport(ERROR,
+				(errcode(ERRCODE_READ_ONLY_SQL_TRANSACTION),
+				 errmsg("cannot compact a bm25 index during recovery")));
+
+	index_rel = tp_open_current_bm25_index(
+			indexoid,
+			databaseoid,
+			tablespaceoid,
+			relfilenumber,
+			RowExclusiveLock);
+	if (index_rel == NULL)
+		PG_RETURN_BOOL(false);
+
+	PreventCommandIfReadOnly("bm25 index compaction");
+
+	index_state = tp_get_local_index_state(indexoid);
+	if (index_state == NULL)
+	{
+		char *relname = pstrdup(RelationGetRelationName(index_rel));
+
+		relation_close(index_rel, RowExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not get index state for \"%s\"", relname)));
+	}
+
+	tp_acquire_index_lock(index_state, LW_EXCLUSIVE);
+	PG_TRY();
+	{
+		pass_ran = tp_compact_step(index_state, index_rel);
+	}
+	PG_FINALLY();
+	{
+		tp_release_index_lock(index_state);
+		relation_close(index_rel, RowExclusiveLock);
+	}
+	PG_END_TRY();
+
+	PG_RETURN_BOOL(pass_ran);
+}
+
+PG_FUNCTION_INFO_V1(tp_needs_compaction_if_current);
+
+Datum
+tp_needs_compaction_if_current(PG_FUNCTION_ARGS)
+{
+	Oid			  indexoid		= PG_GETARG_OID(0);
+	Oid			  databaseoid	= PG_GETARG_OID(1);
+	Oid			  tablespaceoid = PG_GETARG_OID(2);
+	RelFileNumber relfilenumber = PG_GETARG_OID(3);
+	Relation	  index_rel;
+	bool		  needed;
+
+	index_rel = tp_open_current_bm25_index(
+			indexoid,
+			databaseoid,
+			tablespaceoid,
+			relfilenumber,
+			AccessShareLock);
+	if (index_rel == NULL)
+		PG_RETURN_BOOL(false);
+
+	needed = tp_compaction_needed(index_rel);
+	relation_close(index_rel, AccessShareLock);
+
+	PG_RETURN_BOOL(needed);
 }

--- a/test/scripts/durable_compaction.sh
+++ b/test/scripts/durable_compaction.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Focused structural and live test for the per-index pg_durable adapter.
-# The live portion requires pg_durable with the three-argument df.loop()
-# API and is intentionally separate from test-all.
+# The live portion requires pg_durable's df.start() failure policy and is
+# intentionally separate from test-all.
 
 set -euo pipefail
 
@@ -34,6 +34,15 @@ assert_contains() {
 
     grep -Fq -- "${text}" "${file}" \
         || fail "${file} does not contain: ${text}"
+}
+
+assert_not_contains() {
+    local file="$1"
+    local text="$2"
+
+    if grep -Fq -- "${text}" "${file}"; then
+        fail "${file} unexpectedly contains: ${text}"
+    fi
 }
 
 assert_sql_true() {
@@ -97,7 +106,11 @@ static_checks() {
     assert_contains "${wrapper}" "SECURITY DEFINER"
     assert_contains "${wrapper}" \
         "SET search_path = pg_catalog, pg_temp"
-    assert_contains "${wrapper}" "on_error => 'continue'"
+    assert_contains "${wrapper}" "df.loop(body, cond)"
+    assert_not_contains "${wrapper}" \
+        "df.loop(body, cond, on_error => 'continue')"
+    assert_contains "${wrapper}" "max_attempts     => 5"
+    assert_contains "${wrapper}" "on_failure      => 'continue'"
     assert_contains "${wrapper}" "transaction_mode => 'new'"
     assert_contains "${wrapper}" "pg_textsearch_compaction.canary_instance"
     assert_contains "${wrapper}" \
@@ -171,13 +184,14 @@ psql_super -c "ALTER DEFAULT PRIVILEGES FOR ROLE postgres
     GRANT EXECUTE ON FUNCTIONS TO default_privilege_writer;"
 psql_super -c "CREATE EXTENSION pg_textsearch WITH SCHEMA ${EXT_SCHEMA};"
 
-loop_policy_available=$(psql_super -c "SELECT pg_catalog.to_regprocedure(
-    'df.loop(pg_catalog.text,pg_catalog.text,pg_catalog.text)')
+failure_policy_available=$(psql_super -c "SELECT pg_catalog.to_regprocedure(
+    'df.start(pg_catalog.text,pg_catalog.text,pg_catalog.text,'
+    'pg_catalog.text,pg_catalog.int4,pg_catalog.interval,pg_catalog.text)')
     IS NOT NULL;")
-if [ "${loop_policy_available}" != "t" ]; then
+if [ "${failure_policy_available}" != "t" ]; then
     if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
         -v index_owner=missing_owner >/dev/null 2>&1; then
-        fail "role setup accepted pg_durable without loop on_error"
+        fail "role setup accepted pg_durable without start failure policy"
     fi
     assert_sql_true "failed role preflight created no compactor role" \
         "SELECT NOT EXISTS (
@@ -194,13 +208,13 @@ SQL
         'public.bm25_request_compaction(regclass)'::regprocedure::oid;")
     if psql_super -f "${GLUE_DIR}/02_wrapper.sql" \
         -v writer_role=missing_writer >/dev/null 2>&1; then
-        fail "wrapper setup accepted pg_durable without loop on_error"
+        fail "wrapper setup accepted pg_durable without start failure policy"
     fi
     [ "${preflight_oid}" = "$(psql_super -c "SELECT
         'public.bm25_request_compaction(regclass)'::regprocedure::oid;")" ] \
         || fail "failed wrapper preflight replaced the existing wrapper"
     printf '%s\n' \
-        "Live positive checks skipped: df.loop(..., on_error) unavailable."
+        "Live positive checks skipped: df.start() failure policy unavailable."
     exit 0
 fi
 

--- a/test/scripts/durable_compaction.sh
+++ b/test/scripts/durable_compaction.sh
@@ -79,6 +79,7 @@ static_checks() {
     assert_contains "${compaction_api}" "tp_open_current_bm25_index"
     assert_contains "${compaction_api}" "tp_compact_index_step_if_current"
     assert_contains "${compaction_api}" "tp_needs_compaction_if_current"
+    assert_contains "${compaction_api}" "!index_rel->rd_index->indisvalid"
 
     for sql in "${fresh_sql}" "${upgrade_sql}"; do
         assert_contains "${sql}" \
@@ -99,6 +100,8 @@ static_checks() {
     assert_contains "${wrapper}" "on_error => 'continue'"
     assert_contains "${wrapper}" "transaction_mode => 'new'"
     assert_contains "${wrapper}" "pg_textsearch_compaction.canary_instance"
+    assert_contains "${wrapper}" \
+        "IF NOT FOUND OR relfilenumber IS NULL THEN"
     assert_contains "${GLUE_DIR}/README.md" \
         "public.bm25_request_compaction(regclass)"
 
@@ -162,15 +165,50 @@ PGHOST="${SOCKET_DIR}" "${PGBINDIR}/pg_ctl" start -D "${DATA_DIR}" \
 psql_super -c "CREATE EXTENSION pg_durable;"
 psql_super -c "CREATE SCHEMA ${EXT_SCHEMA};"
 psql_super -c "GRANT USAGE ON SCHEMA ${EXT_SCHEMA} TO PUBLIC;"
+psql_super -c "CREATE ROLE default_privilege_writer LOGIN;"
+psql_super -c "ALTER DEFAULT PRIVILEGES FOR ROLE postgres
+    IN SCHEMA ${EXT_SCHEMA}
+    GRANT EXECUTE ON FUNCTIONS TO default_privilege_writer;"
 psql_super -c "CREATE EXTENSION pg_textsearch WITH SCHEMA ${EXT_SCHEMA};"
 
-assert_sql_true "released pg_durable loop policy is available" \
-    "SELECT pg_catalog.to_regprocedure(
-        'df.loop(pg_catalog.text,pg_catalog.text,pg_catalog.text)')
-        IS NOT NULL;"
+loop_policy_available=$(psql_super -c "SELECT pg_catalog.to_regprocedure(
+    'df.loop(pg_catalog.text,pg_catalog.text,pg_catalog.text)')
+    IS NOT NULL;")
+if [ "${loop_policy_available}" != "t" ]; then
+    if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+        -v index_owner=missing_owner >/dev/null 2>&1; then
+        fail "role setup accepted pg_durable without loop on_error"
+    fi
+    assert_sql_true "failed role preflight created no compactor role" \
+        "SELECT NOT EXISTS (
+            SELECT 1 FROM pg_catalog.pg_roles
+            WHERE rolname = 'textsearch_compactor');"
+
+    psql_super <<'SQL'
+CREATE FUNCTION public.bm25_request_compaction(pg_catalog.regclass)
+RETURNS pg_catalog.text
+LANGUAGE sql
+RETURN 'preflight-sentinel'::pg_catalog.text;
+SQL
+    preflight_oid=$(psql_super -c "SELECT
+        'public.bm25_request_compaction(regclass)'::regprocedure::oid;")
+    if psql_super -f "${GLUE_DIR}/02_wrapper.sql" \
+        -v writer_role=missing_writer >/dev/null 2>&1; then
+        fail "wrapper setup accepted pg_durable without loop on_error"
+    fi
+    [ "${preflight_oid}" = "$(psql_super -c "SELECT
+        'public.bm25_request_compaction(regclass)'::regprocedure::oid;")" ] \
+        || fail "failed wrapper preflight replaced the existing wrapper"
+    printf '%s\n' \
+        "Live positive checks skipped: df.loop(..., on_error) unavailable."
+    exit 0
+fi
 
 psql_super -c "CREATE ROLE app_owner LOGIN;"
 psql_super -c "CREATE ROLE app_writer LOGIN;"
+psql_super -c "ALTER DEFAULT PRIVILEGES FOR ROLE postgres
+    IN SCHEMA public
+    GRANT EXECUTE ON FUNCTIONS TO default_privilege_writer;"
 psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
     -v index_owner=app_owner >/dev/null
 
@@ -279,6 +317,20 @@ assert_sql_true "private helpers are available only to the compactor" \
         AND pg_catalog.has_function_privilege(
             'textsearch_compactor',
             '${EXT_SCHEMA}.bm25_needs_compaction_if_current(oid,oid,oid,oid)',
+            'EXECUTE');"
+assert_sql_true "named default helper grants were removed" \
+    "SELECT
+        NOT pg_catalog.has_function_privilege(
+            'default_privilege_writer',
+            '${EXT_SCHEMA}.bm25_compact_step_if_current(oid,oid,oid,oid)',
+            'EXECUTE')
+        AND NOT pg_catalog.has_function_privilege(
+            'default_privilege_writer',
+            '${EXT_SCHEMA}.bm25_needs_compaction_if_current(oid,oid,oid,oid)',
+            'EXECUTE')
+        AND NOT pg_catalog.has_function_privilege(
+            'default_privilege_writer',
+            'public.bm25_request_compaction(regclass)',
             'EXECUTE');"
 
 psql_super <<SQL

--- a/test/scripts/durable_compaction.sh
+++ b/test/scripts/durable_compaction.sh
@@ -1,0 +1,412 @@
+#!/bin/bash
+#
+# Focused structural and live test for the per-index pg_durable adapter.
+# The live portion requires pg_durable with the three-argument df.loop()
+# API and is intentionally separate from test-all.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+GLUE_DIR="${ROOT_DIR}/scripts/durable_compaction"
+DATA_DIR="${ROOT_DIR}/test/tmp_durable_compaction"
+SOCKET_DIR="${ROOT_DIR}"
+TEST_PORT=55447
+TEST_DB=durable_compaction_test
+EXT_SCHEMA=textsearch_ext
+PG_CONFIG="${PG_CONFIG:-pg_config}"
+PGBINDIR="$("${PG_CONFIG}" --bindir)"
+PKGLIBDIR="$("${PG_CONFIG}" --pkglibdir)"
+
+if [ "${DURABLE_PG_CONFIG_PROBE:-0}" = "1" ]; then
+    printf '%s|%s\n' "${PGBINDIR}" "${PKGLIBDIR}"
+    exit 0
+fi
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local file="$1"
+    local text="$2"
+
+    grep -Fq -- "${text}" "${file}" \
+        || fail "${file} does not contain: ${text}"
+}
+
+assert_sql_true() {
+    local description="$1"
+    local query="$2"
+    local result
+
+    result=$(psql_super -c "${query}")
+    [ "${result}" = "t" ] \
+        || fail "${description} (expected t, got ${result})"
+}
+
+wait_for_instance() {
+    local instance_id="$1"
+    local waited=0
+    local state
+
+    while [ "${waited}" -lt 60 ]; do
+        state=$(psql_super -c "SELECT status
+            FROM df.instances WHERE id = '${instance_id}';")
+        if [ "${state}" = "completed" ] || [ "${state}" = "failed" ] \
+            || [ "${state}" = "cancelled" ]; then
+            printf '%s\n' "${state}"
+            return
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    fail "durable instance ${instance_id} did not finish"
+}
+
+static_checks() {
+    local fresh_sql="${ROOT_DIR}/sql/pg_textsearch--1.5.0-dev.sql"
+    local upgrade_sql="${ROOT_DIR}/sql/pg_textsearch--1.4.0--1.5.0-dev.sql"
+    local wrapper="${GLUE_DIR}/02_wrapper.sql"
+
+    [ ! -e "${GLUE_DIR}/03_backstop.sql" ] \
+        || fail "03_backstop.sql is outside this PR"
+
+    local compaction_api="${ROOT_DIR}/src/access/compaction_api.c"
+
+    assert_contains "${compaction_api}" "tp_open_current_bm25_index"
+    assert_contains "${compaction_api}" "tp_compact_index_step_if_current"
+    assert_contains "${compaction_api}" "tp_needs_compaction_if_current"
+
+    for sql in "${fresh_sql}" "${upgrade_sql}"; do
+        assert_contains "${sql}" \
+            "bm25_compact_step_if_current(oid, oid, oid, oid)"
+        assert_contains "${sql}" \
+            "bm25_needs_compaction_if_current(oid, oid, oid, oid)"
+        assert_contains "${sql}" "REVOKE ALL ON FUNCTION"
+        assert_contains "${sql}" "pg_catalog.aclexplode"
+    done
+
+    assert_contains "${GLUE_DIR}/01_setup_role.sql" \
+        "pg_catalog.pg_shdepend"
+    assert_contains "${GLUE_DIR}/01_setup_role.sql" \
+        "WITH INHERIT TRUE, SET FALSE"
+    assert_contains "${wrapper}" "SECURITY DEFINER"
+    assert_contains "${wrapper}" \
+        "SET search_path = pg_catalog, pg_temp"
+    assert_contains "${wrapper}" "on_error => 'continue'"
+    assert_contains "${wrapper}" "transaction_mode => 'new'"
+    assert_contains "${wrapper}" "pg_textsearch_compaction.canary_instance"
+    assert_contains "${GLUE_DIR}/README.md" \
+        "public.bm25_request_compaction(regclass)"
+
+    printf 'Static pg_durable adapter checks passed.\n'
+}
+
+static_checks
+
+if [ "${DURABLE_STATIC_ONLY:-0}" = "1" ]; then
+    exit 0
+fi
+
+for library in pg_durable pg_textsearch; do
+    [ -f "${PKGLIBDIR}/${library}.so" ] \
+        || fail "${library}.so not found in ${PKGLIBDIR}"
+done
+
+psql_as() {
+    local role="$1"
+    shift
+    "${PGBINDIR}/psql" -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -U "${role}" -d "${TEST_DB}" -qAt -v ON_ERROR_STOP=1 "$@"
+}
+
+psql_super() {
+    psql_as postgres "$@"
+}
+
+cleanup() {
+    local status=$?
+
+    if [ -f "${DATA_DIR}/postmaster.pid" ]; then
+        "${PGBINDIR}/pg_ctl" stop -D "${DATA_DIR}" -m immediate \
+            >/dev/null 2>&1 || true
+    fi
+    rm -rf "${DATA_DIR}"
+    exit "${status}"
+}
+
+trap cleanup EXIT INT TERM
+
+rm -rf "${DATA_DIR}"
+mkdir -p "${DATA_DIR}"
+"${PGBINDIR}/initdb" -D "${DATA_DIR}" -U postgres \
+    --auth-local=trust --auth-host=reject >/dev/null
+{
+    printf "port = %s\n" "${TEST_PORT}"
+    printf "unix_socket_directories = '%s'\n" "${SOCKET_DIR}"
+    printf "listen_addresses = ''\n"
+    printf "shared_preload_libraries = 'pg_durable,pg_textsearch'\n"
+    printf "max_prepared_transactions = 10\n"
+    printf "pg_durable.database = '%s'\n" "${TEST_DB}"
+    printf "pg_durable.worker_role = 'postgres'\n"
+} >>"${DATA_DIR}/postgresql.conf"
+
+PGHOST="${SOCKET_DIR}" "${PGBINDIR}/pg_ctl" start -D "${DATA_DIR}" \
+    -l "${DATA_DIR}/postgres.log" -w >/dev/null
+"${PGBINDIR}/createdb" -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+    -U postgres "${TEST_DB}"
+
+psql_super -c "CREATE EXTENSION pg_durable;"
+psql_super -c "CREATE SCHEMA ${EXT_SCHEMA};"
+psql_super -c "GRANT USAGE ON SCHEMA ${EXT_SCHEMA} TO PUBLIC;"
+psql_super -c "CREATE EXTENSION pg_textsearch WITH SCHEMA ${EXT_SCHEMA};"
+
+assert_sql_true "released pg_durable loop policy is available" \
+    "SELECT pg_catalog.to_regprocedure(
+        'df.loop(pg_catalog.text,pg_catalog.text,pg_catalog.text)')
+        IS NOT NULL;"
+
+psql_super -c "CREATE ROLE app_owner LOGIN;"
+psql_super -c "CREATE ROLE app_writer LOGIN;"
+psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=app_owner >/dev/null
+
+psql_super -c "ALTER ROLE textsearch_compactor PASSWORD 'hostile';"
+if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=app_owner >/dev/null 2>&1; then
+    fail "role setup accepted credentials on an existing role"
+fi
+assert_sql_true "failed role reuse did not mutate owner membership" \
+    "SELECT NOT pg_catalog.pg_has_role(
+        'textsearch_compactor', 'app_owner', 'SET');"
+psql_super -c "ALTER ROLE textsearch_compactor PASSWORD NULL;"
+
+psql_super <<'SQL'
+CREATE FUNCTION public.bm25_request_compaction(pg_catalog.regclass)
+RETURNS pg_catalog.text
+LANGUAGE sql
+SECURITY DEFINER
+RETURN 'hostile-wrapper'::pg_catalog.text;
+ALTER FUNCTION public.bm25_request_compaction(pg_catalog.regclass)
+    OWNER TO textsearch_compactor;
+SQL
+
+hostile_oid=$(psql_super -c "SELECT
+    'public.bm25_request_compaction(regclass)'::regprocedure::oid;")
+if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=app_owner >/dev/null 2>&1; then
+    fail "role setup accepted a hostile managed wrapper"
+fi
+[ "${hostile_oid}" = "$(psql_super -c "SELECT
+    'public.bm25_request_compaction(regclass)'::regprocedure::oid;")" ] \
+    || fail "failed wrapper reuse replaced hostile state"
+psql_super -c "DROP FUNCTION
+    public.bm25_request_compaction(pg_catalog.regclass);"
+
+psql_super -f "${GLUE_DIR}/02_wrapper.sql" \
+    -v writer_role=app_writer >/dev/null
+psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=app_owner >/dev/null
+
+psql_super -c "CREATE ROLE delegable_writer LOGIN;"
+psql_super -c "GRANT EXECUTE ON FUNCTION
+    public.bm25_request_compaction(regclass)
+    TO delegable_writer WITH GRANT OPTION;"
+managed_oid=$(psql_super -c "SELECT
+    'public.bm25_request_compaction(regclass)'::regprocedure::oid;")
+if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=app_owner >/dev/null 2>&1; then
+    fail "role setup accepted a delegable wrapper ACL"
+fi
+[ "${managed_oid}" = "$(psql_super -c "SELECT
+    'public.bm25_request_compaction(regclass)'::regprocedure::oid;")" ] \
+    || fail "failed ACL validation replaced the managed wrapper"
+psql_super -c "REVOKE ALL ON FUNCTION
+    public.bm25_request_compaction(regclass) FROM delegable_writer;"
+psql_super -c "DROP ROLE delegable_writer;"
+
+assert_sql_true "compactor role has the exact safe attributes" \
+    "SELECT rolcanlogin AND rolinherit AND NOT rolsuper
+            AND NOT rolcreatedb AND NOT rolcreaterole
+            AND NOT rolreplication AND NOT rolbypassrls
+            AND rolconnlimit = -1
+     FROM pg_catalog.pg_roles
+     WHERE rolname = 'textsearch_compactor';"
+assert_sql_true "owner membership inherits but cannot SET ROLE" \
+    "SELECT member.inherit_option AND NOT member.set_option
+            AND NOT member.admin_option
+     FROM pg_catalog.pg_auth_members member
+     WHERE member.member = 'textsearch_compactor'::regrole
+       AND member.roleid = 'app_owner'::regrole;"
+assert_sql_true "wrapper has the intended security envelope" \
+    "SELECT procedure.prosecdef
+            AND procedure.proconfig =
+                ARRAY['search_path=pg_catalog, pg_temp']::text[]
+            AND procedure.proowner =
+                'textsearch_compactor'::regrole
+     FROM pg_catalog.pg_proc procedure
+     WHERE procedure.oid =
+        'public.bm25_request_compaction(regclass)'::regprocedure;"
+assert_sql_true "wrapper ACL is owner plus non-grantable writer" \
+    "SELECT NOT EXISTS (
+                SELECT 1
+                FROM pg_catalog.aclexplode(procedure.proacl) acl
+                WHERE acl.grantee = 0 OR acl.is_grantable)
+            AND pg_catalog.has_function_privilege(
+                'app_writer',
+                'public.bm25_request_compaction(regclass)',
+                'EXECUTE')
+     FROM pg_catalog.pg_proc procedure
+     WHERE procedure.oid =
+        'public.bm25_request_compaction(regclass)'::regprocedure;"
+assert_sql_true "private helpers are available only to the compactor" \
+    "SELECT
+        NOT pg_catalog.has_function_privilege(
+            'app_writer',
+            '${EXT_SCHEMA}.bm25_compact_step_if_current(oid,oid,oid,oid)',
+            'EXECUTE')
+        AND pg_catalog.has_function_privilege(
+            'textsearch_compactor',
+            '${EXT_SCHEMA}.bm25_compact_step_if_current(oid,oid,oid,oid)',
+            'EXECUTE')
+        AND NOT pg_catalog.has_function_privilege(
+            'app_writer',
+            '${EXT_SCHEMA}.bm25_needs_compaction_if_current(oid,oid,oid,oid)',
+            'EXECUTE')
+        AND pg_catalog.has_function_privilege(
+            'textsearch_compactor',
+            '${EXT_SCHEMA}.bm25_needs_compaction_if_current(oid,oid,oid,oid)',
+            'EXECUTE');"
+
+psql_super <<SQL
+CREATE TABLE adapter_docs (id integer PRIMARY KEY, body text);
+CREATE INDEX adapter_docs_idx ON adapter_docs
+    USING bm25(body) WITH (text_config = 'english');
+ALTER TABLE adapter_docs OWNER TO app_owner;
+ALTER INDEX adapter_docs_idx OWNER TO app_owner;
+GRANT INSERT ON adapter_docs TO app_writer;
+SQL
+
+instance_id=$(psql_as app_writer <<'SQL'
+BEGIN;
+SELECT public.bm25_request_compaction('adapter_docs_idx');
+ROLLBACK;
+SQL
+)
+[ -n "${instance_id}" ] || fail "wrapper returned no durable instance id"
+assert_sql_true "new-transaction request survived caller rollback" \
+    "SELECT EXISTS (
+        SELECT 1 FROM df.instances WHERE id = '${instance_id}');"
+assert_sql_true "durable graph contains current-identity helpers" \
+    "SELECT pg_catalog.count(*) = 2
+     FROM df.nodes
+     WHERE instance_id = '${instance_id}'
+       AND query ~ 'bm25_(compact_step|needs_compaction)_if_current';"
+[ "$(wait_for_instance "${instance_id}")" = "completed" ] \
+    || fail "direct request did not complete"
+
+if psql_as app_writer <<'SQL' >/dev/null 2>&1
+CREATE TEMP TABLE adapter_temp (body text);
+CREATE INDEX adapter_temp_idx ON adapter_temp
+    USING bm25(body) WITH (text_config = 'english');
+SELECT public.bm25_request_compaction('adapter_temp_idx');
+SQL
+then
+    fail "wrapper accepted a temporary index"
+fi
+
+psql_super <<'SQL'
+CREATE ROLE other_owner LOGIN;
+CREATE TABLE unauthorized_docs (body text);
+CREATE INDEX unauthorized_docs_idx ON unauthorized_docs
+    USING bm25(body) WITH (text_config = 'english');
+ALTER TABLE unauthorized_docs OWNER TO other_owner;
+ALTER INDEX unauthorized_docs_idx OWNER TO other_owner;
+SQL
+if psql_as app_writer -c "SELECT
+    public.bm25_request_compaction('unauthorized_docs_idx');" \
+    >/dev/null 2>&1; then
+    fail "writer requested compaction without INSERT privilege"
+fi
+
+psql_super <<'SQL'
+GRANT CREATE ON SCHEMA public TO app_owner;
+SET ROLE app_owner;
+CREATE TABLE partitioned_docs (part_key integer, body text)
+PARTITION BY RANGE (part_key);
+CREATE TABLE partitioned_docs_leaf PARTITION OF partitioned_docs
+    FOR VALUES FROM (0) TO (10);
+CREATE INDEX partitioned_docs_idx ON partitioned_docs
+    USING bm25(body) WITH (text_config = 'english');
+RESET ROLE;
+GRANT INSERT ON partitioned_docs TO app_writer;
+SQL
+leaf_index=$(psql_super -c "SELECT index_catalog.indexrelid::regclass
+    FROM pg_catalog.pg_index index_catalog
+         JOIN pg_catalog.pg_class relation
+           ON relation.oid = index_catalog.indexrelid
+         JOIN pg_catalog.pg_am access_method
+           ON access_method.oid = relation.relam
+    WHERE index_catalog.indrelid = 'partitioned_docs_leaf'::regclass
+      AND access_method.amname = 'bm25';")
+partition_instance=$(psql_as app_writer -c "SELECT
+    public.bm25_request_compaction('${leaf_index}'::regclass);")
+[ "$(wait_for_instance "${partition_instance}")" = "completed" ] \
+    || fail "partition-authorized request did not complete"
+
+psql_super -c "GRANT EXECUTE ON FUNCTION
+    public.bm25_request_compaction(regclass) TO app_owner;"
+psql_super -c "ALTER SYSTEM SET
+    pg_textsearch.segments_per_level = '2';"
+psql_super -c "SELECT pg_catalog.pg_reload_conf();" >/dev/null
+psql_super <<'SQL'
+CREATE TABLE compact_docs (id integer PRIMARY KEY, body text);
+CREATE INDEX compact_docs_idx ON compact_docs
+    USING bm25(body) WITH (text_config = 'english');
+ALTER TABLE compact_docs OWNER TO app_owner;
+ALTER INDEX compact_docs_idx OWNER TO app_owner;
+SQL
+levels_before=$(psql_as app_owner <<SQL
+INSERT INTO compact_docs
+SELECT i, 'first batch ' || i FROM generate_series(1, 20) i;
+SELECT ${EXT_SCHEMA}.bm25_spill_index('compact_docs_idx');
+INSERT INTO compact_docs
+SELECT i, 'second batch ' || i FROM generate_series(21, 40) i;
+SELECT ${EXT_SCHEMA}.bm25_spill_index('compact_docs_idx');
+SELECT (${EXT_SCHEMA}.bm25_level_counts('compact_docs_idx'))[1];
+SQL
+)
+levels_before=$(printf '%s\n' "${levels_before}" | tail -1)
+[ "${levels_before}" -ge 2 ] \
+    || fail "test did not create compaction debt"
+compact_instance=$(psql_as app_owner -c "SELECT
+    public.bm25_request_compaction('compact_docs_idx');")
+[ "$(wait_for_instance "${compact_instance}")" = "completed" ] \
+    || fail "stepped compaction request did not complete"
+levels_after=$(psql_super -c "SELECT
+    (${EXT_SCHEMA}.bm25_level_counts('compact_docs_idx'))[1];")
+[ "${levels_after}" -lt "${levels_before}" ] \
+    || fail "stepped task did not reduce L0"
+
+stale_identity=$(psql_super -c "SELECT
+    relation.oid::text || '|' ||
+    database.oid::text || '|' ||
+    coalesce(nullif(relation.reltablespace, 0),
+             database.dattablespace)::text || '|' ||
+    pg_catalog.pg_relation_filenode(relation.oid)::text
+    FROM pg_catalog.pg_class relation
+         JOIN pg_catalog.pg_database database
+           ON database.datname = pg_catalog.current_database()
+    WHERE relation.oid = 'compact_docs_idx'::regclass;")
+IFS='|' read -r stale_oid stale_db stale_spc stale_filenode \
+    <<<"${stale_identity}"
+psql_as app_owner -c "REINDEX INDEX compact_docs_idx;" >/dev/null
+assert_sql_true "stale physical helper is a no-op" \
+    "SET ROLE textsearch_compactor;
+     SELECT NOT ${EXT_SCHEMA}.bm25_needs_compaction_if_current(
+        ${stale_oid}, ${stale_db}, ${stale_spc}, ${stale_filenode});"
+
+printf 'Live pg_durable adapter checks passed.\n'

--- a/test/scripts/durable_compaction.sh
+++ b/test/scripts/durable_compaction.sh
@@ -45,6 +45,48 @@ assert_not_contains() {
     fi
 }
 
+md5_stream() {
+    if command -v md5sum >/dev/null 2>&1; then
+        md5sum | awk '{print $1}'
+    elif command -v md5 >/dev/null 2>&1; then
+        md5 -q
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -md5 | awk '{print $NF}'
+    else
+        fail "an MD5 implementation is required for wrapper verification"
+    fi
+}
+
+assert_managed_wrapper_hash() {
+    local role_setup="$1"
+    local wrapper="$2"
+    local actual_hash
+    local embedded_hashes
+    local embedded_count
+    local embedded_unique
+
+    actual_hash=$(
+        {
+            printf '\n'
+            awk '/^AS \$fn\$$/ { body = 1; next }
+                 /^\$fn\$;$/ { exit }
+                 body { print }' "${wrapper}"
+        } | md5_stream
+    )
+    embedded_hashes=$(
+        grep -Eho "'[[:xdigit:]]{32}'" "${role_setup}" "${wrapper}" \
+            | tr -d "'"
+    )
+    embedded_count=$(printf '%s\n' "${embedded_hashes}" | grep -c .)
+    embedded_unique=$(printf '%s\n' "${embedded_hashes}" | sort -u)
+
+    [ "${embedded_count}" -eq 3 ] \
+        || fail "managed wrapper hash must have exactly three copies"
+    [ "${embedded_unique}" = "${actual_hash}" ] \
+        || fail "managed wrapper hash mismatch: body=${actual_hash}, \
+embedded=${embedded_unique}"
+}
+
 assert_sql_true() {
     local description="$1"
     local query="$2"
@@ -75,6 +117,29 @@ wait_for_instance() {
     fail "durable instance ${instance_id} did not finish"
 }
 
+wait_for_durable_worker() {
+    local attempt
+    local instance_id
+    local state
+
+    for attempt in $(seq 1 60); do
+        instance_id=$(psql_as textsearch_compactor -c "SELECT df.start(
+            'SELECT 1',
+            label => 'adapter-worker-probe-${attempt}',
+            max_attempts => 1,
+            on_failure => 'fail');" 2>/dev/null || true)
+        if [ -n "${instance_id}" ]; then
+            state=$(wait_for_instance "${instance_id}")
+            if [ "${state}" = "completed" ]; then
+                return
+            fi
+        fi
+        sleep 1
+    done
+
+    fail "pg_durable worker did not become ready"
+}
+
 static_checks() {
     local fresh_sql="${ROOT_DIR}/sql/pg_textsearch--1.5.0-dev.sql"
     local upgrade_sql="${ROOT_DIR}/sql/pg_textsearch--1.4.0--1.5.0-dev.sql"
@@ -89,6 +154,9 @@ static_checks() {
     assert_contains "${compaction_api}" "tp_compact_index_step_if_current"
     assert_contains "${compaction_api}" "tp_needs_compaction_if_current"
     assert_contains "${compaction_api}" "!index_rel->rd_index->indisvalid"
+    # The return means a pass ran, not that more work remains.
+    assert_not_contains "${compaction_api}" "more_work"
+    assert_contains "${compaction_api}" "pass_ran"
 
     for sql in "${fresh_sql}" "${upgrade_sql}"; do
         assert_contains "${sql}" \
@@ -101,6 +169,10 @@ static_checks() {
 
     assert_contains "${GLUE_DIR}/01_setup_role.sql" \
         "pg_catalog.pg_shdepend"
+    assert_contains "${GLUE_DIR}/01_setup_role.sql" \
+        "TP_MANAGED_WRAPPER_PRECHECK"
+    assert_contains "${GLUE_DIR}/01_setup_role.sql" \
+        "df.loop(pg_catalog.text,pg_catalog.text)"
     assert_contains "${GLUE_DIR}/01_setup_role.sql" \
         "WITH INHERIT TRUE, SET FALSE"
     assert_contains "${wrapper}" "SECURITY DEFINER"
@@ -117,6 +189,8 @@ static_checks() {
         "IF NOT FOUND OR relfilenumber IS NULL THEN"
     assert_contains "${GLUE_DIR}/README.md" \
         "public.bm25_request_compaction(regclass)"
+    assert_managed_wrapper_hash \
+        "${GLUE_DIR}/01_setup_role.sql" "${wrapper}"
 
     printf 'Static pg_durable adapter checks passed.\n'
 }
@@ -218,11 +292,55 @@ SQL
     exit 0
 fi
 
+psql_super -c "CREATE ROLE partial_capability_owner LOGIN;"
+psql_super -c "ALTER FUNCTION
+    df.loop(pg_catalog.text, pg_catalog.text)
+    RENAME TO loop_missing;"
+if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=partial_capability_owner >/dev/null 2>&1; then
+    fail "role setup accepted pg_durable without df.loop(text, text)"
+fi
+psql_super -c "ALTER FUNCTION
+    df.loop_missing(pg_catalog.text, pg_catalog.text)
+    RENAME TO loop;"
+assert_sql_true "partial capability rejection precedes role changes" \
+    "SELECT NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_roles
+        WHERE rolname = 'textsearch_compactor');"
+psql_super -c "DROP ROLE partial_capability_owner;"
+
 psql_super -c "CREATE ROLE app_owner LOGIN;"
 psql_super -c "CREATE ROLE app_writer LOGIN;"
+psql_super -c "CREATE ROLE foreign_wrapper_owner LOGIN;"
 psql_super -c "ALTER DEFAULT PRIVILEGES FOR ROLE postgres
     IN SCHEMA public
     GRANT EXECUTE ON FUNCTIONS TO default_privilege_writer;"
+
+psql_super <<'SQL'
+CREATE FUNCTION public.bm25_request_compaction(pg_catalog.regclass)
+RETURNS pg_catalog.text
+LANGUAGE sql
+SECURITY DEFINER
+RETURN 'foreign-hostile-wrapper'::pg_catalog.text;
+ALTER FUNCTION public.bm25_request_compaction(pg_catalog.regclass)
+    OWNER TO foreign_wrapper_owner;
+SQL
+if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=app_owner >/dev/null 2>&1; then
+    fail "role setup accepted a foreign-owned hostile wrapper"
+fi
+assert_sql_true "foreign wrapper rejection precedes role side effects" \
+    "SELECT NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_roles
+        WHERE rolname = 'textsearch_compactor')
+     AND (
+        SELECT procedure.proowner = 'foreign_wrapper_owner'::regrole
+        FROM pg_catalog.pg_proc procedure
+        WHERE procedure.oid =
+            'public.bm25_request_compaction(regclass)'::regprocedure);"
+psql_super -c "DROP FUNCTION
+    public.bm25_request_compaction(pg_catalog.regclass);"
+
 psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
     -v index_owner=app_owner >/dev/null
 
@@ -258,10 +376,33 @@ fi
 psql_super -c "DROP FUNCTION
     public.bm25_request_compaction(pg_catalog.regclass);"
 
+wait_for_durable_worker
+
 psql_super -f "${GLUE_DIR}/02_wrapper.sql" \
     -v writer_role=app_writer >/dev/null
 psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
     -v index_owner=app_owner >/dev/null
+
+psql_super -c "CREATE ROLE owner_drift_target LOGIN;"
+psql_super -c "ALTER FUNCTION
+    public.bm25_request_compaction(pg_catalog.regclass)
+    OWNER TO foreign_wrapper_owner;"
+if psql_super -f "${GLUE_DIR}/01_setup_role.sql" \
+    -v index_owner=owner_drift_target >/dev/null 2>&1; then
+    fail "role setup accepted managed wrapper owner drift"
+fi
+assert_sql_true "owner drift rejection precedes new owner membership" \
+    "SELECT NOT pg_catalog.pg_has_role(
+        'textsearch_compactor', 'owner_drift_target', 'MEMBER')
+     AND (
+        SELECT procedure.proowner = 'foreign_wrapper_owner'::regrole
+        FROM pg_catalog.pg_proc procedure
+        WHERE procedure.oid =
+            'public.bm25_request_compaction(regclass)'::regprocedure);"
+psql_super -c "ALTER FUNCTION
+    public.bm25_request_compaction(pg_catalog.regclass)
+    OWNER TO textsearch_compactor;"
+psql_super -c "DROP ROLE owner_drift_target;"
 
 psql_super -c "CREATE ROLE delegable_writer LOGIN;"
 psql_super -c "GRANT EXECUTE ON FUNCTION

--- a/test/scripts/durable_compaction.sh
+++ b/test/scripts/durable_compaction.sh
@@ -427,6 +427,11 @@ psql_super -c "GRANT EXECUTE ON FUNCTION
     public.bm25_request_compaction(regclass) TO app_owner;"
 psql_super -c "ALTER SYSTEM SET
     pg_textsearch.segments_per_level = '2';"
+psql_super -c "ALTER SYSTEM SET
+    pg_textsearch.compaction_mode = 'background';"
+psql_super -c "ALTER SYSTEM SET
+    pg_textsearch.compaction_request_function =
+        'public.bm25_request_compaction';"
 psql_super -c "SELECT pg_catalog.pg_reload_conf();" >/dev/null
 psql_super <<'SQL'
 CREATE TABLE compact_docs (id integer PRIMARY KEY, body text);
@@ -436,6 +441,7 @@ ALTER TABLE compact_docs OWNER TO app_owner;
 ALTER INDEX compact_docs_idx OWNER TO app_owner;
 SQL
 levels_before=$(psql_as app_owner <<SQL
+BEGIN;
 INSERT INTO compact_docs
 SELECT i, 'first batch ' || i FROM generate_series(1, 20) i;
 SELECT ${EXT_SCHEMA}.bm25_spill_index('compact_docs_idx');
@@ -443,19 +449,58 @@ INSERT INTO compact_docs
 SELECT i, 'second batch ' || i FROM generate_series(21, 40) i;
 SELECT ${EXT_SCHEMA}.bm25_spill_index('compact_docs_idx');
 SELECT (${EXT_SCHEMA}.bm25_level_counts('compact_docs_idx'))[1];
+COMMIT;
 SQL
 )
 levels_before=$(printf '%s\n' "${levels_before}" | tail -1)
 [ "${levels_before}" -ge 2 ] \
     || fail "test did not create compaction debt"
-compact_instance=$(psql_as app_owner -c "SELECT
-    public.bm25_request_compaction('compact_docs_idx');")
+compact_label=$(psql_super -c "SELECT
+    'bm25-compact-' || 'compact_docs_idx'::regclass::oid;")
+compact_instance=$(psql_super -c "SELECT id
+    FROM df.instances
+    WHERE label = '${compact_label}'
+    ORDER BY created_at DESC
+    LIMIT 1;")
+[ -n "${compact_instance}" ] \
+    || fail "PRE_COMMIT did not persist an adapter request"
 [ "$(wait_for_instance "${compact_instance}")" = "completed" ] \
-    || fail "stepped compaction request did not complete"
+    || fail "PRE_COMMIT adapter request did not complete"
 levels_after=$(psql_super -c "SELECT
     (${EXT_SCHEMA}.bm25_level_counts('compact_docs_idx'))[1];")
 [ "${levels_after}" -lt "${levels_before}" ] \
-    || fail "stepped task did not reduce L0"
+    || fail "PRE_COMMIT adapter task did not reduce L0"
+
+psql_super <<'SQL'
+CREATE TABLE prepare_docs (id integer PRIMARY KEY, body text);
+CREATE INDEX prepare_docs_idx ON prepare_docs
+    USING bm25(body) WITH (text_config = 'english');
+ALTER TABLE prepare_docs OWNER TO app_owner;
+ALTER INDEX prepare_docs_idx OWNER TO app_owner;
+SQL
+psql_as app_owner <<SQL >/dev/null
+INSERT INTO prepare_docs
+SELECT i, 'prepare seed ' || i FROM generate_series(1, 20) i;
+SELECT ${EXT_SCHEMA}.bm25_spill_index('prepare_docs_idx');
+BEGIN;
+INSERT INTO prepare_docs
+SELECT i, 'prepare pending ' || i FROM generate_series(21, 40) i;
+SELECT ${EXT_SCHEMA}.bm25_spill_index('prepare_docs_idx');
+PREPARE TRANSACTION 'durable_compaction_prepare';
+SQL
+prepare_label=$(psql_super -c "SELECT
+    'bm25-compact-' || 'prepare_docs_idx'::regclass::oid;")
+prepare_instance=$(psql_super -c "SELECT id
+    FROM df.instances
+    WHERE label = '${prepare_label}'
+    ORDER BY created_at DESC
+    LIMIT 1;")
+[ -n "${prepare_instance}" ] \
+    || fail "PREPARE did not persist an adapter request"
+[ "$(wait_for_instance "${prepare_instance}")" = "completed" ] \
+    || fail "PREPARE adapter request did not complete"
+psql_as app_owner -c \
+    "ROLLBACK PREPARED 'durable_compaction_prepare';" >/dev/null
 
 stale_identity=$(psql_super -c "SELECT
     relation.oid::text || '|' ||

--- a/test/scripts/durable_compaction.sh
+++ b/test/scripts/durable_compaction.sh
@@ -569,15 +569,14 @@ psql_super -c "GRANT EXECUTE ON FUNCTION
 psql_super -c "ALTER SYSTEM SET
     pg_textsearch.segments_per_level = '2';"
 psql_super -c "ALTER SYSTEM SET
-    pg_textsearch.compaction_mode = 'background';"
-psql_super -c "ALTER SYSTEM SET
     pg_textsearch.compaction_request_function =
         'public.bm25_request_compaction';"
 psql_super -c "SELECT pg_catalog.pg_reload_conf();" >/dev/null
 psql_super <<'SQL'
 CREATE TABLE compact_docs (id integer PRIMARY KEY, body text);
 CREATE INDEX compact_docs_idx ON compact_docs
-    USING bm25(body) WITH (text_config = 'english');
+    USING bm25(body) WITH (text_config = 'english',
+                           compaction = 'background');
 ALTER TABLE compact_docs OWNER TO app_owner;
 ALTER INDEX compact_docs_idx OWNER TO app_owner;
 SQL
@@ -615,7 +614,8 @@ levels_after=$(psql_super -c "SELECT
 psql_super <<'SQL'
 CREATE TABLE prepare_docs (id integer PRIMARY KEY, body text);
 CREATE INDEX prepare_docs_idx ON prepare_docs
-    USING bm25(body) WITH (text_config = 'english');
+    USING bm25(body) WITH (text_config = 'english',
+                           compaction = 'background');
 ALTER TABLE prepare_docs OWNER TO app_owner;
 ALTER INDEX prepare_docs_idx OWNER TO app_owner;
 SQL
@@ -636,10 +636,10 @@ prepare_instance=$(psql_super -c "SELECT id
     WHERE label = '${prepare_label}'
     ORDER BY created_at DESC
     LIMIT 1;")
-[ -n "${prepare_instance}" ] \
-    || fail "PREPARE did not persist an adapter request"
-[ "$(wait_for_instance "${prepare_instance}")" = "completed" ] \
-    || fail "PREPARE adapter request did not complete"
+# Requests live in TopTransactionContext, which PREPARE TRANSACTION
+# discards. Dispatch happens at PRE_COMMIT only.
+[ -z "${prepare_instance}" ] \
+    || fail "PREPARE dispatched an adapter request"
 psql_as app_owner -c \
     "ROLLBACK PREPARED 'durable_compaction_prepare';" >/dev/null
 

--- a/test/scripts/fixtures/pg_config
+++ b/test/scripts/fixtures/pg_config
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "ambient pg_config fixture was selected" >&2
+exit 99


### PR DESCRIPTION
## Summary

Add an optional pg_durable adapter for per-index background compaction.
pg_textsearch's dispatch stays scheduler-neutral; the adapter supplies the
operator scripts and the two stale-safe entry points a durable scheduler
needs.

## Merge blocker

**Do not merge until [microsoft/pg_durable#354](https://github.com/microsoft/pg_durable/pull/354)
lands in a release.** The adapter needs the seven-argument `df.start` with
`on_failure => 'continue'`. No released pg_durable provides it: v0.2.7
shipped without #354, which is still an open draft. Both scripts check the
exact `df.start` signature before any managed side effect, so they refuse to
install rather than half-configure. The capability checks must gain a
released version floor once one exists.

## Design

- `01_setup_role.sql` creates and validates a least-privilege compactor role
  in a single transaction, making no change when pg_durable capabilities are
  absent or drifted.
- `02_wrapper.sql` installs a SECURITY DEFINER request wrapper with a fixed
  search path, target validation, and owner-only helper privileges.
- Each BM25 index is submitted to its own pg_durable loop, so pg_textsearch
  owns the per-index identity rather than requiring a keyed scheduling API
  upstream.
- `bm25_compact_step_if_current()` and `bm25_needs_compaction_if_current()`
  bind work to the database, index OID, tablespace and relfilenumber, and
  return false when the target is stale, so a stale job cannot compact a
  replacement relation.
- Each loop iteration calls `bm25_compact_step_if_current()` in its own
  transaction, releasing the per-index lock between merge batches.
- Install and upgrade SQL revoke helper access from nonowners, including
  grants inherited from `ALTER DEFAULT PRIVILEGES`.

## Test coverage

`test/scripts/durable_compaction.sh` runs in two modes. The static mode
checks wrapper identity, body hashes, extension ownership, privilege
boundaries, callback wiring, and package contents. It needs no pg_durable,
so it gates `installcheck` and `test-local` alongside the other source
guards. The live mode (`make test-durable`) additionally covers pre-commit
dispatch, that PREPARE dispatches nothing, precise skipping against a build
lacking the failure policy, and full execution against #354. It is excluded
from `test-all` because the CI image has no pg_durable.

## Known limitations

- Submission is not deduplicated across transactions. Every committing
  writer that spills can start another workflow for the same index; the
  per-index lock serializes the work but the instances still accumulate.
  A singleton admission key is needed before this is production-ready.
- A target that goes stale through `REINDEX` or `ALTER INDEX ... SET
  TABLESPACE` stops compacting until a later spill registers a new
  identity. There is no reconciliation sweep.
- The stale and no-work cases are both `false`, so a scheduler cannot
  distinguish them.

## Stack position

Fourth layer of stack #479, on top of #477's dispatch. Draft pending the
upstream release. The final layer adds the singleton recovery backstop and
operational packaging.
