### PR TITLE
Fix REINDEX cache accounting leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,18 @@ jobs:
         make PG_CFLAGS="-Werror -Wno-error=unused-parameter"
         sudo env "PATH=$PATH" make install
 
+    - name: Run cross-database registry regression
+      timeout-minutes: 5
+      run: |
+        export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
+        make test-cross-database-registry
+
+    - name: Run multi-backend REINDEX regression
+      timeout-minutes: 10
+      run: |
+        export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
+        make test-reindex
+
     - name: Run regression tests
       timeout-minutes: 10
       run: |

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 # SQL regression tests
-test: test-compaction-ownercheck test-compaction-request-source
+test: test-compaction-ownercheck test-compaction-request-source test-state-build-source
 	@echo "Running SQL regression tests..."
 	@$(pg_regress_installcheck) $(REGRESS_OPTS) $(REGRESS)
 
@@ -106,10 +106,13 @@ test-compaction-ownercheck:
 test-compaction-request-source:
 	@./test/scripts/compaction_request_source.sh
 
+test-state-build-source:
+	@./test/scripts/state_build_source.sh
+
 # These guards cover invariants the SQL suite cannot observe, so they must
 # gate every way the suite is run, not just `make test`.
-installcheck: test-compaction-ownercheck test-compaction-request-source
-test-local: test-compaction-ownercheck test-compaction-request-source
+installcheck: test-compaction-ownercheck test-compaction-request-source test-state-build-source
+test-local: test-compaction-ownercheck test-compaction-request-source test-state-build-source
 
 # Custom local test target with dedicated PostgreSQL instance
 test-local: install
@@ -217,7 +220,11 @@ test-reindex:
 	@echo "Running multi-backend reindex regression tests (issue #390)..."
 	@cd test/scripts && ./multi_backend_reindex.sh
 
-test-shell: test-concurrency test-recovery test-segment test-cic test-multi-index test-reindex
+test-cross-database-registry:
+	@echo "Running cross-database registry regression tests (issue #464)..."
+	@cd test/scripts && ./cross_database_registry.sh
+
+test-shell: test-concurrency test-recovery test-segment test-cic test-multi-index test-reindex test-cross-database-registry
 	@echo "All shell-based tests completed"
 
 test-all: test test-shell
@@ -370,6 +377,7 @@ help:
 	@echo "  make test-cic         - Run CREATE INDEX CONCURRENTLY tests"
 	@echo "  make test-chinese     - Run Chinese tokenization test (needs zhparser)"
 	@echo "  make test-reindex     - Run multi-backend reindex regression tests (issue #390)"
+	@echo "  make test-cross-database-registry - Run issue #464 registry regression"
 	@echo "  make expected     - Generate expected output files from test results"
 	@echo ""
 	@echo "Code formatting targets:"
@@ -393,4 +401,4 @@ help:
 	@echo "  make test-all"
 	@echo "  make format"
 
-.PHONY: test test-compaction-ownercheck test-compaction-request-source clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help
+.PHONY: test test-compaction-ownercheck test-compaction-request-source test-state-build-source clean-test-dirs installcheck test-concurrency test-recovery test-segment test-stress test-cic test-chinese test-replication test-replication-extended test-logical-replication test-multi-index test-reindex test-cross-database-registry test-shell test-all expected lint-format format format-check format-diff format-single coverage coverage-build coverage-clean coverage-report help

--- a/src/access/build.c
+++ b/src/access/build.c
@@ -268,7 +268,7 @@ tp_finish_spill(
 	 * concurrent insert can have bumped this since the
 	 * pre-spill chain extension was published.
 	 */
-	pg_atomic_write_u32(&index_state->shared->chain_page_count, 0);
+	tp_set_chain_page_count_for_relation(index_state, index_rel, 0);
 
 	if (post_action == TP_SPILL_POST_NONE)
 		return;
@@ -367,6 +367,8 @@ tp_auto_spill_if_needed(TpLocalIndexState *index_state, Relation index_rel)
 	threshold = (uint32)tp_memtable_pages_threshold;
 	if (threshold == 0)
 		return; /* auto-spill disabled */
+
+	tp_reseed_chain_page_count_if_needed(index_state, index_rel);
 
 	if (pg_atomic_read_u32(&index_state->shared->chain_page_count) < threshold)
 		return;
@@ -1390,6 +1392,8 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 	uint64			   total_docs = 0;
 	uint64			   total_len  = 0;
 	TpLocalIndexState *index_state;
+	TpLocalIndexState *build_state;
+	SubTransactionId   index_create_subid;
 	bool			   is_text_array;
 
 	/* Show "started" for first partition only (suppresses duplicates) */
@@ -1435,6 +1439,10 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 				 text_config_name);
 		elog(NOTICE, "Using index options: k1=%.2f, b=%.2f", k1, b);
 	}
+
+	index_create_subid = index->rd_createSubid;
+	build_state		   = tp_create_build_index_state(
+			   index->rd_id, heap->rd_id, index_create_subid);
 
 	/* Initialize metapage */
 	tp_build_init_metapage(index, text_config_oid, k1, b);
@@ -1516,31 +1524,16 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 					nworkers);
 
 			/*
-			 * Create shared index state for runtime queries.
-			 *
-			 * The parallel build writes segments and updates
-			 * the metapage, but does not create the in-memory
-			 * shared state that INSERT and SELECT need.
-			 * Without this, the first post-build access falls
-			 * through to tp_rebuild_index_from_disk() (the
-			 * first-access bootstrap path), which can race
-			 * with concurrent backends touching the same
-			 * index and re-creating its registry entry.
-			 *
-			 * By creating the state here — the same backend
-			 * that ran the build — we ensure the registry
-			 * entry and local cache are ready before the
-			 * CREATE INDEX transaction commits.
+			 * Parallel workers kept all build data in DSM/BufFiles.
+			 * Invalidate the stable runtime cache only after the new
+			 * index relfilenode is complete.
 			 */
 			{
 				Buffer			metabuf;
 				Page			mpage;
 				TpIndexMetaPage metap;
 
-				(void)tp_create_shared_index_state(
-						RelationGetRelid(index),
-						RelationGetRelid(heap),
-						/* reuse_if_exists */ false);
+				tp_finalize_build_mode(build_state);
 
 				if (build_progress.active)
 				{
@@ -1592,14 +1585,7 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 		Size				 budget;
 		double				 reltuples;
 
-		/*
-		 * Still create build index state for:
-		 * - Per-index LWLock infrastructure
-		 * - Post-build transition to runtime mode
-		 * - Shared state initialization for runtime queries
-		 */
-		index_state = tp_create_build_index_state(
-				RelationGetRelid(index), RelationGetRelid(heap));
+		index_state = build_state;
 		tp_acquire_index_lock(index_state, LW_EXCLUSIVE);
 
 		/* Budget: maintenance_work_mem (in KB) -> bytes */
@@ -1723,8 +1709,8 @@ tp_build(Relation heap, Relation index, IndexInfo *indexInfo)
 		tp_release_index_lock(index_state);
 
 		/*
-		 * Finalize build mode: destroy private DSA and
-		 * transition to global DSA for runtime operation.
+		 * The build output is complete; invalidate the derived runtime
+		 * cache in place without replacing its stable allocation.
 		 */
 		tp_finalize_build_mode(index_state);
 

--- a/src/access/vacuum.c
+++ b/src/access/vacuum.c
@@ -311,6 +311,8 @@ tp_spill_memtable_if_needed(
 	if (!index_state || !index_state->shared)
 		return;
 
+	tp_reseed_chain_page_count_if_needed(index_state, index);
+
 	if (pg_atomic_read_u32(&index_state->shared->chain_page_count) < min_pages)
 		return;
 

--- a/src/index/registry.c
+++ b/src/index/registry.c
@@ -604,9 +604,9 @@ tp_registry_eviction_mutex(void)
 void
 tp_registry_walk(TpRegistryWalkCb cb, void *ctx)
 {
-	dshash_table	 *registry_hash;
-	dshash_seq_status status;
-	TpRegistryEntry	 *entry;
+	dshash_table	  *registry_hash;
+	dshash_seq_status *status;
+	TpRegistryEntry	  *entry;
 
 	Assert(cb != NULL);
 
@@ -615,15 +615,19 @@ tp_registry_walk(TpRegistryWalkCb cb, void *ctx)
 		tapir_registry->registry_handle == DSHASH_HANDLE_INVALID)
 		return;
 
+	status = palloc(sizeof(*status));
 	registry_hash =
 			registry_attach(tapir_dsa, tapir_registry->registry_handle);
 	if (!registry_hash)
+	{
+		pfree(status);
 		return;
+	}
 
-	dshash_seq_init(&status, registry_hash, false);
+	dshash_seq_init(status, registry_hash, false);
 	PG_TRY();
 	{
-		while ((entry = (TpRegistryEntry *)dshash_seq_next(&status)) != NULL)
+		while ((entry = (TpRegistryEntry *)dshash_seq_next(status)) != NULL)
 		{
 			if (cb(entry->key, entry->shared_state_dp, ctx))
 				break;
@@ -631,8 +635,9 @@ tp_registry_walk(TpRegistryWalkCb cb, void *ctx)
 	}
 	PG_FINALLY();
 	{
-		dshash_seq_term(&status);
+		dshash_seq_term(status);
 		dshash_detach(registry_hash);
+		pfree(status);
 	}
 	PG_END_TRY();
 }

--- a/src/index/registry.c
+++ b/src/index/registry.c
@@ -2,7 +2,8 @@
  * Copyright (c) 2025-2026 Tiger Data, Inc.
  * Licensed under the PostgreSQL License. See LICENSE for details.
  *
- * registry.c - Global registry mapping index OIDs to shared state
+ * registry.c - Global registry mapping database-qualified index OIDs
+ * to shared state
  *
  * Uses a dshash (dynamic shared hash table) for O(1) lookups and no
  * limit on the number of indexes (beyond available memory).
@@ -35,44 +36,54 @@ static TpGlobalRegistry *tapir_registry = NULL;
 static dsa_area *tapir_dsa = NULL;
 
 /*
- * Hash function for Oid keys
+ * Hash function for database-qualified index keys
  */
 static uint32
 registry_hash_fn(const void *key, size_t keysize, void *arg)
 {
+	const TpRegistryKey *registry_key = (const TpRegistryKey *)key;
+	Oid					 key_parts[2] = {
+			 registry_key->database_oid,
+			 registry_key->index_oid,
+	 };
+
 	(void)keysize;
 	(void)arg;
-	return hash_bytes((const unsigned char *)key, sizeof(Oid));
+	return hash_bytes((const unsigned char *)key_parts, sizeof(key_parts));
 }
 
 /*
- * Compare function for Oid keys
+ * Compare function for database-qualified index keys
  */
 static int
 registry_compare_fn(const void *a, const void *b, size_t keysize, void *arg)
 {
-	Oid oid_a = *(const Oid *)a;
-	Oid oid_b = *(const Oid *)b;
+	const TpRegistryKey *key_a = (const TpRegistryKey *)a;
+	const TpRegistryKey *key_b = (const TpRegistryKey *)b;
 
 	(void)keysize;
 	(void)arg;
 
-	if (oid_a < oid_b)
+	if (key_a->database_oid < key_b->database_oid)
 		return -1;
-	if (oid_a > oid_b)
+	if (key_a->database_oid > key_b->database_oid)
+		return 1;
+	if (key_a->index_oid < key_b->index_oid)
+		return -1;
+	if (key_a->index_oid > key_b->index_oid)
 		return 1;
 	return 0;
 }
 
 /*
- * Copy function for Oid keys
+ * Copy function for database-qualified index keys
  */
 static void
 registry_copy_fn(void *dest, const void *src, size_t keysize, void *arg)
 {
 	(void)keysize;
 	(void)arg;
-	*(Oid *)dest = *(const Oid *)src;
+	*(TpRegistryKey *)dest = *(const TpRegistryKey *)src;
 }
 
 /*
@@ -81,7 +92,7 @@ registry_copy_fn(void *dest, const void *src, size_t keysize, void *arg)
 static void
 get_registry_params(dshash_parameters *params)
 {
-	params->key_size		 = sizeof(Oid);
+	params->key_size		 = sizeof(TpRegistryKey);
 	params->entry_size		 = sizeof(TpRegistryEntry);
 	params->compare_function = registry_compare_fn;
 	params->hash_function	 = registry_hash_fn;
@@ -264,7 +275,9 @@ tp_registry_get_dsa(void)
  */
 bool
 tp_registry_register(
-		Oid index_oid, TpSharedIndexState *shared_state, dsa_pointer shared_dp)
+		TpRegistryKey		key,
+		TpSharedIndexState *shared_state,
+		dsa_pointer			shared_dp)
 {
 	dshash_table	*registry_hash;
 	TpRegistryEntry *entry;
@@ -279,8 +292,9 @@ tp_registry_register(
 		tapir_registry->registry_handle == DSHASH_HANDLE_INVALID)
 	{
 		elog(ERROR,
-			 "Failed to initialize Tapir registry for index %u",
-			 index_oid);
+			 "Failed to initialize Tapir registry for database %u index %u",
+			 key.database_oid,
+			 key.index_oid);
 	}
 
 	registry_hash =
@@ -290,8 +304,8 @@ tp_registry_register(
 
 	/* Insert or update the entry */
 	entry = (TpRegistryEntry *)
-			dshash_find_or_insert(registry_hash, &index_oid, &found);
-	entry->index_oid	   = index_oid;
+			dshash_find_or_insert(registry_hash, &key, &found);
+	entry->key			   = key;
 	entry->shared_state_dp = shared_dp;
 	dshash_release_lock(registry_hash, entry);
 
@@ -308,7 +322,7 @@ tp_registry_register(
  */
 bool
 tp_registry_register_if_absent(
-		Oid index_oid, dsa_pointer shared_dp, dsa_pointer *existing_dp)
+		TpRegistryKey key, dsa_pointer shared_dp, dsa_pointer *existing_dp)
 {
 	dshash_table	*registry_hash;
 	TpRegistryEntry *entry;
@@ -320,8 +334,9 @@ tp_registry_register_if_absent(
 		tapir_registry->registry_handle == DSHASH_HANDLE_INVALID)
 	{
 		elog(ERROR,
-			 "Failed to initialize Tapir registry for index %u",
-			 index_oid);
+			 "Failed to initialize Tapir registry for database %u index %u",
+			 key.database_oid,
+			 key.index_oid);
 	}
 
 	registry_hash =
@@ -330,7 +345,7 @@ tp_registry_register_if_absent(
 		elog(ERROR, "Failed to attach to registry hash table");
 
 	entry = (TpRegistryEntry *)
-			dshash_find_or_insert(registry_hash, &index_oid, &found);
+			dshash_find_or_insert(registry_hash, &key, &found);
 	if (found)
 	{
 		if (existing_dp)
@@ -338,7 +353,7 @@ tp_registry_register_if_absent(
 	}
 	else
 	{
-		entry->index_oid	   = index_oid;
+		entry->key			   = key;
 		entry->shared_state_dp = shared_dp;
 	}
 	dshash_release_lock(registry_hash, entry);
@@ -352,7 +367,7 @@ tp_registry_register_if_absent(
  * Returns the shared state pointer (as DSA pointer cast) or NULL if not found
  */
 TpSharedIndexState *
-tp_registry_lookup(Oid index_oid)
+tp_registry_lookup(TpRegistryKey key)
 {
 	dshash_table	*registry_hash;
 	TpRegistryEntry *entry;
@@ -372,7 +387,7 @@ tp_registry_lookup(Oid index_oid)
 	if (!registry_hash)
 		return NULL;
 
-	entry = (TpRegistryEntry *)dshash_find(registry_hash, &index_oid, false);
+	entry = (TpRegistryEntry *)dshash_find(registry_hash, &key, false);
 	if (entry)
 	{
 		result = entry->shared_state_dp;
@@ -391,7 +406,7 @@ tp_registry_lookup(Oid index_oid)
  * Returns the DSA pointer if found, InvalidDsaPointer otherwise
  */
 dsa_pointer
-tp_registry_lookup_dsa(Oid index_oid)
+tp_registry_lookup_dsa(TpRegistryKey key)
 {
 	dshash_table	*registry_hash;
 	TpRegistryEntry *entry;
@@ -411,7 +426,7 @@ tp_registry_lookup_dsa(Oid index_oid)
 	if (!registry_hash)
 		return InvalidDsaPointer;
 
-	entry = (TpRegistryEntry *)dshash_find(registry_hash, &index_oid, false);
+	entry = (TpRegistryEntry *)dshash_find(registry_hash, &key, false);
 	if (entry)
 	{
 		result = entry->shared_state_dp;
@@ -428,7 +443,7 @@ tp_registry_lookup_dsa(Oid index_oid)
  * Returns true if the index is in the registry, false otherwise
  */
 bool
-tp_registry_is_registered(Oid index_oid)
+tp_registry_is_registered(TpRegistryKey key)
 {
 	dshash_table	*registry_hash;
 	TpRegistryEntry *entry;
@@ -455,7 +470,7 @@ tp_registry_is_registered(Oid index_oid)
 	if (!registry_hash)
 		return false;
 
-	entry = (TpRegistryEntry *)dshash_find(registry_hash, &index_oid, false);
+	entry = (TpRegistryEntry *)dshash_find(registry_hash, &key, false);
 	if (entry)
 	{
 		result = true;
@@ -472,7 +487,7 @@ tp_registry_is_registered(Oid index_oid)
  * Called when an index is dropped
  */
 void
-tp_registry_unregister(Oid index_oid)
+tp_registry_unregister(TpRegistryKey key)
 {
 	dshash_table *registry_hash;
 	bool		  deleted;
@@ -493,10 +508,78 @@ tp_registry_unregister(Oid index_oid)
 	if (!registry_hash)
 		return;
 
-	deleted = dshash_delete_key(registry_hash, &index_oid);
+	deleted = dshash_delete_key(registry_hash, &key);
 	(void)deleted; /* Ignore if not found */
 
 	dshash_detach(registry_hash);
+}
+
+typedef struct DatabaseKeyCollector
+{
+	Oid			   database_oid;
+	TpRegistryKey *keys;
+	Size		   count;
+	Size		   capacity;
+} DatabaseKeyCollector;
+
+static bool
+collect_database_key_cb(TpRegistryKey key, dsa_pointer shared_dp, void *ctx)
+{
+	DatabaseKeyCollector *collector = (DatabaseKeyCollector *)ctx;
+
+	(void)shared_dp;
+
+	if (key.database_oid != collector->database_oid)
+		return false;
+
+	if (collector->count == collector->capacity)
+	{
+		Size new_capacity;
+
+		if (collector->capacity == 0)
+			new_capacity = 16;
+		else
+		{
+			if (collector->capacity >
+				MaxAllocSize / (2 * sizeof(TpRegistryKey)))
+				elog(ERROR, "too many pg_textsearch registry entries");
+			new_capacity = collector->capacity * 2;
+		}
+
+		if (new_capacity > MaxAllocSize / sizeof(TpRegistryKey))
+			elog(ERROR, "too many pg_textsearch registry entries");
+
+		if (collector->keys == NULL)
+			collector->keys = palloc(new_capacity * sizeof(TpRegistryKey));
+		else
+			collector->keys = repalloc(
+					collector->keys, new_capacity * sizeof(TpRegistryKey));
+		collector->capacity = new_capacity;
+	}
+
+	collector->keys[collector->count++] = key;
+	return false;
+}
+
+Size
+tp_registry_collect_database_keys(Oid database_oid, TpRegistryKey **keys)
+{
+	DatabaseKeyCollector collector = {
+			.database_oid = database_oid,
+			.keys		  = NULL,
+			.count		  = 0,
+			.capacity	  = 0,
+	};
+
+	Assert(keys != NULL);
+	*keys = NULL;
+
+	if (!OidIsValid(database_oid))
+		return 0;
+
+	tp_registry_walk(collect_database_key_cb, &collector);
+	*keys = collector.keys;
+	return collector.count;
 }
 
 /*
@@ -538,18 +621,18 @@ tp_registry_walk(TpRegistryWalkCb cb, void *ctx)
 		return;
 
 	dshash_seq_init(&status, registry_hash, false);
-	while ((entry = (TpRegistryEntry *)dshash_seq_next(&status)) != NULL)
+	PG_TRY();
 	{
-		bool stop;
-
-		stop = cb(entry->index_oid, entry->shared_state_dp, ctx);
-		if (stop)
+		while ((entry = (TpRegistryEntry *)dshash_seq_next(&status)) != NULL)
 		{
-			dshash_seq_term(&status);
-			dshash_detach(registry_hash);
-			return;
+			if (cb(entry->key, entry->shared_state_dp, ctx))
+				break;
 		}
 	}
-	dshash_seq_term(&status);
-	dshash_detach(registry_hash);
+	PG_FINALLY();
+	{
+		dshash_seq_term(&status);
+		dshash_detach(registry_hash);
+	}
+	PG_END_TRY();
 }

--- a/src/index/registry.h
+++ b/src/index/registry.h
@@ -4,9 +4,9 @@
  *
  * registry.h - Global registry for shared index states
  *
- * Uses a dshash (dynamic shared hash table) to map index OIDs to their
- * shared state DSA pointers. This allows unlimited indexes (bounded only
- * by available memory) with O(1) lookup performance.
+ * Uses a dshash (dynamic shared hash table) to map database-qualified
+ * index OIDs to their shared state DSA pointers. This allows unlimited
+ * indexes (bounded only by available memory) with O(1) lookup performance.
  */
 #pragma once
 
@@ -29,13 +29,34 @@
 #define TP_REGISTRY_HASH_TRANCHE_ID TP_TRANCHE_REGISTRY
 
 /*
+ * Cluster-wide registry key.  Relation OIDs are unique only within a
+ * database, so every registry operation must carry both identifiers.
+ */
+typedef struct TpRegistryKey
+{
+	Oid database_oid;
+	Oid index_oid;
+} TpRegistryKey;
+
+static inline TpRegistryKey
+tp_registry_key(Oid database_oid, Oid index_oid)
+{
+	TpRegistryKey key = {
+			.database_oid = database_oid,
+			.index_oid	  = index_oid,
+	};
+
+	return key;
+}
+
+/*
  * Registry entry stored in dshash
- * The key is the first field (index_oid), value is shared_state_dp
+ * The key is the first field, value is shared_state_dp.
  */
 typedef struct TpRegistryEntry
 {
-	Oid			index_oid;		 /* Hash key - must be first */
-	dsa_pointer shared_state_dp; /* DSA pointer to TpSharedIndexState */
+	TpRegistryKey key;			   /* Hash key - must be first */
+	dsa_pointer	  shared_state_dp; /* DSA pointer to TpSharedIndexState */
 } TpRegistryEntry;
 
 /*
@@ -69,22 +90,31 @@ extern dsa_area *tp_registry_get_dsa(void);
 
 /* Registry operations */
 extern bool tp_registry_register(
-		Oid					index_oid,
+		TpRegistryKey		key,
 		TpSharedIndexState *shared_state,
 		dsa_pointer			shared_dp);
 /*
- * Register `shared_dp` for `index_oid` only if no entry exists.
+ * Register `shared_dp` for `key` only if no entry exists.
  * Returns true if a fresh entry was created, false if an existing
  * entry was found (in which case `*existing_dp` is set to the
  * existing shared_state_dp and the caller is expected to free its
  * own allocation and use the existing entry).
  */
 extern bool tp_registry_register_if_absent(
-		Oid index_oid, dsa_pointer shared_dp, dsa_pointer *existing_dp);
-extern TpSharedIndexState *tp_registry_lookup(Oid index_oid);
-extern dsa_pointer		   tp_registry_lookup_dsa(Oid index_oid);
-extern bool				   tp_registry_is_registered(Oid index_oid);
-extern void				   tp_registry_unregister(Oid index_oid);
+		TpRegistryKey key, dsa_pointer shared_dp, dsa_pointer *existing_dp);
+extern TpSharedIndexState *tp_registry_lookup(TpRegistryKey key);
+extern dsa_pointer		   tp_registry_lookup_dsa(TpRegistryKey key);
+extern bool				   tp_registry_is_registered(TpRegistryKey key);
+extern void				   tp_registry_unregister(TpRegistryKey key);
+
+/*
+ * Collect every key qualified by `database_oid` in one registry walk.
+ * The returned array is allocated in CurrentMemoryContext and must be
+ * pfree'd by the caller.  No entries are removed while the iterator holds
+ * a dshash partition lock.
+ */
+extern Size
+tp_registry_collect_database_keys(Oid database_oid, TpRegistryKey **keys);
 
 /*
  * Cache memory accounting helpers.  Increment/decrement the
@@ -103,17 +133,16 @@ extern LWLock			*tp_registry_eviction_mutex(void);
 
 /*
  * Callback-based registry iterator.  For each registered index,
- * invokes `cb(oid, shared_state_dp, ctx)`.  Stops early when the
- * callback returns true.  Returns true if the callback ever
- * returned true, false otherwise.  Bucket locks are held while
- * the callback runs; the callback MUST NOT acquire arbitrary
- * LWLocks (the dshash partition lock is held).  Reading fields
- * via dsa_get_address from the supplied DSA pointer is safe.
+ * invokes `cb(key, shared_state_dp, ctx)`.  A true callback return
+ * stops the void iterator early.  Bucket locks are held while the
+ * callback runs; the callback MUST NOT acquire arbitrary LWLocks
+ * (the dshash partition lock is held).  Reading fields via
+ * dsa_get_address from the supplied DSA pointer is safe.
  *
  * Used by tp_cache_evict_largest to scan for the largest-bytes
  * cache.  Reads only — no entry mutation from within the
  * callback.
  */
 typedef bool (*TpRegistryWalkCb)(
-		Oid index_oid, dsa_pointer shared_dp, void *ctx);
+		TpRegistryKey key, dsa_pointer shared_dp, void *ctx);
 extern void tp_registry_walk(TpRegistryWalkCb cb, void *ctx);

--- a/src/index/state.c
+++ b/src/index/state.c
@@ -171,6 +171,55 @@ init_local_state_cache(void)
 	}
 }
 
+static void
+init_memtable(TpMemtable *memtable)
+{
+	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
+	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
+	LWLockInitialize(&memtable->apply_lock, TP_TRANCHE_CACHE_APPLY_LOCK);
+	LWLockInitialize(&memtable->lock, TP_TRANCHE_CACHE_LOCK);
+	memtable->cursor_gen_spill_count = 0;
+	memtable->cursor_next_blkno		 = InvalidBlockNumber;
+	memtable->cursor_next_off		 = 0;
+	memset(&memtable->cursor_locator, 0, sizeof(memtable->cursor_locator));
+	memtable->cursor_locator_valid = false;
+	pg_atomic_init_u64(&memtable->cursor_seq, 0);
+	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
+}
+
+static dsa_pointer
+allocate_memtable(dsa_area *dsa)
+{
+	dsa_pointer memtable_dp = dsa_allocate(dsa, sizeof(TpMemtable));
+	TpMemtable *memtable;
+
+	if (!DsaPointerIsValid(memtable_dp))
+		elog(ERROR, "Failed to allocate memtable in DSA");
+
+	memtable = (TpMemtable *)dsa_get_address(dsa, memtable_dp);
+	init_memtable(memtable);
+
+	return memtable_dp;
+}
+
+static void
+init_local_state(
+		TpLocalIndexState  *local_state,
+		TpSharedIndexState *shared_state,
+		dsa_pointer			shared_dp,
+		dsa_area		   *dsa)
+{
+	local_state->shared						= shared_state;
+	local_state->shared_dp					= shared_dp;
+	local_state->dsa						= dsa;
+	local_state->build_created_shared_state = false;
+	local_state->lock_held					= false;
+	local_state->lock_mode					= 0;
+	local_state->terms_added_this_xact		= 0;
+	local_state->docs_since_global_check	= 0;
+	local_state->created_in_subxact			= InvalidSubTransactionId;
+}
+
 /*
  * Get or create a local index state for the given index OID
  *
@@ -200,7 +249,8 @@ tp_get_local_index_state(Oid index_oid)
 		return entry->local_state;
 
 	/* Look up shared state in registry */
-	shared_state = tp_registry_lookup(index_oid);
+	shared_state = tp_registry_lookup(
+			tp_registry_key(MyDatabaseId, index_oid));
 
 	if (shared_state == NULL)
 	{
@@ -238,16 +288,7 @@ tp_get_local_index_state(Oid index_oid)
 			 */
 			local_state = tp_rebuild_index_from_disk(index_oid);
 			if (local_state != NULL)
-			{
-				/*
-				 * Rebuilt from disk = pre-existing index.
-				 * Override the subtransaction ID so rollback
-				 * of an enclosing savepoint won't destroy the
-				 * shared state used by all backends.
-				 */
-				local_state->created_in_subxact = InvalidSubTransactionId;
 				return local_state;
-			}
 
 			/* Recovery failed - index might be corrupted or stale */
 		}
@@ -274,15 +315,7 @@ tp_get_local_index_state(Oid index_oid)
 		/* Allocate local state */
 		local_state = (TpLocalIndexState *)MemoryContextAlloc(
 				TopMemoryContext, sizeof(TpLocalIndexState));
-		local_state->shared					 = shared_state;
-		local_state->dsa					 = dsa;
-		local_state->is_build_mode			 = false; /* Runtime mode */
-		local_state->lock_held				 = false;
-		local_state->lock_mode				 = 0;
-		local_state->terms_added_this_xact	 = 0;
-		local_state->docs_since_global_check = 0;
-		local_state->created_in_subxact =
-				InvalidSubTransactionId; /* pre-existing index */
+		init_local_state(local_state, shared_state, shared_dp, dsa);
 
 		/* Cache the local state */
 		entry = (LocalStateCacheEntry *)
@@ -294,399 +327,193 @@ tp_get_local_index_state(Oid index_oid)
 }
 
 /*
- * Create a new shared index state and return local state.
- *
- * If `reuse_if_exists` is true and a registry entry for this OID
- * already exists when we go to insert, the just-allocated DSA is
- * freed and we attach to the existing entry instead. This is the
- * mode the cold-start bootstrap path uses, so concurrent rebuilds
- * resolve to the same shared state instead of racing each other.
- *
- * If false, an existing entry is unregistered and replaced — used
- * by the parallel-build completion path on the assumption that any
- * pre-existing entry would be stale (e.g. left behind by a crashed
- * earlier CREATE INDEX with the same OID).
+ * Register a fresh runtime state or attach to the existing state for the
+ * same database-qualified index identity.  REINDEX must never replace the
+ * shared allocation because wrappers retained by other backends keep its
+ * address.  The calling backend's wrapper is replaced below.
  */
-TpLocalIndexState *
-tp_create_shared_index_state(Oid index_oid, Oid heap_oid, bool reuse_if_exists)
+static TpLocalIndexState *
+create_or_attach_index_state(
+		Oid index_oid, Oid heap_oid, SubTransactionId index_create_subid)
 {
+	TpRegistryKey		  key = tp_registry_key(MyDatabaseId, index_oid);
 	TpSharedIndexState	 *shared_state;
 	TpLocalIndexState	 *local_state;
-	TpMemtable			 *memtable;
+	TpLocalIndexState	 *old_local_state = NULL;
 	dsa_area			 *dsa;
 	dsa_pointer			  shared_dp;
 	dsa_pointer			  memtable_dp;
+	dsa_pointer			  existing_dp = InvalidDsaPointer;
 	LocalStateCacheEntry *entry;
 	bool				  found;
 
-	/* Get the shared DSA area */
 	dsa = tp_registry_get_dsa();
 
-	/*
-	 * Allocate shared state in DSA.
-	 * Use dsa_allocate directly (not tp_dsa_allocate) because shared_state
-	 * contains the memory_usage tracker itself. This allocation is not
-	 * counted against the index memory limit.
-	 */
 	shared_dp = dsa_allocate(dsa, sizeof(TpSharedIndexState));
-	if (shared_dp == InvalidDsaPointer)
-	{
+	if (!DsaPointerIsValid(shared_dp))
 		elog(ERROR,
 			 "Failed to allocate DSA memory for shared state (index OID: %u, "
 			 "size: %zu)",
 			 index_oid,
 			 sizeof(TpSharedIndexState));
-	}
-	shared_state = (TpSharedIndexState *)dsa_get_address(dsa, shared_dp);
 
-	/* Initialize shared state */
+	shared_state = (TpSharedIndexState *)dsa_get_address(dsa, shared_dp);
 	shared_state->index_oid = index_oid;
 	shared_state->heap_oid	= heap_oid;
 	pg_atomic_init_u64(&shared_state->estimated_bytes, 0);
 	pg_atomic_init_u32(&shared_state->chain_page_count, 0);
-	shared_state->is_build_mode = false; /* runtime-mode publication */
-	/*
-	 * Initialize per-index LWLock + spill_generation in the
-	 * freshly DSA-allocated shared_state.  dsa_allocate does
-	 * NOT zero memory (reused chunks can hold garbage), so any
-	 * field that requires a known initial value must be set
-	 * explicitly.  Without these inits a future
-	 * LWLockAcquire(&shared->lock) can hang on a stuck spinlock
-	 * (PANIC: stuck spinlock detected at LWLockWaitListLock).
-	 * Same tranche choices as tp_create_build_index_state for
-	 * consistency.
-	 */
+	pg_atomic_init_u32(&shared_state->chain_page_count_needs_reseed, 0);
+	pg_atomic_init_u32(&shared_state->chain_page_count_spc_oid, InvalidOid);
+	pg_atomic_init_u32(&shared_state->chain_page_count_db_oid, InvalidOid);
+	pg_atomic_init_u32(
+			&shared_state->chain_page_count_rel_number, InvalidRelFileNumber);
 	LWLockInitialize(&shared_state->lock, TP_TRANCHE_INDEX_LOCK);
 	pg_atomic_init_u64(&shared_state->spill_generation, 0);
-	memtable_dp = dsa_allocate(dsa, sizeof(TpMemtable));
-	if (!DsaPointerIsValid(memtable_dp))
-		elog(ERROR, "Failed to allocate memtable in DSA");
-
-	memtable = (TpMemtable *)dsa_get_address(dsa, memtable_dp);
-	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
-	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(&memtable->apply_lock, TP_TRANCHE_CACHE_APPLY_LOCK);
-	LWLockInitialize(&memtable->lock, TP_TRANCHE_CACHE_LOCK);
-	memtable->cursor_gen_spill_count = 0;
-	memtable->cursor_next_blkno		 = InvalidBlockNumber;
-	memtable->cursor_next_off		 = 0;
-	pg_atomic_init_u64(&memtable->cursor_seq, 0);
-	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
-
+	memtable_dp				  = allocate_memtable(dsa);
 	shared_state->memtable_dp = memtable_dp;
 
-	if (reuse_if_exists)
+	if (!tp_registry_register_if_absent(key, shared_dp, &existing_dp))
 	{
-		/*
-		 * Atomic register-or-attach. If a concurrent backend
-		 * registered first, free our just-allocated DSA and attach
-		 * to its shared state instead — second arrival's bootstrap
-		 * still runs (under the per-index LW_EXCLUSIVE), but the
-		 * idempotency gate dedups and the atomic-write yields the
-		 * same answer.
-		 */
-		dsa_pointer existing_dp = InvalidDsaPointer;
-
-		if (!tp_registry_register_if_absent(
-					index_oid, shared_dp, &existing_dp))
-		{
-			dsa_free(dsa, memtable_dp);
-			dsa_free(dsa, shared_dp);
-			shared_dp	 = existing_dp;
-			shared_state = (TpSharedIndexState *)
-					dsa_get_address(dsa, existing_dp);
-		}
-	}
-	else
-	{
-		/* Replace any stale entry (e.g. left by a crashed CREATE INDEX). */
-		if (tp_registry_lookup(index_oid) != NULL)
-			tp_registry_unregister(index_oid);
-
-		if (!tp_registry_register(index_oid, shared_state, shared_dp))
-		{
-			tp_registry_shmem_startup();
-			if (!tp_registry_register(index_oid, shared_state, shared_dp))
-			{
-				dsa_free(dsa, memtable_dp);
-				dsa_free(dsa, shared_dp);
-				elog(ERROR, "Failed to register index %u", index_oid);
-			}
-		}
+		dsa_free(dsa, memtable_dp);
+		dsa_free(dsa, shared_dp);
+		shared_dp	 = existing_dp;
+		shared_state = (TpSharedIndexState *)dsa_get_address(dsa, existing_dp);
 	}
 
-	/* Create local state for the creating backend */
+	/*
+	 * The wrapper cache is backend-local and can outlive a committed DROP
+	 * performed by another backend.  The registry state resolved above is
+	 * authoritative; never inspect the old wrapper's potentially stale
+	 * shared pointer.  Release only the known-live shared lock, if this
+	 * backend already acquired it earlier in the transaction.
+	 */
+	if (LWLockHeldByMe(&shared_state->lock))
+		LWLockRelease(&shared_state->lock);
+
 	local_state = (TpLocalIndexState *)
 			MemoryContextAlloc(TopMemoryContext, sizeof(TpLocalIndexState));
-	local_state->shared					 = shared_state;
-	local_state->dsa					 = dsa;
-	local_state->is_build_mode			 = false; /* Runtime mode */
-	local_state->lock_held				 = false;
-	local_state->lock_mode				 = 0;
-	local_state->terms_added_this_xact	 = 0;
-	local_state->docs_since_global_check = 0;
-	local_state->created_in_subxact		 = GetCurrentSubTransactionId();
+	init_local_state(local_state, shared_state, shared_dp, dsa);
+	if (index_create_subid != InvalidSubTransactionId)
+	{
+		local_state->build_created_shared_state = true;
+		local_state->created_in_subxact			= index_create_subid;
+	}
 
-	/* Cache the local state */
 	init_local_state_cache();
 	entry = (LocalStateCacheEntry *)
 			hash_search(local_state_cache, &index_oid, HASH_ENTER, &found);
 	if (found)
+		old_local_state = entry->local_state;
+
+	/*
+	 * REINDEX replaces this backend's wrapper while retaining the same
+	 * registry allocation.  Carry transaction-local scalar accounting
+	 * forward only when the saved DSA identity matches the authoritative
+	 * state resolved above.  Never dereference old_local_state->shared.
+	 */
+	if (old_local_state != NULL && old_local_state->shared_dp == shared_dp)
 	{
-		/* This happens during index rebuild (e.g., VACUUM FULL)
-		 * Clean up the old local state before registering the new one */
-		if (entry->local_state != NULL)
-		{
-			/* Don't detach DSA as it's shared */
-			pfree(entry->local_state);
-		}
+		local_state->terms_added_this_xact =
+				old_local_state->terms_added_this_xact;
+		local_state->docs_since_global_check =
+				old_local_state->docs_since_global_check;
 	}
 
 	entry->local_state = local_state;
+	if (old_local_state != NULL)
+		pfree(old_local_state);
 
 	return local_state;
 }
 
-/*
- * Create index state for BUILD mode (CREATE INDEX)
- *
- * Uses a private DSA that is not shared with other backends.
- * This private DSA will be destroyed and recreated on each spill,
- * providing perfect memory reclamation.
- */
 TpLocalIndexState *
-tp_create_build_index_state(Oid index_oid, Oid heap_oid)
+tp_create_shared_index_state(
+		Oid index_oid, Oid heap_oid, SubTransactionId index_create_subid)
 {
-	TpSharedIndexState	 *shared_state;
-	TpLocalIndexState	 *local_state;
-	TpMemtable			 *memtable;
-	dsa_area			 *private_dsa;
-	dsa_area			 *global_dsa;
-	dsa_pointer			  shared_dp;
-	dsa_pointer			  memtable_dp;
-	LocalStateCacheEntry *entry;
-	bool				  found;
+	return create_or_attach_index_state(
+			index_oid, heap_oid, index_create_subid);
+}
 
-	/* Get the global DSA for shared state allocation */
-	global_dsa = tp_registry_get_dsa();
-
-	/* Allocate shared state in GLOBAL DSA (for statistics) */
-	shared_dp = dsa_allocate(global_dsa, sizeof(TpSharedIndexState));
-	if (shared_dp == InvalidDsaPointer)
-		elog(ERROR,
-			 "Failed to allocate shared state for build (index OID: %u)",
-			 index_oid);
-
-	shared_state = (TpSharedIndexState *)
-			dsa_get_address(global_dsa, shared_dp);
-
-	/* Initialize shared state */
-	shared_state->index_oid = index_oid;
-	shared_state->heap_oid	= heap_oid;
-	shared_state->memtable_dp =
-			InvalidDsaPointer; /* Memtable in private DSA */
-	/*
-	 * Mark this shared state as build-mode BEFORE we publish it
-	 * via tp_registry_register below.  The cross-index eviction
-	 * walker (src/memtable/cache.c:evict_walk_cb) reads this
-	 * flag lock-free and skips entries where it is true, which
-	 * prevents the walker from dereferencing memtable_dp through
-	 * the GLOBAL DSA once we publish a PRIVATE-DSA pointer at
-	 * "shared_state->memtable_dp = memtable_dp" further down.
-	 *
-	 * The flag is cleared in tp_finalize_build_mode() under
-	 * tp_registry_eviction_mutex EXCL, atomically with swapping
-	 * memtable_dp to a global-DSA pointer.
-	 */
-	shared_state->is_build_mode = true;
-	pg_atomic_init_u64(&shared_state->estimated_bytes, 0);
-	pg_atomic_init_u32(&shared_state->chain_page_count, 0);
-
-	/*
-	 * Initialize per-index LWLock using a fixed tranche ID.
-	 * Using a fixed ID avoids exhausting tranche IDs when creating many
-	 * indexes (e.g., partitioned tables with 500+ partitions).
-	 */
-	LWLockInitialize(&shared_state->lock, TP_TRANCHE_INDEX_LOCK);
-	pg_atomic_init_u64(&shared_state->spill_generation, 0);
-
-	/* Check if index already registered (rebuild case) */
-	if (tp_registry_lookup(index_oid) != NULL)
-		tp_registry_unregister(index_oid);
-
-	/* Register in global registry */
-	if (!tp_registry_register(index_oid, shared_state, shared_dp))
-	{
-		tp_registry_shmem_startup();
-		if (!tp_registry_register(index_oid, shared_state, shared_dp))
-		{
-			dsa_free(global_dsa, shared_dp);
-			elog(ERROR, "Failed to register index %u", index_oid);
-		}
-	}
-
-	/*
-	 * Create PRIVATE DSA for build.
-	 * This DSA is not registered globally - only this backend knows about it.
-	 * It will be destroyed and recreated on each spill for perfect
-	 * memory reclamation.
-	 *
-	 * Use a fixed tranche ID to avoid exhausting tranche IDs when creating
-	 * many indexes (e.g., partitioned tables with 500+ partitions).
-	 */
-	private_dsa = dsa_create(TP_TRANCHE_BUILD_DSA);
-	if (!private_dsa)
-		elog(ERROR, "Failed to create private DSA for index build");
-
-	/* Allocate and initialize memtable in PRIVATE DSA */
-	memtable_dp = dsa_allocate(private_dsa, sizeof(TpMemtable));
-	if (!DsaPointerIsValid(memtable_dp))
-		elog(ERROR, "Failed to allocate memtable in private DSA");
-
-	memtable = (TpMemtable *)dsa_get_address(private_dsa, memtable_dp);
-	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
-	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(&memtable->apply_lock, TP_TRANCHE_CACHE_APPLY_LOCK);
-	LWLockInitialize(&memtable->lock, TP_TRANCHE_CACHE_LOCK);
-	memtable->cursor_gen_spill_count = 0;
-	memtable->cursor_next_blkno		 = InvalidBlockNumber;
-	memtable->cursor_next_off		 = 0;
-	pg_atomic_init_u64(&memtable->cursor_seq, 0);
-	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
-
-	/* Store memtable pointer in shared state for memtable access */
-	shared_state->memtable_dp = memtable_dp;
-
-	/* Create local state pointing to PRIVATE DSA */
-	local_state = (TpLocalIndexState *)
-			MemoryContextAlloc(TopMemoryContext, sizeof(TpLocalIndexState));
-	local_state->shared					 = shared_state;
-	local_state->dsa					 = private_dsa; /* PRIVATE DSA */
-	local_state->is_build_mode			 = true;		/* BUILD MODE */
-	local_state->lock_held				 = false;
-	local_state->lock_mode				 = 0;
-	local_state->terms_added_this_xact	 = 0;
-	local_state->docs_since_global_check = 0;
-	local_state->created_in_subxact		 = GetCurrentSubTransactionId();
-
-	/* Cache the local state */
-	init_local_state_cache();
-	entry = (LocalStateCacheEntry *)
-			hash_search(local_state_cache, &index_oid, HASH_ENTER, &found);
-	if (found && entry->local_state != NULL)
-		pfree(entry->local_state);
-
-	entry->local_state = local_state;
-
-	return local_state;
+TpLocalIndexState *
+tp_create_build_index_state(
+		Oid index_oid, Oid heap_oid, SubTransactionId index_create_subid)
+{
+	return create_or_attach_index_state(
+			index_oid, heap_oid, index_create_subid);
 }
 
 /*
- * Finalize build mode and transition to runtime mode
- *
- * This is called at the end of CREATE INDEX. It:
- * 1. Destroys the private DSA (returns all memory to OS)
- * 2. Attaches to the global shared DSA
- * 3. Initializes a fresh memtable in the global DSA
- * 4. Sets is_build_mode = false for runtime operation
- *
- * After this, the index is ready for normal concurrent access.
+ * A successful serial or parallel build replaces the on-disk relfilenode.
+ * Discard the derived cache in place while preserving the registry entry,
+ * per-index LWLock, TpMemtable allocation, and memtable_dp.
  */
 void
 tp_finalize_build_mode(TpLocalIndexState *local_state)
 {
-	dsa_area   *global_dsa;
 	TpMemtable *memtable;
-	dsa_pointer memtable_dp;
-	LWLock	   *eviction_mutex;
 
 	Assert(local_state != NULL);
-	Assert(local_state->is_build_mode);
+	Assert(local_state->shared != NULL);
+	Assert(local_state->dsa != NULL);
+	Assert(DsaPointerIsValid(local_state->shared->memtable_dp));
 
-	/*
-	 * Attach to the global shared DSA for runtime operation.
-	 * This is the same DSA used by all backends for concurrent access.
-	 *
-	 * NOTE: we do NOT detach the private DSA yet.  The cross-index
-	 * eviction walker (src/memtable/cache.c:evict_walk_cb) skips
-	 * entries where shared->is_build_mode is true, so as long as
-	 * is_build_mode remains true the private memtable_dp is
-	 * safe.  We only detach after the swap+clear below.
-	 */
-	global_dsa = tp_registry_get_dsa();
-	if (!global_dsa)
-		elog(ERROR, "Failed to get global DSA for runtime mode");
+	tp_acquire_index_lock(local_state, LW_EXCLUSIVE);
+	memtable = (TpMemtable *)dsa_get_address(
+			local_state->dsa, local_state->shared->memtable_dp);
+	LWLockAcquire(&memtable->apply_lock, LW_EXCLUSIVE);
+	LWLockAcquire(&memtable->lock, LW_EXCLUSIVE);
+	tp_cache_clear(local_state->dsa, memtable);
+	pg_atomic_add_fetch_u64(&local_state->shared->spill_generation, 1);
+	pg_atomic_write_u32(
+			&local_state->shared->chain_page_count_needs_reseed, 1);
+	pg_atomic_write_u32(&local_state->shared->chain_page_count, 0);
+	LWLockRelease(&memtable->lock);
+	LWLockRelease(&memtable->apply_lock);
+	tp_release_index_lock(local_state);
+}
 
-	/*
-	 * Allocate a fresh memtable in the global DSA.
-	 * This memtable will be shared with other backends.
-	 */
-	memtable_dp = dsa_allocate(global_dsa, sizeof(TpMemtable));
-	if (!DsaPointerIsValid(memtable_dp))
-		elog(ERROR, "Failed to allocate memtable in global DSA");
+static void
+cleanup_owned_build_state(LocalStateCacheEntry *entry, dsa_area *global_dsa)
+{
+	TpLocalIndexState *local_state = entry->local_state;
+	TpRegistryKey	   key;
+	dsa_pointer		   shared_dp;
+	LWLock			  *eviction_mutex;
 
-	memtable = (TpMemtable *)dsa_get_address(global_dsa, memtable_dp);
-	memtable->string_hash_handle = DSHASH_HANDLE_INVALID;
-	memtable->doc_lengths_handle = DSHASH_HANDLE_INVALID;
-	LWLockInitialize(&memtable->apply_lock, TP_TRANCHE_CACHE_APPLY_LOCK);
-	LWLockInitialize(&memtable->lock, TP_TRANCHE_CACHE_LOCK);
-	memtable->cursor_gen_spill_count = 0;
-	memtable->cursor_next_blkno		 = InvalidBlockNumber;
-	memtable->cursor_next_off		 = 0;
-	pg_atomic_init_u64(&memtable->cursor_seq, 0);
-	pg_atomic_init_u64(&memtable->estimated_bytes, 0);
+	Assert(local_state != NULL);
+	Assert(local_state->build_created_shared_state);
+	Assert(local_state->shared != NULL);
 
-	/*
-	 * Publish the new global memtable_dp and clear is_build_mode
-	 * atomically with respect to the cross-index eviction walker.
-	 * The walker holds tp_registry_eviction_mutex EXCL across its
-	 * entire scan, so taking it EXCL here gives readers a single
-	 * coherent transition:
-	 *
-	 *   BEFORE: is_build_mode=true,  memtable_dp=<PRIVATE-DSA ptr>
-	 *   AFTER:  is_build_mode=false, memtable_dp=<GLOBAL-DSA ptr>
-	 *
-	 * Lock order matches evict_largest (eviction_mutex outermost),
-	 * so no inversion vs the rest of the eviction subsystem.
-	 */
+	key		  = tp_registry_key(MyDatabaseId, local_state->shared->index_oid);
+	shared_dp = tp_registry_lookup_dsa(key);
 	eviction_mutex = tp_registry_eviction_mutex();
+
 	if (eviction_mutex != NULL)
 		LWLockAcquire(eviction_mutex, LW_EXCLUSIVE);
 
-	local_state->shared->memtable_dp   = memtable_dp;
-	local_state->shared->is_build_mode = false;
+	tp_registry_unregister(key);
+	if (DsaPointerIsValid(shared_dp) && global_dsa != NULL)
+	{
+		TpMemtable *memtable = (TpMemtable *)
+				dsa_get_address(global_dsa, local_state->shared->memtable_dp);
+
+		tp_cache_clear(global_dsa, memtable);
+		dsa_free(global_dsa, local_state->shared->memtable_dp);
+		dsa_free(global_dsa, shared_dp);
+	}
 
 	if (eviction_mutex != NULL)
 		LWLockRelease(eviction_mutex);
 
-	/*
-	 * Now that no other backend can reach the private DSA via the
-	 * registry, detach it.  This returns ALL build-time memory to
-	 * the OS.  After build the memtable should be empty (all data
-	 * spilled to disk).
-	 */
-	if (local_state->dsa)
-	{
-		dsa_detach(local_state->dsa);
-		local_state->dsa = NULL;
-	}
-
-	local_state->dsa = global_dsa;
-
-	/* Transition to runtime mode (local-state flag) */
-	local_state->is_build_mode = false;
+	pfree(local_state);
+	entry->local_state = NULL;
 }
 
 /*
- * Clean up build mode state on transaction abort
- *
- * This is called from the transaction callback when a transaction aborts.
- * If we were in the middle of a CREATE INDEX (build mode), we need to:
- * 1. Detach from the private DSA (which destroys it since no other refs)
- * 2. Clean up the shared state from the registry
- * 3. Remove from local cache
- *
- * This prevents memory leaks when CREATE INDEX is aborted.
+ * Abort removes only a shared state registered by this transaction's
+ * initial CREATE INDEX.  REINDEX reuses pre-existing state; failure before
+ * finalization leaves its cache untouched, while abort after finalization
+ * may leave the stable cache empty.
  */
 void
 tp_cleanup_build_mode_on_abort(void)
@@ -708,61 +535,51 @@ tp_cleanup_build_mode_on_abort(void)
 		if (local_state == NULL)
 			continue;
 
-		if (!local_state->is_build_mode)
+		if (!local_state->build_created_shared_state)
 			continue;
 
-		/*
-		 * Detach from private DSA. Since this is a private DSA with no other
-		 * attachments, dsa_detach will destroy it and return memory to OS.
-		 */
-		if (local_state->dsa != NULL && local_state->dsa != global_dsa)
-		{
-			dsa_detach(local_state->dsa);
-			local_state->dsa = NULL;
-		}
-
-		/*
-		 * Clean up shared state from registry. The shared state was allocated
-		 * in the global DSA, so we need to free it there.
-		 *
-		 * Take tp_registry_eviction_mutex EXCL across the
-		 * unregister + dsa_free so the cross-index eviction
-		 * walker (src/memtable/cache.c:tp_cache_evict_largest)
-		 * cannot deref a half-freed shared_state.  We unregister
-		 * FIRST so a future walker can't even find the entry,
-		 * then free under the same mutex so any walker that is
-		 * currently iterating completes before we recycle the
-		 * memory.  Lock order matches evict_largest
-		 * (eviction_mutex outermost).
-		 */
-		if (local_state->shared != NULL)
-		{
-			Oid			index_oid	   = local_state->shared->index_oid;
-			dsa_pointer shared_dp	   = tp_registry_lookup_dsa(index_oid);
-			LWLock	   *eviction_mutex = tp_registry_eviction_mutex();
-
-			if (eviction_mutex != NULL)
-				LWLockAcquire(eviction_mutex, LW_EXCLUSIVE);
-
-			/* Unregister first so no new walker can find us */
-			tp_registry_unregister(index_oid);
-
-			if (DsaPointerIsValid(shared_dp) && global_dsa != NULL)
-			{
-				/* Free shared state from global DSA */
-				dsa_free(global_dsa, shared_dp);
-			}
-
-			if (eviction_mutex != NULL)
-				LWLockRelease(eviction_mutex);
-
-			local_state->shared = NULL;
-		}
-
-		/* Free local state */
-		pfree(local_state);
-		entry->local_state = NULL;
+		cleanup_owned_build_state(entry, global_dsa);
 	}
+}
+
+void
+tp_commit_build_states(void)
+{
+	HASH_SEQ_STATUS		  status;
+	LocalStateCacheEntry *entry;
+
+	if (local_state_cache == NULL)
+		return;
+
+	hash_seq_init(&status, local_state_cache);
+	while ((entry = hash_seq_search(&status)) != NULL)
+	{
+		if (entry->local_state != NULL)
+		{
+			entry->local_state->build_created_shared_state = false;
+			entry->local_state->created_in_subxact = InvalidSubTransactionId;
+		}
+	}
+}
+
+bool
+tp_has_initial_create_ownership(void)
+{
+	HASH_SEQ_STATUS		  status;
+	LocalStateCacheEntry *entry;
+
+	if (local_state_cache == NULL)
+		return false;
+
+	hash_seq_init(&status, local_state_cache);
+	while ((entry = hash_seq_search(&status)) != NULL)
+	{
+		if (entry->local_state != NULL &&
+			entry->local_state->build_created_shared_state)
+			return true;
+	}
+
+	return false;
 }
 
 /*
@@ -808,100 +625,19 @@ tp_cleanup_subxact_abort(SubTransactionId mySubid)
 		ls->lock_held = false;
 		ls->lock_mode = 0;
 
-		/* Only clean up state created in the aborting subxact */
+		/* Only process build state created in the aborting subxact. */
 		if (ls->created_in_subxact != mySubid)
 			continue;
 
-		/*
-		 * Reset bulk load counter only for entries being
-		 * destroyed. Resetting surviving entries would suppress
-		 * the PRE_COMMIT spill check for terms already in the
-		 * memtable from the outer transaction.
-		 */
-		ls->terms_added_this_xact = 0;
-
-		if (ls->is_build_mode)
+		if (ls->build_created_shared_state)
 		{
-			/*
-			 * Build mode: private DSA not shared with anyone.
-			 * Detach destroys it and returns memory to OS.
-			 */
-			if (ls->dsa != NULL && ls->dsa != global_dsa)
-			{
-				dsa_detach(ls->dsa);
-				ls->dsa = NULL;
-			}
+			ls->terms_added_this_xact = 0;
+			cleanup_owned_build_state(entry, global_dsa);
 		}
-
-		/*
-		 * Free shared state from global DSA and unregister.
-		 *
-		 * Take tp_registry_eviction_mutex EXCL across the
-		 * unregister + dsa_free (and, for runtime mode, the
-		 * memtable free + cache clear) so the cross-index
-		 * eviction walker can't observe a half-freed shared
-		 * state.  We unregister FIRST: once the registry no
-		 * longer references this oid, no new walker can find
-		 * it, and any walker currently iterating completes
-		 * before we recycle the memory.  Lock order matches
-		 * evict_largest (eviction_mutex outermost).
-		 *
-		 * NOTE: the runtime branch's tp_cache_clear is safe
-		 * under the eviction_mutex; it only takes per-memtable
-		 * locks (cache.apply_lock / cache.lock), which are
-		 * acquired BELOW eviction_mutex in the canonical lock
-		 * order documented at src/memtable/cache.c.
-		 */
-		if (ls->shared != NULL)
+		else
 		{
-			Oid			index_oid	   = ls->shared->index_oid;
-			dsa_pointer shared_dp	   = tp_registry_lookup_dsa(index_oid);
-			LWLock	   *eviction_mutex = tp_registry_eviction_mutex();
-
-			if (eviction_mutex != NULL)
-				LWLockAcquire(eviction_mutex, LW_EXCLUSIVE);
-
-			/* Unregister first so no new walker can find us */
-			tp_registry_unregister(index_oid);
-
-			if (!ls->is_build_mode && global_dsa != NULL)
-			{
-				/*
-				 * Runtime mode: the in-memory cache may have
-				 * populated the dshash tables hanging off the
-				 * TpMemtable; drop them first so dsa_free on
-				 * the TpMemtable allocation does not leak the
-				 * dshash internals.  Safe with an empty cache:
-				 * tp_cache_clear is a no-op when both handles
-				 * are INVALID.
-				 *
-				 * Subxact abort doesn't acquire cache.lock
-				 * itself: this path is unwinding an aborted
-				 * CREATE-INDEX-like subtransaction whose
-				 * shared state we just unregistered.
-				 */
-				TpMemtable *mt = NULL;
-
-				if (DsaPointerIsValid(ls->shared->memtable_dp))
-				{
-					mt = (TpMemtable *)dsa_get_address(
-							global_dsa, ls->shared->memtable_dp);
-					tp_cache_clear(global_dsa, mt);
-					dsa_free(global_dsa, ls->shared->memtable_dp);
-				}
-			}
-
-			if (DsaPointerIsValid(shared_dp) && global_dsa != NULL)
-				dsa_free(global_dsa, shared_dp);
-
-			if (eviction_mutex != NULL)
-				LWLockRelease(eviction_mutex);
-
-			ls->shared = NULL;
+			ls->created_in_subxact = InvalidSubTransactionId;
 		}
-
-		pfree(ls);
-		entry->local_state = NULL;
 	}
 }
 
@@ -941,8 +677,8 @@ tp_promote_subxact_states(
  * This is called when an index is dropped. We free the DSA allocations
  * but keep the DSA area itself since it's shared by all indices.
  */
-void
-tp_cleanup_index_shared_memory(Oid index_oid)
+static void
+cleanup_index_shared_memory(TpRegistryKey key, bool cleanup_local_state)
 {
 	dsa_area			 *dsa;
 	dsa_pointer			  shared_dp;
@@ -964,9 +700,12 @@ tp_cleanup_index_shared_memory(Oid index_oid)
 	 * remove it from the cache yet — the later block below will
 	 * dispose of it after the DSA frees.
 	 */
-	if (local_state_cache != NULL)
+	Assert(!cleanup_local_state || key.database_oid == MyDatabaseId);
+
+	if (cleanup_local_state && local_state_cache != NULL)
 	{
-		entry = hash_search(local_state_cache, &index_oid, HASH_FIND, &found);
+		entry = hash_search(
+				local_state_cache, &key.index_oid, HASH_FIND, &found);
 		if (found && entry != NULL && entry->local_state != NULL &&
 			entry->local_state->lock_held)
 			tp_release_index_lock(entry->local_state);
@@ -974,12 +713,15 @@ tp_cleanup_index_shared_memory(Oid index_oid)
 	entry = NULL;
 
 	/* Look up the DSA pointer in registry */
-	shared_dp = tp_registry_lookup_dsa(index_oid);
+	LWLockAcquire(tp_registry_eviction_mutex(), LW_EXCLUSIVE);
+
+	shared_dp = tp_registry_lookup_dsa(key);
 
 	if (!DsaPointerIsValid(shared_dp))
 	{
 		/* Still unregister even if no shared state found */
-		tp_registry_unregister(index_oid);
+		tp_registry_unregister(key);
+		LWLockRelease(tp_registry_eviction_mutex());
 		return; /* Nothing to clean up */
 	}
 
@@ -1010,10 +752,8 @@ tp_cleanup_index_shared_memory(Oid index_oid)
 	 * memory.  The mutex order is global before per-index, matching
 	 * evict_largest's acquire sequence.
 	 */
-	LWLockAcquire(tp_registry_eviction_mutex(), LW_EXCLUSIVE);
-
 	/* Unregister first so no new walker can find us */
-	tp_registry_unregister(index_oid);
+	tp_registry_unregister(key);
 
 	if (DsaPointerIsValid(shared_state->memtable_dp))
 	{
@@ -1030,15 +770,17 @@ tp_cleanup_index_shared_memory(Oid index_oid)
 	LWLockRelease(tp_registry_eviction_mutex());
 
 	/* Clean up local state if we have it cached */
-	if (local_state_cache != NULL)
+	if (cleanup_local_state && local_state_cache != NULL)
 	{
-		entry = hash_search(local_state_cache, &index_oid, HASH_FIND, &found);
+		entry = hash_search(
+				local_state_cache, &key.index_oid, HASH_FIND, &found);
 		if (found && entry != NULL && entry->local_state != NULL)
 		{
 			TpLocalIndexState *ls = entry->local_state;
 
 			/* Remove from cache first, before detaching DSA */
-			hash_search(local_state_cache, &index_oid, HASH_REMOVE, &found);
+			hash_search(
+					local_state_cache, &key.index_oid, HASH_REMOVE, &found);
 
 			/* Don't detach DSA - it's shared and still in use by registry */
 			/* Just nullify the reference */
@@ -1049,6 +791,144 @@ tp_cleanup_index_shared_memory(Oid index_oid)
 			pfree(ls);
 		}
 	}
+}
+
+void
+tp_cleanup_index_shared_memory(Oid index_oid)
+{
+	cleanup_index_shared_memory(
+			tp_registry_key(MyDatabaseId, index_oid), true);
+}
+
+/*
+ * Clean up every shared allocation qualified by a successfully dropped
+ * database.  DROP DATABASE cannot target the current connection, so this
+ * path deliberately leaves the backend-local wrapper cache untouched.
+ */
+void
+tp_cleanup_database_shared_memory(Oid database_oid)
+{
+	TpRegistryKey *keys;
+	Size		   key_count;
+	Size		   i;
+
+	if (!OidIsValid(database_oid))
+		return;
+
+	Assert(database_oid != MyDatabaseId);
+
+	key_count = tp_registry_collect_database_keys(database_oid, &keys);
+	for (i = 0; i < key_count; i++)
+		cleanup_index_shared_memory(keys[i], false);
+
+	if (keys != NULL)
+		pfree(keys);
+}
+
+void
+tp_set_chain_page_count_for_relation(
+		TpLocalIndexState *local_state, Relation index_rel, uint32 chain_pages)
+{
+	RelFileLocator locator;
+
+	Assert(local_state != NULL);
+	Assert(local_state->shared != NULL);
+	Assert(local_state->lock_held);
+	Assert(local_state->lock_mode == LW_EXCLUSIVE);
+	Assert(index_rel != NULL);
+
+	locator = index_rel->rd_locator;
+	pg_atomic_write_u32(&local_state->shared->chain_page_count, chain_pages);
+	pg_atomic_write_u32(
+			&local_state->shared->chain_page_count_spc_oid, locator.spcOid);
+	pg_atomic_write_u32(
+			&local_state->shared->chain_page_count_db_oid, locator.dbOid);
+	pg_atomic_write_u32(
+			&local_state->shared->chain_page_count_rel_number,
+			locator.relNumber);
+	pg_atomic_write_u32(
+			&local_state->shared->chain_page_count_needs_reseed, 0);
+}
+
+static bool
+chain_page_count_matches_relation(
+		TpLocalIndexState *local_state, Relation index_rel)
+{
+	RelFileLocator locator = index_rel->rd_locator;
+
+	Assert(local_state != NULL);
+	Assert(local_state->shared != NULL);
+	Assert(index_rel != NULL);
+
+	if (pg_atomic_read_u32(
+				&local_state->shared->chain_page_count_needs_reseed) != 0)
+		return false;
+
+	return pg_atomic_read_u32(
+				   &local_state->shared->chain_page_count_spc_oid) ==
+				   locator.spcOid &&
+		   pg_atomic_read_u32(&local_state->shared->chain_page_count_db_oid) ==
+				   locator.dbOid &&
+		   pg_atomic_read_u32(
+				   &local_state->shared->chain_page_count_rel_number) ==
+				   locator.relNumber;
+}
+
+static void
+reseed_chain_page_count_locked(
+		TpLocalIndexState *local_state, Relation index_rel)
+{
+	TpDataSource *chain_src;
+	uint32		  chain_pages = 0;
+
+	Assert(local_state != NULL);
+	Assert(local_state->shared != NULL);
+	Assert(local_state->lock_held);
+	Assert(local_state->lock_mode == LW_EXCLUSIVE);
+	Assert(index_rel != NULL);
+
+	chain_src =
+			tp_memtable_chain_source_create(local_state, index_rel, NULL, 0);
+	if (chain_src != NULL)
+	{
+		chain_pages = tp_memtable_chain_source_page_count(chain_src);
+		tp_source_close(chain_src);
+	}
+
+	tp_set_chain_page_count_for_relation(local_state, index_rel, chain_pages);
+}
+
+/*
+ * Rebuild finalization cannot know whether commit or rollback will select the
+ * new or old relfilenode.  Defer page-count reconstruction until a threshold
+ * consumer has the current Relation, then recount under the per-index lock.
+ */
+void
+tp_reseed_chain_page_count_if_needed(
+		TpLocalIndexState *local_state, Relation index_rel)
+{
+	bool acquired_lock = false;
+
+	if (local_state == NULL || local_state->shared == NULL ||
+		index_rel == NULL)
+		return;
+
+	if (chain_page_count_matches_relation(local_state, index_rel))
+		return;
+
+	if (!local_state->lock_held)
+	{
+		tp_acquire_index_lock(local_state, LW_EXCLUSIVE);
+		acquired_lock = true;
+	}
+	else
+		Assert(local_state->lock_mode == LW_EXCLUSIVE);
+
+	if (!chain_page_count_matches_relation(local_state, index_rel))
+		reseed_chain_page_count_locked(local_state, index_rel);
+
+	if (acquired_lock)
+		tp_release_index_lock(local_state);
 }
 
 /*
@@ -1086,7 +966,7 @@ tp_rebuild_index_from_disk(Oid index_oid)
 	TpIndexMetaPage	   early_metap;
 	TpLocalIndexState *local_state;
 	Oid				   heap_oid;
-	TpDataSource	  *chain_src;
+	SubTransactionId   index_create_subid;
 
 	/* Open the index relation */
 	index_rel = index_open(index_oid, AccessShareLock);
@@ -1096,7 +976,8 @@ tp_rebuild_index_from_disk(Oid index_oid)
 		return NULL;
 	}
 
-	heap_oid = index_rel->rd_index->indrelid;
+	heap_oid		   = index_rel->rd_index->indrelid;
+	index_create_subid = index_rel->rd_createSubid;
 
 	/*
 	 * Read the metapage early so we can validate the magic before
@@ -1137,7 +1018,7 @@ tp_rebuild_index_from_disk(Oid index_oid)
 	 * reaches this path.
 	 */
 	local_state = tp_create_shared_index_state(
-			index_oid, heap_oid, /* reuse_if_exists */ true);
+			index_oid, heap_oid, index_create_subid);
 	if (local_state == NULL)
 	{
 		index_close(index_rel, AccessShareLock);
@@ -1152,26 +1033,7 @@ tp_rebuild_index_from_disk(Oid index_oid)
 	 * entirely on the metapage and need no shmem seed.
 	 */
 	tp_acquire_index_lock(local_state, LW_EXCLUSIVE);
-
-	chain_src =
-			tp_memtable_chain_source_create(local_state, index_rel, NULL, 0);
-	if (chain_src != NULL)
-	{
-		uint32 chain_pages;
-
-		chain_pages = tp_memtable_chain_source_page_count(chain_src);
-		tp_source_close(chain_src);
-
-		/*
-		 * The writer always increments chain_page_count strictly
-		 * under SHARED, but we're inside tp_rebuild_index_from_disk's
-		 * LW_EXCLUSIVE (acquired above), so we can atomically
-		 * initialize it without racing the writer.
-		 */
-		pg_atomic_write_u32(
-				&local_state->shared->chain_page_count, chain_pages);
-	}
-
+	reseed_chain_page_count_locked(local_state, index_rel);
 	tp_release_index_lock(local_state);
 	index_close(index_rel, AccessShareLock);
 

--- a/src/index/state.h
+++ b/src/index/state.h
@@ -19,6 +19,7 @@
  * Postgres headers we include here).
  */
 #include <storage/block.h>
+#include <storage/relfilelocator.h>
 
 /* Forward declarations */
 struct TpMemtable;
@@ -96,7 +97,10 @@ typedef struct TpMemtable
 	 * cursor_gen_spill_count is the generation token captured from
 	 * TpSharedIndexState.spill_generation at cold-build time; a
 	 * mismatch on a later apply means a spill raced through and the
-	 * cache is stale.
+	 * cache is stale.  cursor_locator identifies the relation file
+	 * from which the cache was populated, so transaction or savepoint
+	 * rollback after REINDEX cannot reuse a cache built from the
+	 * discarded file.
 	 *
 	 * (cursor_next_blkno, cursor_next_off) is the logical position of
 	 * the next chain record to apply; InvalidBlockNumber means "no
@@ -109,6 +113,8 @@ typedef struct TpMemtable
 	uint64			 cursor_gen_spill_count;
 	BlockNumber		 cursor_next_blkno;
 	uint16			 cursor_next_off;
+	RelFileLocator	 cursor_locator;
+	bool			 cursor_locator_valid;
 	pg_atomic_uint64 cursor_seq;
 
 	/*
@@ -130,43 +136,32 @@ typedef struct TpSharedIndexState
 	Oid index_oid; /* OID of this index */
 	Oid heap_oid;  /* OID of the indexed heap relation */
 
-	/* Memtable stored in DSA */
-	dsa_pointer memtable_dp; /* DSA pointer to TpMemtable */
-
 	/*
-	 * True while this shared state is published by a backend that
-	 * is still in BUILD mode (CREATE INDEX).  In that mode
-	 * `memtable_dp` is a pointer into the **private** DSA of the
-	 * building backend and MUST NOT be dereferenced through the
-	 * global DSA by any other backend (notably the cross-index
-	 * eviction walker at src/memtable/cache.c:evict_walk_cb).
-	 *
-	 * Set to true at registration time in
-	 * tp_create_build_index_state(), cleared in
-	 * tp_finalize_build_mode() under
-	 * tp_registry_eviction_mutex EXCL (the same mutex evict_largest
-	 * walks under) so the walker observes a consistent
-	 * (is_build_mode=false, memtable_dp in global DSA) transition.
-	 *
-	 * Read lock-free by the eviction walker; correctness comes from
-	 * the publish-before-register barrier on the true→true path
-	 * and the eviction_mutex on the true→false transition.
+	 * Runtime cache stored in the global DSA.  The allocation remains
+	 * stable for the lifetime of the registry entry, including REINDEX.
 	 */
-	bool is_build_mode;
+	dsa_pointer memtable_dp; /* DSA pointer to TpMemtable */
 
 	/*
 	 * Auto-spill heuristic for the on-disk memtable: number of
 	 * chain pages currently published in the page chain.
 	 * Incremented after each successful page-publish
 	 * GenericXLogFinish in src/memtable/log.c; reset to 0 after
-	 * tp_spill_finalize() completes.  Not WAL-logged: on crash
-	 * recovery, the counter starts at 0 even if the chain
-	 * survived.  Worst case the heuristic overshoots by ~one
-	 * threshold's worth of pages between restart and the next
-	 * normal merge — acceptable since the counter only governs
-	 * when to spill, not correctness.
+	 * tp_spill_finalize() completes.
+	 *
+	 * A completed CREATE/REINDEX also resets the count and sets
+	 * chain_page_count_needs_reseed.  The next threshold consumer
+	 * recounts the chain in whichever relfilenode PostgreSQL selected
+	 * (new file on commit, restored file on abort) under LW_EXCLUSIVE,
+	 * records that file's locator, then clears the marker.  A locator
+	 * mismatch also forces a recount, covering rollback after an
+	 * in-transaction reseed.  These fields are not WAL-logged.
 	 */
 	pg_atomic_uint32 chain_page_count;
+	pg_atomic_uint32 chain_page_count_needs_reseed;
+	pg_atomic_uint32 chain_page_count_spc_oid;
+	pg_atomic_uint32 chain_page_count_db_oid;
+	pg_atomic_uint32 chain_page_count_rel_number;
 
 	/*
 	 * Cached estimated memtable size in bytes, updated
@@ -185,8 +180,9 @@ typedef struct TpSharedIndexState
 	LWLock lock; /* Per-index lock for this index */
 
 	/*
-	 * Spill generation counter.  Bumped by tp_spill_finalize()
-	 * under LW_EXCLUSIVE after the on-disk chain is truncated.
+	 * Spill generation counter.  Bumped under LW_EXCLUSIVE after
+	 * the on-disk chain is truncated or a completed index build
+	 * replaces the relfilenode.
 	 * Acts as the in-memory memtable cache's invalidation
 	 * token: a cache built against generation N becomes stale
 	 * the moment this counter advances to N+1, even if a new
@@ -210,15 +206,23 @@ typedef struct TpLocalIndexState
 	/* Pointer to shared state in registry */
 	TpSharedIndexState *shared;
 
+	/*
+	 * DSA identity of shared.  This scalar remains safe to compare after a
+	 * committed DROP makes shared itself potentially stale.
+	 */
+	dsa_pointer shared_dp;
+
 	/* DSA attachment for this backend */
 	dsa_area *dsa; /* Attached DSA area for this index */
 
 	/*
-	 * Build mode flag: If true, this backend owns a private DSA that
-	 * gets destroyed and recreated on each spill for perfect memory
-	 * reclamation. If false, uses shared DSA for concurrent access.
+	 * True when this wrapper belongs to an index relation created by the
+	 * current transaction.  It remains set through build finalization so
+	 * abort can remove only state owned by that initial CREATE.  REINDEX
+	 * of a pre-existing relation leaves this false even if the registry
+	 * was cold and the build registered the shared state.
 	 */
-	bool is_build_mode;
+	bool build_created_shared_state;
 
 	/* Transaction-level lock tracking */
 	bool	   lock_held; /* True if we hold the lock in this transaction */
@@ -243,27 +247,19 @@ typedef struct TpLocalIndexState
 /* Function declarations for index state management */
 extern TpLocalIndexState *tp_get_local_index_state(Oid index_oid);
 /*
- * Allocate the per-index shared state, register it in the global
- * registry, and return a local-state handle.
- *
- * If `reuse_if_exists` is true and an entry for `index_oid` is
- * already registered when we go to insert, the just-allocated
- * DSA is freed and we attach to the existing entry — this is
- * what the cold-start bootstrap path uses, so concurrent
- * rebuilds from two backends don't unregister each other.
- *
- * If false, an existing entry is unregistered and replaced; the
- * parallel-build completion path uses this on the assumption
- * that any pre-existing entry is stale (left by a crashed
- * earlier CREATE INDEX).
+ * Create or attach the per-index shared runtime state and return a
+ * backend-local wrapper.  Existing registry state is always reused.
  */
 extern TpLocalIndexState *tp_create_shared_index_state(
-		Oid index_oid, Oid heap_oid, bool reuse_if_exists);
-extern TpLocalIndexState			 *
-tp_create_build_index_state(Oid index_oid, Oid heap_oid);
+		Oid index_oid, Oid heap_oid, SubTransactionId index_create_subid);
+extern TpLocalIndexState *tp_create_build_index_state(
+		Oid index_oid, Oid heap_oid, SubTransactionId index_create_subid);
 extern void tp_cleanup_index_shared_memory(Oid index_oid);
+extern void tp_cleanup_database_shared_memory(Oid database_oid);
 extern void tp_finalize_build_mode(TpLocalIndexState *local_state);
 extern void tp_cleanup_build_mode_on_abort(void);
+extern void tp_commit_build_states(void);
+extern bool tp_has_initial_create_ownership(void);
 extern TpLocalIndexState *tp_rebuild_index_from_disk(Oid index_oid);
 
 /* Helper function for accessing memtable from local state */
@@ -274,6 +270,12 @@ extern void
 tp_acquire_index_lock(TpLocalIndexState *local_state, LWLockMode mode);
 extern void tp_release_index_lock(TpLocalIndexState *local_state);
 extern void tp_release_all_index_locks(void);
+extern void tp_set_chain_page_count_for_relation(
+		TpLocalIndexState *local_state,
+		Relation		   index_rel,
+		uint32			   chain_pages);
+extern void tp_reseed_chain_page_count_if_needed(
+		TpLocalIndexState *local_state, Relation index_rel);
 
 /* Bulk load auto-spill */
 extern void tp_bulk_load_spill_check(void);

--- a/src/memtable/cache.c
+++ b/src/memtable/cache.c
@@ -86,6 +86,58 @@ extern int tp_memory_limit_kb;
  */
 #define TP_CACHE_GLOBAL_SOFT_CAP_DIVISOR 2
 
+static bool
+cache_locator_matches(const TpMemtable *memtable, Relation rel)
+{
+	const RelFileLocator *cached  = &memtable->cursor_locator;
+	const RelFileLocator *current = &rel->rd_locator;
+
+	return memtable->cursor_locator_valid &&
+		   cached->spcOid == current->spcOid &&
+		   cached->dbOid == current->dbOid &&
+		   cached->relNumber == current->relNumber;
+}
+
+static void
+cache_locator_set(TpMemtable *memtable, Relation rel)
+{
+	memtable->cursor_locator	   = rel->rd_locator;
+	memtable->cursor_locator_valid = true;
+}
+
+/*
+ * Drop cache contents built from a different relation file before
+ * admission checks can reject work and leave those stale bytes charged.
+ * The caller already holds the per-index lock.
+ */
+static bool
+cache_drop_locator_mismatch(
+		TpLocalIndexState *local_state, Relation rel, TpMemtable *memtable)
+{
+	bool dropped = false;
+
+	LWLockAcquire(&memtable->apply_lock, LW_EXCLUSIVE);
+	LWLockAcquire(&memtable->lock, LW_SHARED);
+
+	if (memtable->cursor_locator_valid &&
+		!cache_locator_matches(memtable, rel))
+	{
+		LWLockRelease(&memtable->lock);
+		LWLockAcquire(&memtable->lock, LW_EXCLUSIVE);
+		if (memtable->cursor_locator_valid &&
+			!cache_locator_matches(memtable, rel))
+		{
+			tp_cache_clear(local_state->dsa, memtable);
+			dropped = true;
+		}
+	}
+
+	LWLockRelease(&memtable->lock);
+	LWLockRelease(&memtable->apply_lock);
+
+	return dropped;
+}
+
 uint64
 tp_cache_per_index_soft_cap_bytes(void)
 {
@@ -205,6 +257,8 @@ tp_cache_clear(dsa_area *dsa, TpMemtable *memtable)
 	memtable->cursor_gen_spill_count = 0;
 	memtable->cursor_next_blkno		 = InvalidBlockNumber;
 	memtable->cursor_next_off		 = 0;
+	memset(&memtable->cursor_locator, 0, sizeof(memtable->cursor_locator));
+	memtable->cursor_locator_valid = false;
 	pg_atomic_write_u64(&memtable->cursor_seq, 0);
 
 	/*
@@ -219,17 +273,18 @@ tp_cache_clear(dsa_area *dsa, TpMemtable *memtable)
 /* ---------- eviction ---------- */
 
 /*
- * Argmax callback state.  We track (oid, dsa_pointer, bytes) of
- * the largest non-caller cache observed so far.  The dsa pointer
- * lets the post-walk path resolve the victim's shared state
- * without re-walking the registry.
+ * Argmax callback state.  We track (registry key, dsa_pointer,
+ * bytes) of the largest non-caller cache observed so far.  The
+ * dsa pointer lets the post-walk path resolve the victim's shared
+ * state without re-walking the registry.
  */
 typedef struct EvictCandidate
 {
-	Oid			caller_oid;
-	Oid			best_oid;
-	dsa_pointer best_shared_dp;
-	uint64		best_bytes;
+	TpRegistryKey caller_key;
+	TpRegistryKey best_key;
+	dsa_pointer	  best_shared_dp;
+	uint64		  best_bytes;
+	bool		  found;
 } EvictCandidate;
 
 /*
@@ -241,7 +296,7 @@ typedef struct EvictCandidate
  * eviction policy.
  */
 static bool
-evict_walk_cb(Oid oid, dsa_pointer shared_dp, void *ctx)
+evict_walk_cb(TpRegistryKey key, dsa_pointer shared_dp, void *ctx)
 {
 	EvictCandidate	   *c = (EvictCandidate *)ctx;
 	dsa_area		   *dsa;
@@ -249,7 +304,8 @@ evict_walk_cb(Oid oid, dsa_pointer shared_dp, void *ctx)
 	TpMemtable		   *mt;
 	uint64				bytes;
 
-	if (oid == c->caller_oid)
+	if (key.database_oid == c->caller_key.database_oid &&
+		key.index_oid == c->caller_key.index_oid)
 		return false;
 	if (!DsaPointerIsValid(shared_dp))
 		return false;
@@ -261,22 +317,6 @@ evict_walk_cb(Oid oid, dsa_pointer shared_dp, void *ctx)
 	if (st == NULL || !DsaPointerIsValid(st->memtable_dp))
 		return false;
 
-	/*
-	 * Skip entries owned by a backend that is still in
-	 * CREATE INDEX build mode: in that mode `st->memtable_dp` is
-	 * a pointer into the building backend's PRIVATE DSA and
-	 * cannot be safely dereferenced through the global DSA.  The
-	 * flag is set lock-free before tp_registry_register (see
-	 * src/index/state.c:tp_create_build_index_state) and cleared
-	 * under tp_registry_eviction_mutex EXCL (the mutex this
-	 * walker holds via tp_cache_evict_largest), so we either
-	 * observe is_build_mode=true (and skip the private pointer)
-	 * or is_build_mode=false (and the memtable_dp we read below
-	 * is guaranteed to be a global-DSA pointer).
-	 */
-	if (st->is_build_mode)
-		return false;
-
 	mt = (TpMemtable *)dsa_get_address(dsa, st->memtable_dp);
 	if (mt == NULL)
 		return false;
@@ -284,15 +324,16 @@ evict_walk_cb(Oid oid, dsa_pointer shared_dp, void *ctx)
 	bytes = pg_atomic_read_u64(&mt->estimated_bytes);
 	if (bytes > c->best_bytes)
 	{
-		c->best_oid		  = oid;
+		c->best_key		  = key;
 		c->best_shared_dp = shared_dp;
 		c->best_bytes	  = bytes;
+		c->found		  = true;
 	}
 	return false; /* don't stop early; scan all entries */
 }
 
 TpCacheEvictResult
-tp_cache_evict_largest(Oid caller_oid)
+tp_cache_evict_largest(TpRegistryKey caller_key)
 {
 	LWLock			   *mutex = tp_registry_eviction_mutex();
 	dsa_area		   *dsa	  = tp_registry_get_dsa();
@@ -305,14 +346,26 @@ tp_cache_evict_largest(Oid caller_oid)
 
 	LWLockAcquire(mutex, LW_EXCLUSIVE);
 
-	c.caller_oid	 = caller_oid;
-	c.best_oid		 = InvalidOid;
+	c.caller_key	 = caller_key;
+	c.best_key		 = tp_registry_key(InvalidOid, InvalidOid);
 	c.best_shared_dp = InvalidDsaPointer;
 	c.best_bytes	 = 0;
+	c.found			 = false;
 
 	tp_registry_walk(evict_walk_cb, &c);
 
-	if (c.best_oid == InvalidOid || !DsaPointerIsValid(c.best_shared_dp))
+	if (!c.found || !DsaPointerIsValid(c.best_shared_dp))
+	{
+		LWLockRelease(mutex);
+		return TP_CACHE_EVICT_NOTHING_FOUND;
+	}
+
+	/*
+	 * Registry replacements do not take the eviction mutex.  Confirm
+	 * that the qualified victim key still names the DSA allocation
+	 * selected by the walk before dereferencing it.
+	 */
+	if (tp_registry_lookup_dsa(c.best_key) != c.best_shared_dp)
 	{
 		LWLockRelease(mutex);
 		return TP_CACHE_EVICT_NOTHING_FOUND;
@@ -395,7 +448,7 @@ tp_cache_evict_largest(Oid caller_oid)
  * cache locks are out of the chain.
  */
 static bool
-global_cap_check(Oid caller_oid)
+global_cap_check(TpRegistryKey caller_key)
 {
 	uint64 soft = tp_cache_global_soft_cap_bytes();
 	uint64 hard = tp_cache_global_hard_cap_bytes();
@@ -408,7 +461,7 @@ global_cap_check(Oid caller_oid)
 
 	if (soft > 0 && cur >= soft)
 	{
-		(void)tp_cache_evict_largest(caller_oid);
+		(void)tp_cache_evict_largest(caller_key);
 		cur = pg_atomic_read_u64(tp_registry_estimated_total_bytes());
 	}
 
@@ -608,17 +661,41 @@ tp_cache_apply_to_tail(TpLocalIndexState *local_state, Relation rel)
 			 "index oid=%u",
 			 local_state->shared->index_oid);
 
+	if (cache_drop_locator_mismatch(local_state, rel, memtable))
+		return TP_CACHE_APPLY_DROPPED;
+
 	/*
 	 * Apply-protocol-entry hook: enforce the global cap before
 	 * we take cache.apply_lock.  If eviction fails to make room
 	 * and we're over the hard cap, return BUDGET_EXCEEDED so
 	 * the caller falls back to chain_source.
 	 */
-	if (!global_cap_check(local_state->shared->index_oid))
+	if (!global_cap_check(
+				tp_registry_key(MyDatabaseId, local_state->shared->index_oid)))
 		return TP_CACHE_APPLY_BUDGET_EXCEEDED;
 
 	LWLockAcquire(&memtable->apply_lock, LW_EXCLUSIVE);
 	LWLockAcquire(&memtable->lock, LW_SHARED);
+
+	if (memtable->cursor_locator_valid &&
+		!cache_locator_matches(memtable, rel))
+	{
+		/*
+		 * PostgreSQL can restore the previous relfilenode when a
+		 * transaction or savepoint containing REINDEX rolls back.
+		 * Generation alone cannot detect that switch if this cache
+		 * was repopulated after the REINDEX.  Drop the discarded-file
+		 * cache before any cursor block is read from the restored file.
+		 */
+		LWLockRelease(&memtable->lock);
+		LWLockAcquire(&memtable->lock, LW_EXCLUSIVE);
+		if (memtable->cursor_locator_valid &&
+			!cache_locator_matches(memtable, rel))
+			tp_cache_clear(local_state->dsa, memtable);
+		LWLockRelease(&memtable->lock);
+		LWLockRelease(&memtable->apply_lock);
+		return TP_CACHE_APPLY_DROPPED;
+	}
 
 	if (memtable->cursor_next_blkno == InvalidBlockNumber)
 	{
@@ -743,17 +820,24 @@ tp_cache_cold_build(TpLocalIndexState *local_state, Relation rel)
 			 "index oid=%u",
 			 local_state->shared->index_oid);
 
+	(void)cache_drop_locator_mismatch(local_state, rel, memtable);
+
 	/*
 	 * Apply-protocol-entry hook: enforce the global cap before
 	 * we take cache.apply_lock.  Returning ABORT instead of
 	 * building lets the caller fall back to chain_source for
 	 * this query without dirtying any cache state.
 	 */
-	if (!global_cap_check(local_state->shared->index_oid))
+	if (!global_cap_check(
+				tp_registry_key(MyDatabaseId, local_state->shared->index_oid)))
 		return TP_CACHE_COLD_ABORT;
 
 	LWLockAcquire(&memtable->apply_lock, LW_EXCLUSIVE);
 	LWLockAcquire(&memtable->lock, LW_EXCLUSIVE);
+
+	if (memtable->cursor_locator_valid &&
+		!cache_locator_matches(memtable, rel))
+		tp_cache_clear(local_state->dsa, memtable);
 
 	/*
 	 * Lost-race detection: another backend cold-built (or
@@ -899,6 +983,8 @@ tp_cache_cold_build(TpLocalIndexState *local_state, Relation rel)
 		 */
 		tp_cache_clear(local_state->dsa, memtable);
 	}
+	else
+		cache_locator_set(memtable, rel);
 
 	LWLockRelease(&memtable->lock);
 	LWLockRelease(&memtable->apply_lock);
@@ -1188,7 +1274,7 @@ bm25_cache_evict_largest(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("pg_textsearch index \"%s\" not found", idx_name)));
 
-	r = tp_cache_evict_largest(oid);
+	r = tp_cache_evict_largest(tp_registry_key(MyDatabaseId, oid));
 	switch (r)
 	{
 	case TP_CACHE_EVICT_EVICTED:

--- a/src/memtable/cache.h
+++ b/src/memtable/cache.h
@@ -30,11 +30,10 @@
  *                            teardown.  See the per-function
  *                            comment below for its lock contract.
  *
- * Spill detection: every apply call generation-checks the
- * cursor's captured spill_generation against
- * TpSharedIndexState.spill_generation; on mismatch the cache is
- * dropped (apply_to_tail) or the build is rejected (cold_build's
- * RETRY).
+ * Stale-cache detection: every apply call checks both the cursor's
+ * captured spill_generation and the RelFileLocator from which the
+ * cache was populated.  A mismatch drops the cache before any cursor
+ * block is read.
  *
  * Lock order:
  *   per-index LWLock (SHARED for read, EXCL for spill)
@@ -51,6 +50,7 @@
 
 #include <postgres.h>
 
+#include "index/registry.h"
 #include "index/state.h"
 #include "utils/rel.h"
 
@@ -61,11 +61,12 @@
  *                   tail; all locks released.  Caller can serve
  *                   from the cache.
  *
- *   DROPPED         the cursor's captured spill_generation
- *                   disagreed with TpSharedIndexState; the
- *                   cache has been cleared and locks released.
- *                   Caller (read path) decides whether to
- *                   cold_build or fall back to chain_source.
+ *   DROPPED         the cursor's captured spill_generation or
+ *                   RelFileLocator disagreed with the current
+ *                   index state; the cache has been cleared and
+ *                   locks released.  Caller (read path) decides
+ *                   whether to cold_build or fall back to
+ *                   chain_source.
  *
  *   BUDGET_EXCEEDED applying the next chain record would push
  *                   the cache footprint over the per-index soft
@@ -169,12 +170,12 @@ typedef enum TpCacheEvictResult
 } TpCacheEvictResult;
 
 /*
- * Pick the largest cache other than `caller_oid` and evict it
+ * Pick the largest cache other than `caller_key` and evict it
  * (clear its dshash tables, subtract its bytes from the global
  * counter).  Caller MUST hold its own per-index LWLock SHARED
  * (the read path's natural state); MUST NOT hold any cache lock.
  */
-extern TpCacheEvictResult tp_cache_evict_largest(Oid caller_oid);
+extern TpCacheEvictResult tp_cache_evict_largest(TpRegistryKey caller_key);
 
 /*
  * Drain `memtable->estimated_bytes` to zero and subtract the
@@ -188,9 +189,10 @@ extern void tp_cache_account_bytes_drain(TpMemtable *memtable);
 /*
  * Drop the in-memory cache state.  Frees the dshash inverted index
  * and doc-length table (returning their DSA memory to the arena),
- * resets the apply cursor and estimated_bytes to their post-init
- * values, and trims the DSA.  Safe to call when the cache is
- * already empty (handles == DSHASH_HANDLE_INVALID): a no-op then.
+ * resets the apply cursor, source locator, and estimated_bytes to
+ * their post-init values, and trims the DSA.  Safe to call when the
+ * cache is already empty (handles == DSHASH_HANDLE_INVALID): a no-op
+ * then.
  *
  * Does NOT touch:
  *   - apply_lock / lock: these LWLocks live inside the TpMemtable

--- a/src/memtable/cache_source.c
+++ b/src/memtable/cache_source.c
@@ -475,9 +475,7 @@ tp_memtable_source_create_for_read(
 	 * Gate on the GUC and on contexts where the cache cannot be
 	 * trusted to keep up with the chain.  Standbys never apply
 	 * cache mutations (no shared-memory bumps from WAL replay),
-	 * so they must always read the chain directly.  Build mode
-	 * uses a private DSA and bypasses posting-list locks; the
-	 * cache invariants do not hold there.  In all of these
+	 * so they must always read the chain directly.  In these
 	 * cases fall through to chain_source unconditionally.
 	 */
 	if (!tp_memtable_cache_enabled)
@@ -500,17 +498,6 @@ tp_memtable_source_create_for_read(
 		return tp_memtable_chain_source_create(
 				state, rel, query_terms, query_term_count);
 	}
-	if (state->is_build_mode)
-	{
-		if (tp_log_cache_state)
-			elog(LOG,
-				 "pg_textsearch cache_source: disabled_by_build, "
-				 "using chain (oid=%u)",
-				 state->shared->index_oid);
-		return tp_memtable_chain_source_create(
-				state, rel, query_terms, query_term_count);
-	}
-
 	src = tp_memtable_cache_source_create(
 			state, rel, query_terms, query_term_count);
 	if (src != NULL)

--- a/src/memtable/posting.c
+++ b/src/memtable/posting.c
@@ -132,8 +132,7 @@ tp_add_document_to_posting_list(
 	Assert(posting_list != NULL);
 	Assert(ItemPointerIsValid(ctid));
 
-	if (!local_state->is_build_mode)
-		LWLockAcquire(&posting_list->lock, LW_EXCLUSIVE);
+	LWLockAcquire(&posting_list->lock, LW_EXCLUSIVE);
 
 	/* Expand array if needed */
 	if (posting_list->doc_count >= posting_list->capacity)
@@ -190,8 +189,7 @@ tp_add_document_to_posting_list(
 	posting_list->doc_freq	= posting_list->doc_count;
 	posting_list->is_sorted = false; /* New entry may break sort order */
 
-	if (!local_state->is_build_mode)
-		LWLockRelease(&posting_list->lock);
+	LWLockRelease(&posting_list->lock);
 }
 
 /*

--- a/src/memtable/stringtable.c
+++ b/src/memtable/stringtable.c
@@ -331,24 +331,12 @@ tp_get_or_create_posting_list(TpLocalIndexState *local_state, const char *term)
 	/*
 	 * The string hash table must already be initialized
 	 * by tp_ensure_string_table_initialized (called under
-	 * LW_EXCLUSIVE). In build mode it's created lazily
-	 * since there's no concurrency.
+	 * LW_EXCLUSIVE).
 	 */
 	if (memtable->string_hash_handle == DSHASH_HANDLE_INVALID)
-	{
-		if (!local_state->is_build_mode)
-			elog(ERROR,
-				 "String hash table not initialized "
-				 "(call tp_ensure_string_table_initialized "
-				 "first)");
-
-		/* Build mode: create lazily (single-threaded) */
-		string_table = tp_string_table_create(local_state->dsa);
-		if (!string_table)
-			elog(ERROR, "Failed to create string hash table");
-		memtable->string_hash_handle = dshash_get_hash_table_handle(
-				string_table);
-	}
+		elog(ERROR,
+			 "String hash table not initialized "
+			 "(call tp_ensure_string_table_initialized first)");
 	else
 	{
 		string_table = tp_string_table_attach(

--- a/src/mod.c
+++ b/src/mod.c
@@ -12,6 +12,7 @@
 #include <catalog/dependency.h>
 #include <catalog/objectaccess.h>
 #include <catalog/pg_class_d.h>
+#include <commands/dbcommands.h>
 #include <fmgr.h>
 #include <limits.h>
 #include <miscadmin.h>
@@ -559,7 +560,8 @@ tp_object_access(
 		 */
 
 		/* Check if this is one of our indexes */
-		if (!tp_registry_is_registered(objectId))
+		if (!tp_registry_is_registered(
+					tp_registry_key(MyDatabaseId, objectId)))
 			return;
 
 		/* Cleanup shared memory and unregister from registry */
@@ -626,6 +628,7 @@ tp_xact_callback(XactEvent event, void *arg pg_attribute_unused())
 
 	case XACT_EVENT_COMMIT:
 	case XACT_EVENT_PARALLEL_COMMIT:
+		tp_commit_build_states();
 		/* Release all index locks held by this backend */
 		tp_release_all_index_locks();
 		/* Reset bulk load counters for next transaction */
@@ -634,7 +637,7 @@ tp_xact_callback(XactEvent event, void *arg pg_attribute_unused())
 
 	case XACT_EVENT_ABORT:
 	case XACT_EVENT_PARALLEL_ABORT:
-		/* Clean up any in-progress index builds (private DSA) */
+		/* Remove shared state owned by an aborted initial CREATE INDEX. */
 		tp_cleanup_build_mode_on_abort();
 		/* Release all index locks held by this backend */
 		tp_release_all_index_locks();
@@ -643,8 +646,33 @@ tp_xact_callback(XactEvent event, void *arg pg_attribute_unused())
 		break;
 
 	case XACT_EVENT_PRE_PREPARE:
+		if (tp_has_initial_create_ownership())
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot prepare a transaction that created a "
+							"pg_textsearch index"),
+					 errdetail(
+							 "Initial CREATE INDEX shared-state ownership "
+							 "is backend-local and cannot be serialized "
+							 "for two-phase commit."),
+					 errhint("Commit or roll back the CREATE INDEX before "
+							 "preparing the transaction.")));
+		/*
+		 * Spill while PREPARE can still fail.  Once PostgreSQL records the
+		 * prepared transaction, a later backend cannot safely reproduce
+		 * this backend-local threshold decision.
+		 */
+		tp_bulk_load_spill_check();
+		break;
+
 	case XACT_EVENT_PREPARE:
-		/* Nothing to do for these events */
+		/*
+		 * PREPARE is terminal for this backend's transaction just like
+		 * COMMIT or ABORT.  Do not let extension lock tracking or bulk
+		 * counters bleed into the next transaction on this connection.
+		 */
+		tp_release_all_index_locks();
+		tp_reset_bulk_load_counters();
 		break;
 	}
 }
@@ -702,6 +730,45 @@ tp_process_utility(
 		QueryCompletion		 *qc)
 {
 	Node *parsetree = pstmt->utilityStmt;
+
+	if (IsA(parsetree, DropdbStmt))
+	{
+		DropdbStmt *stmt = (DropdbStmt *)parsetree;
+		Oid			database_oid;
+
+		/*
+		 * The pg_database row is gone after standard_ProcessUtility
+		 * succeeds, so resolve the qualified registry key prefix first.
+		 * Let the core command report missing databases and permission
+		 * errors; InvalidOid simply means there is nothing to clean.
+		 */
+		database_oid = get_database_oid(stmt->dbname, true);
+
+		if (prev_process_utility_hook)
+			prev_process_utility_hook(
+					pstmt,
+					queryString,
+					readOnlyTree,
+					context,
+					params,
+					queryEnv,
+					dest,
+					qc);
+		else
+			standard_ProcessUtility(
+					pstmt,
+					queryString,
+					readOnlyTree,
+					context,
+					params,
+					queryEnv,
+					dest,
+					qc);
+
+		if (OidIsValid(database_oid))
+			tp_cleanup_database_shared_memory(database_oid);
+		return;
+	}
 
 	if (IsA(parsetree, IndexStmt))
 	{

--- a/src/mod.c
+++ b/src/mod.c
@@ -12,6 +12,7 @@
 #include <catalog/dependency.h>
 #include <catalog/objectaccess.h>
 #include <catalog/pg_class_d.h>
+#include <catalog/pg_database_d.h>
 #include <commands/dbcommands.h>
 #include <fmgr.h>
 #include <limits.h>
@@ -135,6 +136,15 @@ static shmem_request_hook_type prev_shmem_request_hook = NULL;
 
 /* Previous ProcessUtility hook */
 static ProcessUtility_hook_type prev_process_utility_hook = NULL;
+
+typedef struct TpDropDatabaseContext
+{
+	struct TpDropDatabaseContext *previous;
+	Oid							  database_oid;
+} TpDropDatabaseContext;
+
+/* Active DROP DATABASE invocation, including nested utility hooks. */
+static TpDropDatabaseContext *active_drop_database_context = NULL;
 
 /* Shared memory size calculation */
 static void tp_shmem_request(void);
@@ -549,7 +559,11 @@ tp_object_access(
 	if (prev_object_access_hook)
 		prev_object_access_hook(access, classId, objectId, subId, arg);
 
-	/* We only care about DROP events on relations (indexes are relations) */
+	if (access == OAT_DROP && classId == DatabaseRelationId && subId == 0 &&
+		active_drop_database_context != NULL)
+		active_drop_database_context->database_oid = objectId;
+
+	/* Clean up DROP events on relations (indexes are relations). */
 	if (access == OAT_DROP && classId == RelationRelationId && subId == 0)
 	{
 		/*
@@ -733,37 +747,47 @@ tp_process_utility(
 
 	if (IsA(parsetree, DropdbStmt))
 	{
-		DropdbStmt *stmt = (DropdbStmt *)parsetree;
-		Oid			database_oid;
+		TpDropDatabaseContext *drop_context;
+		Oid					   database_oid;
 
-		/*
-		 * The pg_database row is gone after standard_ProcessUtility
-		 * succeeds, so resolve the qualified registry key prefix first.
-		 * Let the core command report missing databases and permission
-		 * errors; InvalidOid simply means there is nothing to clean.
-		 */
-		database_oid = get_database_oid(stmt->dbname, true);
+		drop_context				 = palloc(sizeof(*drop_context));
+		drop_context->previous		 = active_drop_database_context;
+		drop_context->database_oid	 = InvalidOid;
+		active_drop_database_context = drop_context;
+		PG_TRY();
+		{
+			if (prev_process_utility_hook)
+				prev_process_utility_hook(
+						pstmt,
+						queryString,
+						readOnlyTree,
+						context,
+						params,
+						queryEnv,
+						dest,
+						qc);
+			else
+				standard_ProcessUtility(
+						pstmt,
+						queryString,
+						readOnlyTree,
+						context,
+						params,
+						queryEnv,
+						dest,
+						qc);
+		}
+		PG_CATCH();
+		{
+			active_drop_database_context = drop_context->previous;
+			pfree(drop_context);
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
 
-		if (prev_process_utility_hook)
-			prev_process_utility_hook(
-					pstmt,
-					queryString,
-					readOnlyTree,
-					context,
-					params,
-					queryEnv,
-					dest,
-					qc);
-		else
-			standard_ProcessUtility(
-					pstmt,
-					queryString,
-					readOnlyTree,
-					context,
-					params,
-					queryEnv,
-					dest,
-					qc);
+		active_drop_database_context = drop_context->previous;
+		database_oid				 = drop_context->database_oid;
+		pfree(drop_context);
 
 		if (OidIsValid(database_oid))
 			tp_cleanup_database_shared_memory(database_oid);

--- a/test/expected/abort.out
+++ b/test/expected/abort.out
@@ -39,16 +39,26 @@ SELECT id, ROUND((body <@> to_bm25query('hello', 'abort_test2_idx'))::numeric, 4
   2 | -0.1823
 (1 row)
 
--- Scenario 3: Abort during CREATE INDEX
+-- Scenario 3: Abort during CREATE INDEX after charging its runtime cache
+SELECT bm25_cache_global_estimated_bytes()
+    AS abort_create_baseline \gset
 BEGIN;
 CREATE TABLE abort_test3 (id serial PRIMARY KEY, body text);
 INSERT INTO abort_test3 (body) VALUES ('test document');
-CREATE INDEX ON abort_test3
+CREATE INDEX abort_test3_idx ON abort_test3
     USING bm25 (body) WITH (text_config = 'english');
-NOTICE:  BM25 index build started for relation abort_test3_body_idx
+NOTICE:  BM25 index build started for relation abort_test3_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 1 documents, avg_length=2.00
+-- INSERT only appends the durable chain. A cold build must read it to charge
+-- the derived shared-memory cache before abort cleanup is exercised.
+INSERT INTO abort_test3 (body) VALUES ('charged cache tail');
+SELECT result = 'OK' AND estimated_bytes > 0
+    AS create_abort_cache_charged
+FROM bm25_cache_cold_build('abort_test3_idx') \gset
+\echo create_abort_cache_charged=:create_abort_cache_charged
+create_abort_cache_charged=t
 SELECT 1/0;
 ERROR:  division by zero
 ROLLBACK;
@@ -59,6 +69,10 @@ SELECT count(*) FROM pg_class WHERE relname = 'abort_test3';
      0
 (1 row)
 
+SELECT bm25_cache_global_estimated_bytes() = :abort_create_baseline
+    AS create_abort_accounting_restored \gset
+\echo create_abort_accounting_restored=:create_abort_accounting_restored
+create_abort_accounting_restored=t
 -- Scenario 4: Abort with DDL (DROP TABLE that has a BM25 index)
 CREATE TABLE abort_test4 (id serial PRIMARY KEY, body text);
 CREATE INDEX abort_test4_idx ON abort_test4
@@ -128,10 +142,12 @@ SELECT id FROM abort_test2
 SELECT 1/0;
 ERROR:  division by zero
 ROLLBACK;
--- Scenario 9: SAVEPOINT rollback of CREATE INDEX with populated memtable
--- Exercises SubXactCallback cleanup of dshash tables in memtable
+-- Scenario 9: SAVEPOINT rollback of CREATE INDEX with a charged cache
+-- Exercises SubXactCallback cleanup of cache dshash tables and accounting.
 BEGIN;
 CREATE TABLE abort_subxact1 (id serial PRIMARY KEY, body text);
+SELECT bm25_cache_global_estimated_bytes()
+    AS abort_subxact_create_baseline \gset
 SAVEPOINT sp1;
 CREATE INDEX abort_subxact1_idx ON abort_subxact1
     USING bm25 (body) WITH (text_config = 'english');
@@ -139,10 +155,20 @@ NOTICE:  BM25 index build started for relation abort_subxact1_idx
 NOTICE:  Using text search configuration: english
 NOTICE:  Using index options: k1=1.20, b=0.75
 NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
--- Insert data to populate the memtable (creates string_hash + doc_lengths)
+-- Append durable records, then read them into the shared-memory cache.
 INSERT INTO abort_subxact1 (body) VALUES ('memtable data one');
 INSERT INTO abort_subxact1 (body) VALUES ('memtable data two');
+SELECT result = 'OK' AND estimated_bytes > 0
+    AS subxact_create_abort_cache_charged
+FROM bm25_cache_cold_build('abort_subxact1_idx') \gset
+\echo subxact_create_abort_cache_charged=:subxact_create_abort_cache_charged
+subxact_create_abort_cache_charged=t
 ROLLBACK TO sp1;
+SELECT bm25_cache_global_estimated_bytes()
+           = :abort_subxact_create_baseline
+    AS subxact_create_abort_accounting_restored \gset
+\echo subxact_create_abort_accounting_restored=:subxact_create_abort_accounting_restored
+subxact_create_abort_accounting_restored=t
 -- Table should still be usable without the index
 INSERT INTO abort_subxact1 (body) VALUES ('after rollback');
 COMMIT;

--- a/test/expected/cache_memory_cap.out
+++ b/test/expected/cache_memory_cap.out
@@ -156,10 +156,215 @@ SELECT count(*) AS b_hits FROM (
       5
 (1 row)
 
--- Cleanup
-RESET pg_textsearch.memtable_cache_enabled;
+-- Remove the original test indexes before taking a baseline for the
+-- REINDEX accounting regression.  The baseline is intentionally
+-- relative because the global counter belongs to shared memory.
 DROP INDEX cache_cap_a_idx;
 DROP INDEX cache_cap_b_idx;
 DROP TABLE cache_cap_a;
 DROP TABLE cache_cap_b;
+SELECT bm25_cache_global_estimated_bytes()
+    AS reindex_original_baseline \gset
+-- Keep one populated cache alive across both REINDEX cycles.  This
+-- proves each replaced index releases only its own accounting rather
+-- than relying on the global counter reaching zero.
+CREATE TABLE cache_reindex_control (id int, body text);
+CREATE INDEX cache_reindex_control_idx ON cache_reindex_control
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation cache_reindex_control_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+INSERT INTO cache_reindex_control
+SELECT g, 'control retained ' || g FROM generate_series(1, 10) g;
+SELECT count(*) AS retained_control_hits FROM (
+    SELECT 1 FROM cache_reindex_control
+    ORDER BY body <@>
+        to_bm25query('control', 'cache_reindex_control_idx')
+) q;
+ retained_control_hits 
+-----------------------
+                    10
+(1 row)
+
+SELECT bm25_cache_global_estimated_bytes()
+           - :reindex_original_baseline
+    AS retained_control_bytes \gset
+SELECT :retained_control_bytes > 0 AS retained_control_charged;
+ retained_control_charged 
+--------------------------
+ t
+(1 row)
+
+-- Exercise the parallel REINDEX completion path separately.  The
+-- analyzed row count and worker settings match parallel_build.sql so
+-- both the initial build and REINDEX request one parallel worker.
+SET min_parallel_table_scan_size = 0;
+SET maintenance_work_mem = '256MB';
+SET max_parallel_maintenance_workers = 1;
+CREATE TABLE cache_reindex_parallel (id int, body text);
+INSERT INTO cache_reindex_parallel
+SELECT g, 'parallel database document ' || g
+FROM generate_series(1, 100000) g;
+ANALYZE cache_reindex_parallel;
+CREATE INDEX cache_reindex_parallel_idx ON cache_reindex_parallel
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation cache_reindex_parallel_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  parallel index build: launched 1 of 1 requested workers
+NOTICE:  BM25 index build completed: 100000 documents, avg_length=4.00
+-- Add an unflushed runtime tail after the parallel build, then force
+-- that tail into the cache so REINDEX replaces a charged entry.
+INSERT INTO cache_reindex_parallel
+SELECT g, 'parallel database tail ' || g
+FROM generate_series(100001, 100025) g;
+SELECT count(*) AS parallel_reindex_hits FROM (
+    SELECT 1 FROM cache_reindex_parallel
+    ORDER BY body <@>
+        to_bm25query('database', 'cache_reindex_parallel_idx')
+) q;
+ parallel_reindex_hits 
+-----------------------
+                100000
+(1 row)
+
+SELECT bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS parallel_runtime_cache_charged;
+ parallel_runtime_cache_charged 
+--------------------------------
+ t
+(1 row)
+
+REINDEX INDEX cache_reindex_parallel_idx;
+NOTICE:  BM25 index build started for relation cache_reindex_parallel_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  parallel index build: launched 1 of 1 requested workers
+-- Finalization itself must drain the old cache. Checking before DROP
+-- distinguishes in-place REINDEX cleanup from eventual relation teardown.
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS parallel_reindex_drained_before_drop \gset
+\echo parallel_reindex_drained_before_drop=:parallel_reindex_drained_before_drop
+parallel_reindex_drained_before_drop=t
+DROP TABLE cache_reindex_parallel;
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS parallel_reindex_released,
+       bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS parallel_reindex_exceeds_retained;
+ parallel_reindex_released | parallel_reindex_exceeds_retained 
+---------------------------+-----------------------------------
+ t                         | f
+(1 row)
+
+-- Cycle 1: segment spill, unflushed tail, cache-building scan,
+-- REINDEX, and drop.
+CREATE TABLE cache_reindex_test (id int, body text);
+CREATE INDEX cache_reindex_test_idx ON cache_reindex_test
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation cache_reindex_test_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+INSERT INTO cache_reindex_test
+SELECT g, 'databases original ' || g FROM generate_series(1, 50) g;
+SELECT bm25_spill_index('cache_reindex_test_idx');
+ bm25_spill_index 
+------------------
+                2
+(1 row)
+
+INSERT INTO cache_reindex_test
+SELECT g, 'databases tail ' || g FROM generate_series(51, 75) g;
+SELECT count(*) FROM (
+    SELECT 1 FROM cache_reindex_test
+    ORDER BY body <@> to_bm25query('databases', 'cache_reindex_test_idx')
+) q;
+ count 
+-------
+    75
+(1 row)
+
+REINDEX INDEX cache_reindex_test_idx;
+NOTICE:  BM25 index build started for relation cache_reindex_test_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 75 documents, avg_length=3.00
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS serial_reindex_drained_before_drop \gset
+\echo serial_reindex_drained_before_drop=:serial_reindex_drained_before_drop
+serial_reindex_drained_before_drop=t
+DROP TABLE cache_reindex_test;
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_1_released,
+       bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_1_exceeds_retained;
+ reindex_cycle_1_released | reindex_cycle_1_exceeds_retained 
+--------------------------+----------------------------------
+ t                        | f
+(1 row)
+
+-- Repeat the complete cycle to show that each registry replacement
+-- leaks another cache charge on the unfixed code.
+CREATE TABLE cache_reindex_test (id int, body text);
+CREATE INDEX cache_reindex_test_idx ON cache_reindex_test
+    USING bm25 (body) WITH (text_config = 'english');
+NOTICE:  BM25 index build started for relation cache_reindex_test_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 0 documents, avg_length=0.00
+INSERT INTO cache_reindex_test
+SELECT g, 'databases original ' || g FROM generate_series(1, 50) g;
+SELECT bm25_spill_index('cache_reindex_test_idx');
+ bm25_spill_index 
+------------------
+                2
+(1 row)
+
+INSERT INTO cache_reindex_test
+SELECT g, 'databases tail ' || g FROM generate_series(51, 75) g;
+SELECT count(*) FROM (
+    SELECT 1 FROM cache_reindex_test
+    ORDER BY body <@> to_bm25query('databases', 'cache_reindex_test_idx')
+) q;
+ count 
+-------
+    75
+(1 row)
+
+REINDEX INDEX cache_reindex_test_idx;
+NOTICE:  BM25 index build started for relation cache_reindex_test_idx
+NOTICE:  Using text search configuration: english
+NOTICE:  Using index options: k1=1.20, b=0.75
+NOTICE:  BM25 index build completed: 75 documents, avg_length=3.00
+DROP TABLE cache_reindex_test;
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_2_released,
+       bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_2_exceeds_retained;
+ reindex_cycle_2_released | reindex_cycle_2_exceeds_retained 
+--------------------------+----------------------------------
+ t                        | f
+(1 row)
+
+DROP TABLE cache_reindex_control;
+SELECT bm25_cache_global_estimated_bytes() = :reindex_original_baseline
+           AS control_drop_restored_baseline,
+       bm25_cache_global_estimated_bytes() > :reindex_original_baseline
+           AS control_drop_exceeds_baseline;
+ control_drop_restored_baseline | control_drop_exceeds_baseline 
+--------------------------------+-------------------------------
+ t                              | f
+(1 row)
+
+RESET pg_textsearch.memtable_cache_enabled;
 DROP EXTENSION pg_textsearch CASCADE;

--- a/test/scripts/cross_database_registry.sh
+++ b/test/scripts/cross_database_registry.sh
@@ -1,0 +1,752 @@
+#!/bin/bash
+#
+# Regression test for issue #464: index OIDs are database-local, while the
+# pg_textsearch registry is cluster-wide.  Template clones make matching OIDs
+# deterministic and let this test verify that registry and cache state remain
+# independent across databases.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+TEST_PORT="${TEST_PORT:-55463}"
+TEST_HOST=127.0.0.1
+TOP_K=3
+SEED_DB=pg_textsearch_registry_seed
+DB_A=pg_textsearch_registry_a
+DB_B=pg_textsearch_registry_b
+DB_DROP=pg_textsearch_registry_drop
+DB_FORCE=pg_textsearch_registry_force
+DATA_DIR="${TEST_DIR}/tmp_cross_database_registry_${TEST_PORT}_$$"
+LOGFILE="${DATA_DIR}/postgres.log"
+PRESERVED_LOGFILE="${TEST_DIR}/tmp_cross_database_registry_${TEST_PORT}_$$_postgres.log"
+COMMAND_TIMEOUT_SECONDS=20
+HOLDER_TIMEOUT_SECONDS=60
+
+PG_CONFIG="${PG_CONFIG:-pg_config}"
+PGBINDIR="$("${PG_CONFIG}" --bindir)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+DATA_DIR_OWNED=0
+DATA_DIR_ID=
+HOLDER_PID=
+HOLDER_APPLICATION_NAME=
+
+log() { echo -e "${GREEN}[$(date '+%H:%M:%S')] $1${NC}"; }
+info() { echo -e "${BLUE}[$(date '+%H:%M:%S')] $1${NC}"; }
+
+pass() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    log "PASS: $1"
+}
+
+fail() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo -e "${RED}[$(date '+%H:%M:%S')] FAIL: $1${NC}"
+}
+
+postmaster_pid_is_alive() {
+    local pid
+
+    data_dir_is_owned || return 1
+    [ -f "${DATA_DIR}/postmaster.pid" ] || return 1
+    pid=$(sed -n '1p' "${DATA_DIR}/postmaster.pid")
+    [[ "${pid}" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "${pid}" 2>/dev/null
+}
+
+data_dir_is_owned() {
+    local current_id
+
+    [ "${DATA_DIR_OWNED}" -eq 1 ] || return 1
+    [ -d "${DATA_DIR}" ] && [ ! -L "${DATA_DIR}" ] || return 1
+    current_id=$(stat -c '%d:%i' -- "${DATA_DIR}") || return 1
+    [ "${current_id}" = "${DATA_DIR_ID}" ]
+}
+
+postmaster_matches_data_dir() {
+    local pid_data_dir
+
+    data_dir_is_owned || return 1
+    [ -f "${DATA_DIR}/postmaster.pid" ] || return 1
+    pid_data_dir=$(sed -n '2p' "${DATA_DIR}/postmaster.pid")
+    [ "${pid_data_dir}" = "${DATA_DIR}" ] || return 1
+    "${PGBINDIR}/pg_ctl" status -D "${DATA_DIR}" >/dev/null 2>&1
+}
+
+preserve_failure_log() {
+    data_dir_is_owned || return 1
+    ln -T -- "${LOGFILE}" "${PRESERVED_LOGFILE}"
+}
+
+verify_test_postmaster() {
+    local actual_data_dir
+
+    if ! postmaster_matches_data_dir; then
+        fail "PostgreSQL postmaster is not running from ${DATA_DIR}"
+        return 1
+    fi
+
+    if ! actual_data_dir=$(
+        "${PGBINDIR}/psql" -h "${TEST_HOST}" -p "${TEST_PORT}" \
+            -d postgres -v ON_ERROR_STOP=1 -tA \
+            -c "SHOW data_directory;" 2>&1
+    ); then
+        fail "Could not verify the test postmaster: ${actual_data_dir}"
+        return 1
+    fi
+
+    if [ "${actual_data_dir}" != "${DATA_DIR}" ]; then
+        fail "Port ${TEST_PORT} belongs to ${actual_data_dir}, not ${DATA_DIR}"
+        return 1
+    fi
+}
+
+cleanup() {
+    local exit_code=$?
+    local preserve_data_dir=0
+
+    trap - EXIT
+    trap '' INT TERM
+    set +e
+
+    if ! stop_database_holder; then
+        fail "Could not stop the active database-holder process"
+        exit_code=1
+    fi
+
+    if [ "${DATA_DIR_OWNED}" -eq 0 ]; then
+        exit "${exit_code}"
+    fi
+
+    if ! data_dir_is_owned; then
+        fail "Owned PGDATA identity changed; skipping cleanup"
+        exit 1
+    fi
+
+    log "Cleaning up cross-database registry test (exit code: ${exit_code})..."
+
+    if postmaster_matches_data_dir; then
+        if ! timeout --signal=TERM --kill-after=2s \
+            "${COMMAND_TIMEOUT_SECONDS}s" \
+            "${PGBINDIR}/pg_ctl" stop -D "${DATA_DIR}" -m fast -w; then
+            info "Fast shutdown failed; trying immediate shutdown"
+            if ! timeout --signal=TERM --kill-after=2s \
+                "${COMMAND_TIMEOUT_SECONDS}s" \
+                "${PGBINDIR}/pg_ctl" stop -D "${DATA_DIR}" \
+                -m immediate -w; then
+                fail "PostgreSQL shutdown failed"
+                preserve_data_dir=1
+                exit_code=1
+            fi
+        fi
+    elif postmaster_pid_is_alive; then
+        fail "Cannot confirm ownership of the live postmaster in ${DATA_DIR}"
+        preserve_data_dir=1
+        exit_code=1
+    fi
+
+    if [ "${preserve_data_dir}" -eq 0 ] &&
+        { postmaster_matches_data_dir || postmaster_pid_is_alive; }; then
+        fail "PostgreSQL postmaster is still running after shutdown"
+        preserve_data_dir=1
+        exit_code=1
+    fi
+
+    if [ "${preserve_data_dir}" -eq 0 ] &&
+        [ "${exit_code}" -ne 0 ] && [ -f "${LOGFILE}" ]; then
+        if preserve_failure_log; then
+            info "Preserved server log: ${PRESERVED_LOGFILE}"
+        else
+            fail "Could not safely preserve the server log; preserving ${DATA_DIR}"
+            preserve_data_dir=1
+            exit_code=1
+        fi
+    fi
+
+    if [ "${preserve_data_dir}" -ne 0 ]; then
+        info "Preserved PGDATA and server log: ${DATA_DIR}"
+    elif ! data_dir_is_owned; then
+        fail "Owned PGDATA identity changed; skipping removal"
+        exit_code=1
+    else
+        rm -rf "${DATA_DIR}"
+    fi
+
+    exit "${exit_code}"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+run_sql_quiet() {
+    local database="$1"
+    local sql="$2"
+
+    timeout --signal=TERM --kill-after=2s "${COMMAND_TIMEOUT_SECONDS}s" \
+        "${PGBINDIR}/psql" -h "${TEST_HOST}" -p "${TEST_PORT}" \
+        -d "${database}" -v ON_ERROR_STOP=1 -q -c "${sql}" >/dev/null
+}
+
+run_sql_value() {
+    local database="$1"
+    local sql="$2"
+
+    timeout --signal=TERM --kill-after=2s "${COMMAND_TIMEOUT_SECONDS}s" \
+        "${PGBINDIR}/psql" -h "${TEST_HOST}" -p "${TEST_PORT}" \
+        -d "${database}" -v ON_ERROR_STOP=1 -tA -c "${sql}" 2>&1
+}
+
+run_createdb() {
+    timeout --signal=TERM --kill-after=2s "${COMMAND_TIMEOUT_SECONDS}s" \
+        "${PGBINDIR}/createdb" -h "${TEST_HOST}" -p "${TEST_PORT}" "$@"
+}
+
+run_dropdb() {
+    timeout --signal=TERM --kill-after=2s "${COMMAND_TIMEOUT_SECONDS}s" \
+        "${PGBINDIR}/dropdb" -h "${TEST_HOST}" -p "${TEST_PORT}" "$@"
+}
+
+holder_process_is_running() {
+    local state
+
+    [ -n "${HOLDER_PID}" ] || return 1
+    state=$(ps -o stat= -p "${HOLDER_PID}" 2>/dev/null) || return 1
+    [[ "${state}" != Z* ]]
+}
+
+wait_for_holder_exit() {
+    local deadline=$((SECONDS + 10))
+    local holder_pid="${HOLDER_PID}"
+
+    [ -n "${holder_pid}" ] || return 0
+
+    while holder_process_is_running; do
+        if [ "${SECONDS}" -ge "${deadline}" ]; then
+            return 1
+        fi
+        sleep 0.1
+    done
+
+    wait "${holder_pid}" 2>/dev/null || true
+    HOLDER_PID=
+    HOLDER_APPLICATION_NAME=
+}
+
+start_database_holder() {
+    local database="$1"
+    local application_name="$2"
+    local connected
+
+    if [ -n "${HOLDER_PID}" ]; then
+        fail "Refusing to replace an active database-holder process"
+        return 1
+    fi
+
+    PGAPPNAME="${application_name}" \
+        timeout --signal=TERM --kill-after=2s \
+        "${HOLDER_TIMEOUT_SECONDS}s" \
+        "${PGBINDIR}/psql" -h "${TEST_HOST}" -p "${TEST_PORT}" \
+        -d "${database}" -v ON_ERROR_STOP=1 -q \
+        -c "SELECT pg_sleep(300);" >/dev/null 2>&1 &
+    HOLDER_PID=$!
+    HOLDER_APPLICATION_NAME="${application_name}"
+
+    for _ in $(seq 1 100); do
+        connected=$(run_sql_value postgres "
+            SELECT count(*)
+            FROM pg_stat_activity
+            WHERE datname = '${database}'
+              AND application_name = '${application_name}';
+        ")
+        if [ "${connected}" = "1" ]; then
+            pass "${database} has an active test connection"
+            return 0
+        fi
+        if ! holder_process_is_running; then
+            wait_for_holder_exit || true
+            fail "${database} test connection exited before registering"
+            return 1
+        fi
+        sleep 0.05
+    done
+
+    fail "${database} test connection did not register"
+    return 1
+}
+
+stop_database_holder() {
+    local holder_pid="${HOLDER_PID}"
+
+    [ -n "${holder_pid}" ] || return 0
+
+    if postmaster_matches_data_dir &&
+        [ -n "${HOLDER_APPLICATION_NAME}" ]; then
+        run_sql_quiet postgres "
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE application_name = '${HOLDER_APPLICATION_NAME}';
+        " || true
+    fi
+
+    if wait_for_holder_exit; then
+        return 0
+    fi
+
+    kill "${holder_pid}" 2>/dev/null || true
+    if wait_for_holder_exit; then
+        return 0
+    fi
+
+    kill -KILL "${holder_pid}" 2>/dev/null || true
+    wait "${holder_pid}" 2>/dev/null || true
+    HOLDER_PID=
+    HOLDER_APPLICATION_NAME=
+    return 1
+}
+
+assert_equals() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [ "${actual}" = "${expected}" ]; then
+        pass "${label}"
+    else
+        fail "${label}: expected '${expected}', got '${actual}'"
+    fi
+}
+
+cache_cold_build() {
+    local database="$1"
+
+    cache_cold_build_index "${database}" docs_idx
+}
+
+cache_cold_build_index() {
+    local database="$1"
+    local index_name="$2"
+
+    run_sql_value "${database}" "
+        SELECT result || '|' || records_applied || '|' ||
+               cursor_seq || '|' || estimated_bytes
+        FROM bm25_cache_cold_build('${index_name}');
+    "
+}
+
+cache_apply() {
+    local database="$1"
+
+    cache_apply_index "${database}" docs_idx
+}
+
+cache_apply_index() {
+    local database="$1"
+    local index_name="$2"
+
+    run_sql_value "${database}" "
+        SELECT result || '|' || records_applied || '|' ||
+               cursor_seq || '|' || estimated_bytes
+        FROM bm25_cache_apply_to_tail('${index_name}');
+    "
+}
+
+top_hits() {
+    local database="$1"
+    local term="$2"
+
+    run_sql_value "${database}" "
+        SELECT count(*) || '|' ||
+               bool_and(body LIKE '${term} marker %') || '|' ||
+               string_agg(id::text, ',' ORDER BY score, id)
+        FROM (
+            SELECT id, body,
+                   body <@> to_bm25query('${term}', 'docs_idx') AS score
+            FROM docs
+            ORDER BY body <@> to_bm25query('${term}', 'docs_idx')
+            LIMIT ${TOP_K}
+        ) hits
+    "
+}
+
+setup_cluster() {
+    log "Setting up isolated PostgreSQL cluster..."
+
+    if ! mkdir -m 700 -- "${DATA_DIR}" 2>/dev/null; then
+        fail "Refusing to replace existing PGDATA: ${DATA_DIR}"
+        return 1
+    fi
+    if ! DATA_DIR_ID=$(stat -c '%d:%i' -- "${DATA_DIR}"); then
+        fail "Could not record ownership of PGDATA: ${DATA_DIR}"
+        return 1
+    fi
+    DATA_DIR_OWNED=1
+
+    if ! "${PGBINDIR}/initdb" -D "${DATA_DIR}" \
+        --auth-local=trust --auth-host=trust >/dev/null 2>&1; then
+        fail "initdb failed"
+        return 1
+    fi
+
+    cat >>"${DATA_DIR}/postgresql.conf" <<EOF
+port = ${TEST_PORT}
+max_connections = 20
+shared_buffers = 128MB
+unix_socket_directories = ''
+listen_addresses = '${TEST_HOST}'
+log_min_messages = warning
+shared_preload_libraries = 'pg_textsearch'
+pg_textsearch.bulk_load_threshold = 0
+pg_textsearch.memtable_pages_threshold = 0
+pg_textsearch.memtable_cache_enabled = on
+EOF
+
+    if ! timeout --signal=TERM --kill-after=2s \
+        "${COMMAND_TIMEOUT_SECONDS}s" \
+        "${PGBINDIR}/pg_ctl" start -D "${DATA_DIR}" \
+        -l "${LOGFILE}" -w; then
+        fail "PostgreSQL failed to start"
+        return 1
+    fi
+    verify_test_postmaster || return 1
+
+    run_createdb "${SEED_DB}"
+    run_sql_quiet "${SEED_DB}" "
+        CREATE EXTENSION pg_textsearch VERSION '1.5.0-dev';
+        CREATE TABLE docs (id bigserial PRIMARY KEY, body text NOT NULL);
+        CREATE INDEX docs_idx ON docs USING bm25 (body)
+            WITH (text_config = 'english');
+        INSERT INTO docs(body) VALUES ('shared seed document');
+    "
+
+    run_createdb --template="${SEED_DB}" "${DB_A}"
+    run_createdb --template="${SEED_DB}" "${DB_B}"
+    run_dropdb "${SEED_DB}"
+
+    # Clear the registry entry created while building the template.  The
+    # cloned databases retain identical catalogs and relation files, but the
+    # first post-restart access must rebuild each database's registry state.
+    if ! timeout --signal=TERM --kill-after=2s \
+        "${COMMAND_TIMEOUT_SECONDS}s" \
+        "${PGBINDIR}/pg_ctl" restart -D "${DATA_DIR}" \
+        -l "${LOGFILE}" -w; then
+        fail "PostgreSQL failed to restart"
+        return 1
+    fi
+    verify_test_postmaster || return 1
+}
+
+main() {
+    local oid_a oid_b
+    local cold_a cold_b
+    local a_cursor a_bytes b_cursor b_bytes
+    local a_after_b_cache a_before_reindex a_after_reindex
+    local global_a global_b global_after_evict expected_global
+    local evict_result a_after_evict b_after_evict
+    local a_top_hits b_top_hits
+    local baseline_global b_before_drop b_after_drop
+    local drop_cache drop_extra_cache drop_bytes drop_extra_bytes
+    local drop_before_failed drop_after_failed
+    local drop_extra_before_failed drop_extra_after_failed
+    local global_with_drop global_after_drop drop_status
+    local force_cache force_extra_cache force_bytes force_extra_bytes
+    local global_with_force global_after_force force_status
+
+    command -v "${PGBINDIR}/pg_ctl" >/dev/null 2>&1 ||
+        {
+            fail "pg_ctl not found"
+            return 1
+        }
+    command -v timeout >/dev/null 2>&1 ||
+        {
+            fail "timeout not found"
+            return 1
+        }
+
+    setup_cluster || return 1
+
+    oid_a=$(run_sql_value "${DB_A}" "SELECT 'docs_idx'::regclass::oid;")
+    oid_b=$(run_sql_value "${DB_B}" "SELECT 'docs_idx'::regclass::oid;")
+    if [[ "${oid_a}" =~ ^[0-9]+$ ]] && [ "${oid_a}" = "${oid_b}" ]; then
+        pass "template clones have matching BM25 index OIDs (${oid_a})"
+    else
+        fail "matching-OID setup failed: db_a=${oid_a}, db_b=${oid_b}"
+    fi
+
+    run_sql_quiet "${DB_A}" "
+        INSERT INTO docs(body)
+        SELECT 'alpha marker ' || lpad(g::text, 2, '0') ||
+               repeat(' alpha', 10 - g)
+        FROM generate_series(1, 4) g;
+    "
+    run_sql_quiet "${DB_B}" "
+        INSERT INTO docs(body)
+        SELECT 'bravo marker ' || lpad(g::text, 2, '0') ||
+               repeat(' bravo', 10 - g)
+        FROM generate_series(1, 9) g;
+    "
+
+    cold_a=$(cache_cold_build "${DB_A}")
+    IFS='|' read -r result records a_cursor a_bytes <<<"${cold_a}"
+    assert_equals "database A cold-build result" "OK" "${result}"
+    assert_equals "database A cache record count" "5" "${records}"
+    if [[ "${a_bytes}" =~ ^[0-9]+$ ]] && [ "${a_bytes}" -gt 0 ]; then
+        pass "database A cache has independent nonzero accounting"
+    else
+        fail "database A cache accounting is invalid: '${a_bytes}'"
+    fi
+
+    cold_b=$(cache_cold_build "${DB_B}")
+    IFS='|' read -r result records b_cursor b_bytes <<<"${cold_b}"
+    assert_equals "database B cold-build is independent" "OK" "${result}"
+    assert_equals "database B cache record count" "10" "${records}"
+    if [[ "${b_bytes}" =~ ^[0-9]+$ ]] && [ "${b_bytes}" -gt 0 ]; then
+        pass "database B cache has independent nonzero accounting"
+    else
+        fail "database B cache accounting is invalid: '${b_bytes}'"
+    fi
+
+    a_after_b_cache=$(cache_apply "${DB_A}")
+    assert_equals "database B cache build leaves A cache unchanged" \
+        "OK|0|${a_cursor}|${a_bytes}" "${a_after_b_cache}"
+
+    global_a=$(run_sql_value "${DB_A}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    global_b=$(run_sql_value "${DB_B}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    assert_equals "global cache accounting is cluster-wide" \
+        "${global_a}" "${global_b}"
+    if [[ "${a_bytes}" =~ ^[0-9]+$ ]] &&
+        [[ "${b_bytes}" =~ ^[0-9]+$ ]]; then
+        expected_global=$((a_bytes + b_bytes))
+        assert_equals "global accounting includes both databases" \
+            "${expected_global}" "${global_a}"
+    else
+        fail "cannot validate global accounting: A=${a_bytes}, B=${b_bytes}"
+    fi
+
+    a_top_hits=$(top_hits "${DB_A}" "alpha")
+    b_top_hits=$(top_hits "${DB_B}" "bravo")
+    assert_equals "database A returns its ranked top ${TOP_K}" \
+        "3|true|2,3,4" "${a_top_hits}"
+    assert_equals "database B returns its ranked top ${TOP_K}" \
+        "3|true|2,3,4" "${b_top_hits}"
+
+    # The eviction budget remains cluster-wide.  With B as the caller, A is
+    # the only eligible victim even though both indexes have the same OID.
+    evict_result=$(run_sql_value "${DB_B}" \
+        "SELECT bm25_cache_evict_largest('docs_idx');")
+    assert_equals "cross-database eviction distinguishes the caller key" \
+        "evicted" "${evict_result}"
+    a_after_evict=$(cache_apply "${DB_A}")
+    b_after_evict=$(cache_apply "${DB_B}")
+    assert_equals "cross-database eviction selected database A" \
+        "NOT_INITIALIZED|0|0|0" "${a_after_evict}"
+    assert_equals "cross-database eviction preserved caller B" \
+        "OK|0|${b_cursor}|${b_bytes}" "${b_after_evict}"
+    global_after_evict=$(run_sql_value "${DB_A}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    assert_equals "cross-database eviction drains global accounting" \
+        "${b_bytes}" "${global_after_evict}"
+
+    cold_a=$(cache_cold_build "${DB_A}")
+    IFS='|' read -r result records a_cursor a_bytes <<<"${cold_a}"
+    assert_equals "database A cache rebuild after eviction" "OK" "${result}"
+    assert_equals "database A rebuilt cache record count" "5" "${records}"
+
+    a_before_reindex=$(cache_apply "${DB_A}")
+    if run_sql_quiet "${DB_B}" "REINDEX INDEX docs_idx;"; then
+        pass "database B REINDEX completed"
+    else
+        fail "database B REINDEX failed"
+    fi
+    a_after_reindex=$(cache_apply "${DB_A}")
+    assert_equals "database B REINDEX leaves A registry/cache state unchanged" \
+        "${a_before_reindex}" "${a_after_reindex}"
+
+    a_top_hits=$(top_hits "${DB_A}" "alpha")
+    b_top_hits=$(top_hits "${DB_B}" "bravo")
+    assert_equals "database A top ${TOP_K} survives B REINDEX" \
+        "3|true|2,3,4" "${a_top_hits}"
+    assert_equals "database B top ${TOP_K} survives its REINDEX" \
+        "3|true|2,3,4" "${b_top_hits}"
+
+    baseline_global=$(run_sql_value "${DB_B}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    b_before_drop=$(cache_apply "${DB_B}")
+
+    run_createdb --template="${DB_A}" "${DB_DROP}"
+    run_sql_quiet "${DB_DROP}" "
+        INSERT INTO docs(body)
+        SELECT 'charlie marker ' || lpad(g::text, 2, '0') ||
+               repeat(' charlie', 10 - g)
+        FROM generate_series(1, 6) g;
+        CREATE TABLE extra_docs (
+            id bigserial PRIMARY KEY,
+            body text NOT NULL
+        );
+        CREATE INDEX extra_docs_idx ON extra_docs USING bm25 (body)
+            WITH (text_config = 'english');
+        INSERT INTO extra_docs(body)
+        SELECT 'delta marker ' || lpad(g::text, 2, '0') ||
+               repeat(' delta', 8 - g)
+        FROM generate_series(1, 4) g;
+    "
+    drop_cache=$(cache_cold_build "${DB_DROP}")
+    IFS='|' read -r result records _ drop_bytes <<<"${drop_cache}"
+    assert_equals "drop-test database cold-build result" "OK" "${result}"
+    assert_equals "drop-test database cache record count" "11" "${records}"
+    if [[ "${drop_bytes}" =~ ^[0-9]+$ ]] && [ "${drop_bytes}" -gt 0 ]; then
+        pass "drop-test database cache has nonzero accounting"
+    else
+        fail "drop-test database cache accounting is invalid: '${drop_bytes}'"
+    fi
+    drop_extra_cache=$(cache_cold_build_index "${DB_DROP}" extra_docs_idx)
+    IFS='|' read -r result records _ drop_extra_bytes <<<"${drop_extra_cache}"
+    assert_equals "drop-test second index cold-build result" "OK" "${result}"
+    assert_equals "drop-test second index cache record count" "4" "${records}"
+    if [[ "${drop_extra_bytes}" =~ ^[0-9]+$ ]] &&
+        [ "${drop_extra_bytes}" -gt 0 ]; then
+        pass "drop-test second index has nonzero accounting"
+    else
+        fail "drop-test second index accounting is invalid: '${drop_extra_bytes}'"
+    fi
+    global_with_drop=$(run_sql_value "${DB_B}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    assert_equals "drop-test database contributes both registry entries" \
+        "$((baseline_global + drop_bytes + drop_extra_bytes))" \
+        "${global_with_drop}"
+
+    drop_before_failed=$(cache_apply "${DB_DROP}")
+    drop_extra_before_failed=$(cache_apply_index "${DB_DROP}" extra_docs_idx)
+    start_database_holder "${DB_DROP}" pgts_drop_holder
+    set +e
+    run_dropdb "${DB_DROP}" >/dev/null 2>&1
+    drop_status=$?
+    set -e
+    if [ "${drop_status}" -eq 0 ]; then
+        fail "ordinary DROP DATABASE unexpectedly succeeded with an active connection"
+    elif [ "${drop_status}" -eq 124 ] || [ "${drop_status}" -eq 137 ]; then
+        fail "ordinary DROP DATABASE timed out instead of failing promptly"
+    else
+        pass "failed DROP DATABASE preserves the populated database"
+    fi
+    assert_equals "failed DROP DATABASE preserves global accounting" \
+        "${global_with_drop}" \
+        "$(run_sql_value "${DB_B}" \
+            "SELECT bm25_cache_global_estimated_bytes();")"
+    drop_after_failed=$(cache_apply "${DB_DROP}")
+    assert_equals "failed DROP DATABASE preserves registry/cache state" \
+        "${drop_before_failed}" "${drop_after_failed}"
+    drop_extra_after_failed=$(cache_apply_index "${DB_DROP}" extra_docs_idx)
+    assert_equals "failed DROP DATABASE preserves every registry entry" \
+        "${drop_extra_before_failed}" "${drop_extra_after_failed}"
+    stop_database_holder ||
+        fail "failed DROP DATABASE holder did not stop within 10 seconds"
+
+    if run_dropdb "${DB_DROP}"; then
+        pass "successful DROP DATABASE completed"
+    else
+        fail "successful DROP DATABASE failed"
+    fi
+    global_after_drop=$(run_sql_value "${DB_B}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    assert_equals "successful DROP DATABASE releases only its accounting" \
+        "${baseline_global}" "${global_after_drop}"
+    assert_equals "successful DROP DATABASE removes both cache charges" \
+        "$((drop_bytes + drop_extra_bytes))" \
+        "$((global_with_drop - global_after_drop))"
+    b_after_drop=$(cache_apply "${DB_B}")
+    assert_equals "successful DROP DATABASE preserves database B cache" \
+        "${b_before_drop}" "${b_after_drop}"
+    assert_equals "successful DROP DATABASE preserves database B queries" \
+        "3|true|2,3,4" "$(top_hits "${DB_B}" "bravo")"
+
+    run_createdb --template="${DB_A}" "${DB_FORCE}"
+    run_sql_quiet "${DB_FORCE}" "
+        INSERT INTO docs(body)
+        SELECT 'foxtrot marker ' || lpad(g::text, 2, '0') ||
+               repeat(' foxtrot', 12 - g)
+        FROM generate_series(1, 7) g;
+        CREATE TABLE force_extra_docs (
+            id bigserial PRIMARY KEY,
+            body text NOT NULL
+        );
+        CREATE INDEX force_extra_docs_idx
+            ON force_extra_docs USING bm25 (body)
+            WITH (text_config = 'english');
+        INSERT INTO force_extra_docs(body)
+        SELECT 'golf marker ' || lpad(g::text, 2, '0') ||
+               repeat(' golf', 8 - g)
+        FROM generate_series(1, 4) g;
+    "
+    force_cache=$(cache_cold_build "${DB_FORCE}")
+    IFS='|' read -r result records _ force_bytes <<<"${force_cache}"
+    assert_equals "force-drop database cold-build result" "OK" "${result}"
+    assert_equals "force-drop database cache record count" "12" "${records}"
+    force_extra_cache=$(
+        cache_cold_build_index "${DB_FORCE}" force_extra_docs_idx
+    )
+    IFS='|' read -r result records _ force_extra_bytes <<<"${force_extra_cache}"
+    assert_equals "force-drop second index cold-build result" "OK" "${result}"
+    assert_equals "force-drop second index cache record count" "4" "${records}"
+    if [[ "${force_bytes}" =~ ^[0-9]+$ ]] &&
+        [[ "${force_extra_bytes}" =~ ^[0-9]+$ ]] &&
+        [ "${force_bytes}" -gt 0 ] && [ "${force_extra_bytes}" -gt 0 ]; then
+        pass "force-drop database has two nonzero cache charges"
+    else
+        fail "force-drop cache accounting is invalid: ${force_bytes}, ${force_extra_bytes}"
+    fi
+    global_with_force=$(run_sql_value "${DB_B}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    assert_equals "force-drop database contributes both registry entries" \
+        "$((baseline_global + force_bytes + force_extra_bytes))" \
+        "${global_with_force}"
+
+    start_database_holder "${DB_FORCE}" pgts_force_holder
+    set +e
+    run_dropdb --force "${DB_FORCE}" >/dev/null 2>&1
+    force_status=$?
+    set -e
+    if [ "${force_status}" -eq 0 ]; then
+        pass "DROP DATABASE WITH (FORCE) completed"
+    elif [ "${force_status}" -eq 124 ] || [ "${force_status}" -eq 137 ]; then
+        fail "DROP DATABASE WITH (FORCE) timed out"
+    else
+        fail "DROP DATABASE WITH (FORCE) failed with status ${force_status}"
+    fi
+    if wait_for_holder_exit; then
+        pass "forced DROP DATABASE reaped its terminated client"
+    else
+        fail "forced DROP DATABASE client did not exit within 10 seconds"
+        stop_database_holder || true
+    fi
+    global_after_force=$(run_sql_value "${DB_B}" \
+        "SELECT bm25_cache_global_estimated_bytes();")
+    assert_equals "DROP DATABASE WITH (FORCE) releases only its accounting" \
+        "${baseline_global}" "${global_after_force}"
+    assert_equals "DROP DATABASE WITH (FORCE) removes both cache charges" \
+        "$((force_bytes + force_extra_bytes))" \
+        "$((global_with_force - global_after_force))"
+    assert_equals "DROP DATABASE WITH (FORCE) preserves database B cache" \
+        "${b_before_drop}" "$(cache_apply "${DB_B}")"
+    assert_equals "DROP DATABASE WITH (FORCE) preserves database B queries" \
+        "3|true|2,3,4" "$(top_hits "${DB_B}" "bravo")"
+
+    info "Assertions: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+    if [ "${FAIL_COUNT}" -ne 0 ]; then
+        return 1
+    fi
+
+    log "All cross-database registry tests passed"
+}
+
+main "$@"

--- a/test/scripts/multi_backend_reindex.sh
+++ b/test/scripts/multi_backend_reindex.sh
@@ -27,15 +27,16 @@
 #
 # As of pg_textsearch 1.3.0 (#374/#375/#392) the memtable lives in
 # the index relation's own on-disk pages, so the new relfilenode is
-# automatically empty and stale local-state pointers become
-# harmless. This test pins that behaviour so the bug cannot be
-# reintroduced — for every member of the heap-rewrite / index-rebuild
-# class.
+# automatically empty. The shared-state allocation and its LWLock
+# must remain stable across rewrites because backend-local wrappers
+# are intentionally cached for the backend lifetime. This test pins
+# both properties for every heap-rewrite / index-rebuild path.
 #
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # Allow override but default to a port not used by any other test script.
 # (cross-checked against test/scripts/*.sh: 55434–55450, 55454–55457,
 # 55460–55462 are taken; 55458 is free as of this writing.)
@@ -44,11 +45,13 @@ TEST_DB=pg_textsearch_reindex_test
 # Unique per-PID data dir so concurrent invocations (e.g. accidental
 # parallel make) cannot rm -rf each other's clusters.
 DATA_DIR="${SCRIPT_DIR}/../tmp_reindex_test_${TEST_PORT}_$$"
+SOCKET_DIR="${WORKTREE_ROOT}/.s$$"
 LOGFILE="${DATA_DIR}/postgres.log"
 # Preserved server-log destination if the test fails — kept outside
 # DATA_DIR so it survives the cleanup `rm -rf`. CI can `cat` this on
 # failure for post-mortem.
 PRESERVED_LOGFILE="${SCRIPT_DIR}/../tmp_reindex_test_${TEST_PORT}_$$_postgres.log"
+PREPARE_CLIENT_PID=
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -66,6 +69,7 @@ cleanup() {
     # Disarm the trap so a signal during cleanup doesn't re-enter us.
     trap - EXIT INT TERM
     log "Cleaning up reindex test environment (exit code: $exit_code)..."
+    stop_prepare_client || true
     # On failure, preserve postgres.log outside DATA_DIR so CI can
     # surface it for debugging — DATA_DIR is about to be wiped.
     if [ "${exit_code}" -ne 0 ] && [ -f "${LOGFILE}" ]; then
@@ -80,6 +84,7 @@ cleanup() {
             true
     fi
     rm -rf "${DATA_DIR}"
+    rm -rf "${SOCKET_DIR}"
     exit $exit_code
 }
 
@@ -90,6 +95,7 @@ setup_test_db() {
 
     rm -rf "${DATA_DIR}"
     mkdir -p "${DATA_DIR}"
+    mkdir -p "${SOCKET_DIR}"
 
     initdb -D "${DATA_DIR}" --auth-local=trust --auth-host=trust \
         >/dev/null 2>&1
@@ -104,8 +110,12 @@ setup_test_db() {
     cat >> "${DATA_DIR}/postgresql.conf" << EOF
 port = ${TEST_PORT}
 max_connections = 20
+max_worker_processes = 8
+max_parallel_workers = 4
+max_parallel_maintenance_workers = 2
+max_prepared_transactions = 10
 shared_buffers = 128MB
-unix_socket_directories = '${DATA_DIR}'
+unix_socket_directories = '${SOCKET_DIR}'
 listen_addresses = ''
 log_min_messages = warning
 shared_preload_libraries = 'pg_textsearch'
@@ -116,18 +126,19 @@ EOF
     pg_ctl start -D "${DATA_DIR}" -l "${LOGFILE}" -w \
         || error "Failed to start PostgreSQL"
 
-    createdb -h "${DATA_DIR}" -p "${TEST_PORT}" "${TEST_DB}"
-    psql -h "${DATA_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+    createdb -h "${SOCKET_DIR}" -p "${TEST_PORT}" "${TEST_DB}"
+    psql -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
         -c "CREATE EXTENSION pg_textsearch;" >/dev/null
 }
 
 run_sql() {
-    psql -h "${DATA_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" -c "$1" 2>&1
+    psql -X -v ON_ERROR_STOP=1 -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -c "$1" 2>&1
 }
 
 run_sql_quiet() {
-    psql -h "${DATA_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
-        -c "$1" >/dev/null 2>&1
+    psql -X -v ON_ERROR_STOP=1 -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -c "$1" >/dev/null 2>&1
 }
 
 # run_sql_value: scalar fetch. Captures stderr (2>&1) so that any
@@ -136,7 +147,1420 @@ run_sql_quiet() {
 # validate the format (e.g. `[[ $val =~ ^[0-9]+$ ]]`) because the
 # returned value may be an error message rather than a number.
 run_sql_value() {
-    psql -h "${DATA_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" -tAc "$1" 2>&1
+    psql -X -v ON_ERROR_STOP=1 -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -tAc "$1" 2>&1
+}
+
+run_sql_quiet_bounded() {
+    timeout --signal=TERM --kill-after=2s 20s \
+        psql -X -v ON_ERROR_STOP=1 -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -q -c "$1" >/dev/null 2>&1
+}
+
+run_sql_value_bounded() {
+    timeout --signal=TERM --kill-after=2s 20s \
+        psql -X -v ON_ERROR_STOP=1 -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" -tAc "$1" 2>&1
+}
+
+prepare_client_is_running() {
+    local state
+
+    [ -n "${PREPARE_CLIENT_PID}" ] || return 1
+    state=$(ps -o stat= -p "${PREPARE_CLIENT_PID}" 2>/dev/null) || return 1
+    [[ "${state}" != Z* ]]
+}
+
+wait_for_prepare_client_exit() {
+    local deadline=$((SECONDS + 10))
+    local client_pid="${PREPARE_CLIENT_PID}"
+
+    [ -n "${client_pid}" ] || return 0
+
+    while prepare_client_is_running; do
+        if [ "${SECONDS}" -ge "${deadline}" ]; then
+            return 1
+        fi
+        sleep 0.1
+    done
+
+    wait "${client_pid}" 2>/dev/null || true
+    PREPARE_CLIENT_PID=
+}
+
+stop_prepare_client() {
+    local client_pid="${PREPARE_CLIENT_PID}"
+
+    [ -n "${client_pid}" ] || return 0
+
+    kill "${client_pid}" 2>/dev/null || true
+    if wait_for_prepare_client_exit; then
+        return 0
+    fi
+
+    kill -KILL "${client_pid}" 2>/dev/null || true
+    wait "${client_pid}" 2>/dev/null || true
+    PREPARE_CLIENT_PID=
+    return 1
+}
+
+wait_for_prepare_marker() {
+    local marker_file="$1"
+    local deadline=$((SECONDS + 10))
+
+    while [ ! -f "${marker_file}" ]; do
+        if ! prepare_client_is_running; then
+            return 1
+        fi
+        if [ "${SECONDS}" -ge "${deadline}" ]; then
+            return 1
+        fi
+        sleep 0.05
+    done
+}
+
+# Build a committed index whose old relfilenode has no memtable chain.  Each
+# rollback test then REINDEXes it, appends enough large records to put the new
+# cache cursor beyond the old file's EOF, and opens the cache through a normal
+# BM25 query.  PostgreSQL restores the old relfilenode at the selected rollback
+# boundary, so the next normal query must reject the discarded-file cursor.
+prepare_cache_locator_rollback_fixture() {
+    run_sql_quiet "
+        DROP TABLE IF EXISTS cache_locator_docs CASCADE;
+        CREATE TABLE cache_locator_docs (
+            id      bigint PRIMARY KEY,
+            content text NOT NULL
+        );
+        INSERT INTO cache_locator_docs
+        SELECT g, 'locatoranchor committed row ' || g
+        FROM generate_series(1, 20) g;
+        CREATE INDEX cache_locator_idx ON cache_locator_docs
+        USING bm25 (content) WITH (text_config='english');
+    "
+}
+
+cache_locator_rollback_insert_sql() {
+    cat << 'EOF'
+INSERT INTO cache_locator_docs
+SELECT 1000 + g,
+       'locatoranchor rollbackonly payload ' ||
+       (
+           SELECT string_agg('lex' || g || 'x' || s, ' ')
+           FROM generate_series(1, 96) s
+       )
+FROM generate_series(1, 256) g;
+EOF
+}
+
+assert_cache_locator_rollback_output() {
+    local test_name=$1
+    local output=$2
+    local baseline=$3
+    local session_status=$4
+    local old_filenode new_filenode restored_filenode
+    local old_blocks new_blocks in_tx_hits
+    local in_tx_bytes bytes_before_read bytes_after_read
+    local committed_hits rollback_rows
+
+    info "${test_name} output: ${output}"
+
+    if [ "${session_status}" -ne 0 ]; then
+        error "${test_name} failed while reading the restored relfilenode \
+(status ${session_status}). Full output:\n${output}"
+    fi
+
+    old_filenode=$(echo "${output}" | sed -n \
+        's/^.*locator_old_filenode=\([0-9]*\).*$/\1/p' | head -1)
+    new_filenode=$(echo "${output}" | sed -n \
+        's/^.*locator_new_filenode=\([0-9]*\).*$/\1/p' | head -1)
+    restored_filenode=$(echo "${output}" | sed -n \
+        's/^.*locator_restored_filenode=\([0-9]*\).*$/\1/p' | head -1)
+    old_blocks=$(echo "${output}" | sed -n \
+        's/^.*locator_old_blocks=\([0-9]*\).*$/\1/p' | head -1)
+    new_blocks=$(echo "${output}" | sed -n \
+        's/^.*locator_new_blocks=\([0-9]*\).*$/\1/p' | head -1)
+    in_tx_hits=$(echo "${output}" | sed -n \
+        's/^.*locator_in_tx_hits=\([0-9]*\).*$/\1/p' | head -1)
+    in_tx_bytes=$(echo "${output}" | sed -n \
+        's/^.*locator_in_tx_bytes=\([0-9]*\).*$/\1/p' | head -1)
+    bytes_before_read=$(echo "${output}" | sed -n \
+        's/^.*locator_bytes_before_read=\([0-9]*\).*$/\1/p' | head -1)
+    committed_hits=$(echo "${output}" | sed -n \
+        's/^.*locator_committed_hits=\([0-9]*\).*$/\1/p' | head -1)
+    rollback_rows=$(echo "${output}" | sed -n \
+        's/^.*locator_rollback_rows=\([0-9]*\).*$/\1/p' | head -1)
+    bytes_after_read=$(echo "${output}" | sed -n \
+        's/^.*locator_bytes_after_read=\([0-9]*\).*$/\1/p' | head -1)
+
+    if ! [[ "${old_filenode}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${new_filenode}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${restored_filenode}" =~ ^[0-9]+$ ]] \
+        || [ "${new_filenode}" = "${old_filenode}" ] \
+        || [ "${restored_filenode}" != "${old_filenode}" ]; then
+        error "${test_name} did not replace and restore the index file \
+('${old_filenode:-missing}' -> '${new_filenode:-missing}' -> \
+'${restored_filenode:-missing}'). Full output:\n${output}"
+    fi
+    if ! [[ "${old_blocks}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${new_blocks}" =~ ^[0-9]+$ ]] \
+        || [ "${new_blocks}" -le "${old_blocks}" ]; then
+        error "${test_name} did not extend the discarded relfilenode past \
+the restored file (${old_blocks:-missing} -> ${new_blocks:-missing} blocks). \
+Full output:\n${output}"
+    fi
+    if [ "${in_tx_hits}" != "276" ]; then
+        error "${test_name} did not build the replacement-file cache through \
+the normal BM25 path (hits=${in_tx_hits:-missing}). Full output:\n${output}"
+    fi
+    if ! [[ "${in_tx_bytes}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${bytes_before_read}" =~ ^[0-9]+$ ]] \
+        || [ "${in_tx_bytes}" -le "${baseline}" ] \
+        || [ "${bytes_before_read}" -ne "${in_tx_bytes}" ]; then
+        error "${test_name} did not retain the charged replacement-file \
+cache through rollback (${baseline} -> ${in_tx_bytes:-missing} -> \
+${bytes_before_read:-missing}). Full output:\n${output}"
+    fi
+    if [ "${committed_hits}" != "20" ] || [ "${rollback_rows}" != "0" ]; then
+        error "${test_name} returned the wrong restored rows \
+(committed=${committed_hits:-missing}, rolled_back=${rollback_rows:-missing}). \
+Full output:\n${output}"
+    fi
+    if [ "${bytes_after_read}" != "${baseline}" ]; then
+        error "${test_name} did not drain discarded-file cache accounting \
+(${bytes_before_read:-missing} -> ${bytes_after_read:-missing}, \
+baseline ${baseline}). Full output:\n${output}"
+    fi
+    if ! echo "${output}" | grep -qF "locator_complete"; then
+        error "${test_name} did not complete the restored-file read. \
+Full output:\n${output}"
+    fi
+}
+
+# A top-level abort restores the old index relfilenode after a normal query has
+# populated the shared cache from the replacement file.
+run_cache_locator_top_level_rollback_test() {
+    local output session_status baseline
+
+    log "Test: cache locator survives top-level REINDEX rollback"
+    prepare_cache_locator_rollback_fixture
+    baseline=$(run_sql_value "SELECT bm25_cache_global_estimated_bytes();")
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+SET pg_textsearch.memtable_cache_enabled = on;
+SELECT 'locator_old_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_old_blocks=' ||
+       pg_relation_size('cache_locator_idx') /
+       current_setting('block_size')::bigint;
+BEGIN;
+REINDEX INDEX cache_locator_idx;
+$(cache_locator_rollback_insert_sql)
+SELECT 'locator_new_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_new_blocks=' ||
+       pg_relation_size('cache_locator_idx') /
+       current_setting('block_size')::bigint;
+SELECT 'locator_in_tx_hits=' || count(*) FROM (
+    SELECT id FROM cache_locator_docs
+    ORDER BY content <@>
+        to_bm25query('locatoranchor', 'cache_locator_idx')
+    LIMIT 1000
+) q;
+SELECT 'locator_in_tx_bytes=' ||
+       bm25_cache_global_estimated_bytes();
+ROLLBACK;
+SELECT 'locator_restored_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_bytes_before_read=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'locator_committed_hits=' || count(*) FROM (
+    SELECT id FROM cache_locator_docs
+    ORDER BY content <@>
+        to_bm25query('locatoranchor', 'cache_locator_idx')
+    LIMIT 1000
+) q;
+SELECT 'locator_rollback_rows=' || count(*)
+FROM cache_locator_docs
+WHERE content LIKE '%rollbackonly%';
+SELECT 'locator_bytes_after_read=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'locator_complete';
+EOF
+)
+    session_status=$?
+    set -e
+
+    assert_cache_locator_rollback_output \
+        "Top-level REINDEX rollback" "${output}" "${baseline}" \
+        "${session_status}"
+    run_sql_quiet "DROP TABLE cache_locator_docs CASCADE;"
+    log "✅ top-level rollback rebuilt the cache from the restored file"
+}
+
+# Rolling back to a savepoint switches the relation back to the old file while
+# the outer transaction and backend-local wrapper remain active.
+run_cache_locator_savepoint_rollback_test() {
+    local output session_status baseline
+
+    log "Test: cache locator survives savepoint REINDEX rollback"
+    prepare_cache_locator_rollback_fixture
+    baseline=$(run_sql_value "SELECT bm25_cache_global_estimated_bytes();")
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+SET pg_textsearch.memtable_cache_enabled = on;
+SELECT 'locator_old_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_old_blocks=' ||
+       pg_relation_size('cache_locator_idx') /
+       current_setting('block_size')::bigint;
+BEGIN;
+SAVEPOINT before_reindex;
+REINDEX INDEX cache_locator_idx;
+$(cache_locator_rollback_insert_sql)
+SELECT 'locator_new_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_new_blocks=' ||
+       pg_relation_size('cache_locator_idx') /
+       current_setting('block_size')::bigint;
+SELECT 'locator_in_tx_hits=' || count(*) FROM (
+    SELECT id FROM cache_locator_docs
+    ORDER BY content <@>
+        to_bm25query('locatoranchor', 'cache_locator_idx')
+    LIMIT 1000
+) q;
+SELECT 'locator_in_tx_bytes=' ||
+       bm25_cache_global_estimated_bytes();
+ROLLBACK TO SAVEPOINT before_reindex;
+SELECT 'locator_restored_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_bytes_before_read=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'locator_committed_hits=' || count(*) FROM (
+    SELECT id FROM cache_locator_docs
+    ORDER BY content <@>
+        to_bm25query('locatoranchor', 'cache_locator_idx')
+    LIMIT 1000
+) q;
+SELECT 'locator_rollback_rows=' || count(*)
+FROM cache_locator_docs
+WHERE content LIKE '%rollbackonly%';
+SELECT 'locator_bytes_after_read=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'locator_complete';
+COMMIT;
+EOF
+)
+    session_status=$?
+    set -e
+
+    assert_cache_locator_rollback_output \
+        "Savepoint REINDEX rollback" "${output}" "${baseline}" \
+        "${session_status}"
+    run_sql_quiet "DROP TABLE cache_locator_docs CASCADE;"
+    log "✅ savepoint rollback rebuilt the cache from the restored file"
+}
+
+# Prepared rollback selects the old relfilenode in a different backend after
+# the preparing backend has populated shared cache state from the new file.
+run_cache_locator_prepared_rollback_test() {
+    local prepare_output read_output output session_status baseline
+    local gid prepared_count
+
+    log "Test: cache locator survives ROLLBACK PREPARED after REINDEX"
+    prepare_cache_locator_rollback_fixture
+    baseline=$(run_sql_value "SELECT bm25_cache_global_estimated_bytes();")
+    gid="cache_locator_reindex_${TEST_PORT}_$$"
+
+    prepare_output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+SET pg_textsearch.memtable_cache_enabled = on;
+SELECT 'locator_old_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_old_blocks=' ||
+       pg_relation_size('cache_locator_idx') /
+       current_setting('block_size')::bigint;
+BEGIN;
+REINDEX INDEX cache_locator_idx;
+$(cache_locator_rollback_insert_sql)
+SELECT 'locator_new_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_new_blocks=' ||
+       pg_relation_size('cache_locator_idx') /
+       current_setting('block_size')::bigint;
+SELECT 'locator_in_tx_hits=' || count(*) FROM (
+    SELECT id FROM cache_locator_docs
+    ORDER BY content <@>
+        to_bm25query('locatoranchor', 'cache_locator_idx')
+    LIMIT 1000
+) q;
+SELECT 'locator_in_tx_bytes=' ||
+       bm25_cache_global_estimated_bytes();
+PREPARE TRANSACTION '${gid}';
+EOF
+)
+
+    prepared_count=$(run_sql_value "
+        SELECT count(*) FROM pg_prepared_xacts WHERE gid = '${gid}';
+    ")
+    if [ "${prepared_count}" != "1" ]; then
+        error "REINDEX cache-locator transaction was not prepared. \
+Full output:\n${prepare_output}"
+    fi
+
+    run_sql_quiet "ROLLBACK PREPARED '${gid}';"
+
+    set +e
+    read_output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" \
+        -d "${TEST_DB}" --set ON_ERROR_STOP=1 2>&1 << 'EOF'
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+SET pg_textsearch.memtable_cache_enabled = on;
+SELECT 'locator_restored_filenode=' ||
+       pg_relation_filenode('cache_locator_idx');
+SELECT 'locator_bytes_before_read=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'locator_committed_hits=' || count(*) FROM (
+    SELECT id FROM cache_locator_docs
+    ORDER BY content <@>
+        to_bm25query('locatoranchor', 'cache_locator_idx')
+    LIMIT 1000
+) q;
+SELECT 'locator_rollback_rows=' || count(*)
+FROM cache_locator_docs
+WHERE content LIKE '%rollbackonly%';
+SELECT 'locator_bytes_after_read=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'locator_complete';
+EOF
+)
+    session_status=$?
+    set -e
+    output="${prepare_output}"$'\n'"${read_output}"
+
+    assert_cache_locator_rollback_output \
+        "ROLLBACK PREPARED after REINDEX" "${output}" "${baseline}" \
+        "${session_status}"
+    run_sql_quiet "DROP TABLE cache_locator_docs CASCADE;"
+    log "✅ prepared rollback rebuilt the cache from the restored file"
+}
+
+# DROP removes the runtime registry entry immediately.  If an initial CREATE
+# is dropped in a savepoint and that DROP is rolled back, first access must
+# reconstruct the CREATE ownership from PostgreSQL's restored relation state.
+# A top-level abort must then remove the reconstructed registry/cache state and
+# restore the exact cluster-global accounting baseline.
+run_initial_create_drop_rollback_abort_test() {
+    local output session_status
+    local baseline cache_observation bytes_after index_count
+
+    log "Test: rolled-back DROP preserves initial-CREATE abort ownership"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS create_drop_abort_docs CASCADE;
+        CREATE TABLE create_drop_abort_docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        );
+        INSERT INTO create_drop_abort_docs (content)
+        SELECT 'create drop abort seed ' || g
+        FROM generate_series(1, 25) g;
+    "
+    baseline=$(run_sql_value "SELECT bm25_cache_global_estimated_bytes();")
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+BEGIN;
+CREATE INDEX create_drop_abort_idx ON create_drop_abort_docs
+USING bm25 (content) WITH (text_config='english');
+SAVEPOINT drop_index;
+DROP INDEX create_drop_abort_idx;
+ROLLBACK TO drop_index;
+INSERT INTO create_drop_abort_docs (content)
+VALUES ('create drop abort charged cache tail');
+SELECT 'create_drop_abort_cache=' || result || '|' || estimated_bytes
+FROM bm25_cache_cold_build('create_drop_abort_idx');
+ROLLBACK;
+SELECT 'create_drop_abort_bytes=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'create_drop_abort_index_count=' || count(*)
+FROM pg_class
+WHERE relname = 'create_drop_abort_idx';
+EOF
+)
+    session_status=$?
+    set -e
+
+    info "Rolled-back DROP top-level abort output: ${output}"
+
+    if [ "${session_status}" -ne 0 ]; then
+        error "Rolled-back DROP top-level abort session failed \
+(status ${session_status}). Full output:\n${output}"
+    fi
+
+    cache_observation=$(echo "${output}" | sed -n \
+        's/^.*create_drop_abort_cache=\([^[:space:]]*\).*$/\1/p' | head -1)
+    bytes_after=$(echo "${output}" | sed -n \
+        's/^.*create_drop_abort_bytes=\([0-9]*\).*$/\1/p' | head -1)
+    index_count=$(echo "${output}" | sed -n \
+        's/^.*create_drop_abort_index_count=\([0-9]*\).*$/\1/p' | head -1)
+
+    if ! [[ "${cache_observation}" =~ ^OK\|[1-9][0-9]*$ ]]; then
+        error "Rolled-back DROP setup did not charge the reconstructed \
+initial-CREATE cache (got '${cache_observation:-missing}'). \
+Full output:\n${output}"
+    fi
+    if [ "${bytes_after}" != "${baseline}" ]; then
+        error "Top-level abort after rolled-back DROP leaked cache \
+accounting (${baseline} -> ${bytes_after:-missing}). \
+Full output:\n${output}"
+    fi
+    if [ "${index_count}" != "0" ]; then
+        error "Top-level abort after rolled-back DROP retained the \
+initially-created index (count=${index_count:-missing})."
+    fi
+
+    run_sql_quiet "DROP TABLE create_drop_abort_docs;"
+    log "✅ rolled-back DROP retained initial-CREATE abort ownership"
+}
+
+# A successful REINDEX replaces the relfilenode with an empty memtable chain.
+# The stable shared state's old page count must not make the first post-REINDEX
+# page look over threshold and spill prematurely.
+run_warm_reindex_chain_count_test() {
+    local chain_pages_before chain_pages_after hits
+
+    log "Test: warm successful REINDEX reseeds chain-page accounting"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS warm_chain_docs CASCADE;
+        CREATE TABLE warm_chain_docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        );
+        CREATE INDEX warm_chain_docs_bm25 ON warm_chain_docs
+        USING bm25 (content) WITH (text_config='english');
+        SET pg_textsearch.memtable_pages_threshold = 0;
+        INSERT INTO warm_chain_docs (content)
+        SELECT 'warm chain before reindex ' || g || ' ' ||
+               repeat('filler ', 4)
+        FROM generate_series(1, 200) g;
+    "
+
+    chain_pages_before=$(run_sql_value "
+        SELECT count(*) FROM bm25_memtable_chain('warm_chain_docs_bm25');
+    ")
+    if ! [[ "${chain_pages_before}" =~ ^[0-9]+$ ]] \
+        || [ "${chain_pages_before}" -le 1 ]; then
+        error "Warm REINDEX setup did not create a multi-page chain \
+(pages=${chain_pages_before:-missing})."
+    fi
+
+    run_sql_quiet "REINDEX INDEX warm_chain_docs_bm25;"
+    run_sql_quiet "
+        SET pg_textsearch.memtable_pages_threshold = 2;
+        INSERT INTO warm_chain_docs (content)
+        VALUES ('warm chain first page after reindex');
+    "
+
+    chain_pages_after=$(run_sql_value "
+        SELECT count(*) FROM bm25_memtable_chain('warm_chain_docs_bm25');
+    ")
+    hits=$(run_sql_value "
+        SELECT count(*) FROM (
+            SELECT 1 FROM warm_chain_docs
+            ORDER BY content <@>
+                to_bm25query('warm', 'warm_chain_docs_bm25')
+        ) q;
+    ")
+
+    if [ "${chain_pages_after}" != "1" ]; then
+        error "Successful warm REINDEX reused the old chain-page count; \
+the first new page was spilled (before=${chain_pages_before}, \
+after=${chain_pages_after:-missing})."
+    fi
+    if [ "${hits}" != "201" ]; then
+        error "Warm REINDEX chain-count test returned ${hits:-missing} \
+rows instead of 201."
+    fi
+
+    run_sql_quiet "DROP TABLE warm_chain_docs CASCADE;"
+    log "✅ warm successful REINDEX used the current relfilenode count"
+}
+
+# If a threshold consumer runs after REINDEX but before transaction abort, it
+# may reseed against the replacement relfilenode.  Rollback must make that
+# cached count stale again so the restored multi-page chain is recounted.
+run_warm_reindex_reseed_before_abort_test() {
+    local output session_status
+    local chain_pages_before chain_pages_during chain_pages_after hits
+
+    log "Test: REINDEX abort invalidates an in-transaction reseed"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS warm_abort_chain_docs CASCADE;
+        CREATE TABLE warm_abort_chain_docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        );
+        CREATE INDEX warm_abort_chain_docs_bm25 ON warm_abort_chain_docs
+        USING bm25 (content) WITH (text_config='english');
+        SET pg_textsearch.memtable_pages_threshold = 0;
+        INSERT INTO warm_abort_chain_docs (content)
+        SELECT 'warm abort chain before reindex ' || g || ' ' ||
+               repeat('filler ', 4)
+        FROM generate_series(1, 200) g;
+    "
+
+    chain_pages_before=$(run_sql_value "
+        SELECT count(*)
+        FROM bm25_memtable_chain('warm_abort_chain_docs_bm25');
+    ")
+    if ! [[ "${chain_pages_before}" =~ ^[0-9]+$ ]] \
+        || [ "${chain_pages_before}" -le 1 ]; then
+        error "Warm REINDEX abort setup did not create a multi-page chain \
+(pages=${chain_pages_before:-missing})."
+    fi
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+SET pg_textsearch.memtable_pages_threshold = ${chain_pages_before};
+BEGIN;
+REINDEX INDEX warm_abort_chain_docs_bm25;
+INSERT INTO warm_abort_chain_docs (content)
+VALUES ('warm abort replacement relfilenode reseed');
+SELECT 'warm_abort_chain_during=' || count(*)
+FROM bm25_memtable_chain('warm_abort_chain_docs_bm25');
+ROLLBACK;
+INSERT INTO warm_abort_chain_docs (content)
+VALUES ('warm abort restored relfilenode threshold');
+SELECT 'warm_abort_chain_after=' || count(*)
+FROM bm25_memtable_chain('warm_abort_chain_docs_bm25');
+SELECT 'warm_abort_hits=' || count(*) FROM (
+    SELECT 1 FROM warm_abort_chain_docs
+    ORDER BY content <@>
+        to_bm25query('abort', 'warm_abort_chain_docs_bm25')
+) q;
+EOF
+)
+    session_status=$?
+    set -e
+
+    info "Warm REINDEX reseed-before-abort output: ${output}"
+
+    if [ "${session_status}" -ne 0 ]; then
+        error "Warm REINDEX reseed-before-abort session failed \
+(status ${session_status}). Full output:\n${output}"
+    fi
+
+    chain_pages_during=$(echo "${output}" | sed -n \
+        's/^.*warm_abort_chain_during=\([0-9]*\).*$/\1/p' | head -1)
+    chain_pages_after=$(echo "${output}" | sed -n \
+        's/^.*warm_abort_chain_after=\([0-9]*\).*$/\1/p' | head -1)
+    hits=$(echo "${output}" | sed -n \
+        's/^.*warm_abort_hits=\([0-9]*\).*$/\1/p' | head -1)
+
+    if [ "${chain_pages_during}" != "1" ]; then
+        error "REINDEX replacement chain was not reseeded before abort \
+(pages=${chain_pages_during:-missing}). Full output:\n${output}"
+    fi
+    if [ "${chain_pages_after}" != "0" ]; then
+        error "REINDEX abort left the replacement relfilenode count \
+attached to the restored ${chain_pages_before}-page chain \
+(pages=${chain_pages_after:-missing}). Full output:\n${output}"
+    fi
+    if [ "${hits}" != "201" ]; then
+        error "Warm REINDEX reseed-before-abort test returned \
+${hits:-missing} rows instead of 201."
+    fi
+
+    run_sql_quiet "DROP TABLE warm_abort_chain_docs CASCADE;"
+    log "✅ REINDEX abort invalidated the replacement relfilenode count"
+}
+
+# A restart clears the shared registry while leaving the index relation on
+# disk. The first post-restart REINDEX must therefore attach cold state
+# without claiming initial-CREATE ownership, and transaction abort must leave
+# that state usable in the same backend.  Its page-count heuristic starts at
+# zero, so rollback must force a lazy recount of the restored nonempty chain
+# before the next threshold decision.
+run_cold_registry_reindex_rollback_test() {
+    local output session_status hits chain_pages_before chain_pages_after
+
+    log "Test: cold REINDEX abort reseeds restored chain-page accounting"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS cold_docs CASCADE;
+        CREATE TABLE cold_docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        );
+        INSERT INTO cold_docs (content)
+        SELECT 'cold registry rollback ' || g
+        FROM generate_series(1, 225) g;
+        CREATE INDEX cold_docs_bm25 ON cold_docs
+        USING bm25 (content) WITH (text_config='english');
+        SET pg_textsearch.memtable_pages_threshold = 0;
+        INSERT INTO cold_docs (content)
+        SELECT 'cold registry rollback tail ' || g || ' ' ||
+               repeat('filler ', 4)
+        FROM generate_series(1, 200) g;
+    "
+
+    chain_pages_before=$(run_sql_value "
+        SELECT count(*) FROM bm25_memtable_chain('cold_docs_bm25');
+    ")
+    if ! [[ "${chain_pages_before}" =~ ^[0-9]+$ ]] \
+        || [ "${chain_pages_before}" -le 1 ]; then
+        error "Cold REINDEX abort setup did not create a multi-page chain \
+(pages=${chain_pages_before:-missing})."
+    fi
+
+    pg_ctl restart -D "${DATA_DIR}" -m fast -l "${LOGFILE}" -w \
+        >/dev/null 2>&1 || error "Failed to restart PostgreSQL"
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+SET pg_textsearch.memtable_pages_threshold = 2;
+BEGIN;
+REINDEX INDEX cold_docs_bm25;
+SELECT 'cold_reindex_built_before_abort';
+\set ON_ERROR_STOP 0
+SELECT 1 / 0;
+\set ON_ERROR_STOP 1
+ROLLBACK;
+INSERT INTO cold_docs (content)
+VALUES ('cold registry rollback tail after abort');
+SELECT 'cold_reindex_chain_pages=' || count(*)
+FROM bm25_memtable_chain('cold_docs_bm25');
+SELECT 'cold_reindex_hits=' || count(*) FROM (
+    SELECT 1 FROM cold_docs
+    ORDER BY content <@> to_bm25query('rollback', 'cold_docs_bm25')
+) q;
+EOF
+)
+    session_status=$?
+    set -e
+
+    info "Cold-registry REINDEX session output: ${output}"
+
+    if [ "${session_status}" -ne 0 ]; then
+        error "Cold-registry REINDEX session failed after rollback \
+(status ${session_status}). Full output:\n${output}"
+    fi
+    if ! echo "${output}" | grep -qF "cold_reindex_built_before_abort" \
+        || ! echo "${output}" | grep -qF "division by zero"; then
+        error "Cold-registry REINDEX rollback was not fully exercised. \
+Full output:\n${output}"
+    fi
+
+    hits=$(echo "${output}" | sed -n \
+        's/^.*cold_reindex_hits=\([0-9]*\).*$/\1/p' | head -1)
+    chain_pages_after=$(echo "${output}" | sed -n \
+        's/^.*cold_reindex_chain_pages=\([0-9]*\).*$/\1/p' | head -1)
+    if [ "${chain_pages_after}" != "0" ]; then
+        error "Cold REINDEX abort left a zero heuristic attached to the \
+restored ${chain_pages_before}-page chain; the next threshold insert \
+did not spill (pages=${chain_pages_after:-missing}). \
+Full output:\n${output}"
+    fi
+    if [ "${hits}" != "426" ]; then
+        error "Cold-registry REINDEX rollback left the index unusable \
+(hits=${hits:-missing}). Full output:\n${output}"
+    fi
+
+    run_sql_quiet "DROP TABLE cold_docs CASCADE;"
+    log "✅ cold REINDEX abort recounted and spilled the restored chain"
+}
+
+# REINDEX replaces only the current backend's wrapper.  Transaction-local
+# bulk-load accounting accumulated before a savepoint must survive that
+# replacement and the savepoint rollback so PRE_COMMIT still spills.
+run_reindex_bulk_counter_preservation_test() {
+    local output session_status
+    local chain_pages_before_commit chain_pages_after_commit hits
+
+    log "Test: REINDEX wrapper replacement preserves bulk-load counters"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS bulk_counter_docs CASCADE;
+        CREATE TABLE bulk_counter_docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        );
+        CREATE INDEX bulk_counter_docs_bm25 ON bulk_counter_docs
+        USING bm25 (content) WITH (text_config='english');
+    "
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+SET pg_textsearch.memtable_pages_threshold = 0;
+SET pg_textsearch.bulk_load_threshold = 1;
+BEGIN;
+INSERT INTO bulk_counter_docs (content)
+VALUES ('bulk counter survives savepoint reindex rollback');
+SAVEPOINT reindex_savepoint;
+REINDEX INDEX bulk_counter_docs_bm25;
+SELECT 'bulk_counter_reindex_complete';
+ROLLBACK TO reindex_savepoint;
+SELECT 'bulk_counter_chain_before_commit=' || count(*)
+FROM bm25_memtable_chain('bulk_counter_docs_bm25');
+COMMIT;
+SELECT 'bulk_counter_chain_after_commit=' || count(*)
+FROM bm25_memtable_chain('bulk_counter_docs_bm25');
+SELECT 'bulk_counter_hits=' || count(*) FROM (
+    SELECT 1 FROM bulk_counter_docs
+    ORDER BY content <@>
+        to_bm25query('counter', 'bulk_counter_docs_bm25')
+) q;
+EOF
+)
+    session_status=$?
+    set -e
+
+    info "REINDEX bulk-counter session output: ${output}"
+
+    if [ "${session_status}" -ne 0 ] \
+        || ! echo "${output}" | grep -qF "bulk_counter_reindex_complete"; then
+        error "REINDEX bulk-counter session did not complete the savepoint \
+rollback scenario. Full output:\n${output}"
+    fi
+
+    chain_pages_before_commit=$(echo "${output}" | sed -n \
+        's/^.*bulk_counter_chain_before_commit=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    chain_pages_after_commit=$(echo "${output}" | sed -n \
+        's/^.*bulk_counter_chain_after_commit=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    hits=$(echo "${output}" | sed -n \
+        's/^.*bulk_counter_hits=\([0-9]*\).*$/\1/p' | head -1)
+
+    if ! [[ "${chain_pages_before_commit}" =~ ^[1-9][0-9]*$ ]]; then
+        error "REINDEX bulk-counter setup did not restore a nonempty chain \
+before PRE_COMMIT (pages=${chain_pages_before_commit:-missing})."
+    fi
+    if [ "${chain_pages_after_commit}" != "0" ]; then
+        error "REINDEX wrapper replacement lost terms_added_this_xact; \
+bulk_load_threshold=1 did not spill at PRE_COMMIT \
+(${chain_pages_before_commit} -> ${chain_pages_after_commit:-missing})."
+    fi
+    if [ "${hits}" != "1" ]; then
+        error "REINDEX bulk-counter test returned ${hits:-missing} rows \
+instead of 1."
+    fi
+
+    run_sql_quiet "DROP TABLE bulk_counter_docs CASCADE;"
+    log "✅ REINDEX wrapper preserved PRE_COMMIT bulk-load accounting"
+}
+
+run_prepare_bulk_state_case() {
+    local case_name="$1"
+    local outcome="$2"
+    local table_name="$3"
+    local index_name="$4"
+    local prepared_term="$5"
+    local controller_term="$6"
+    local gid="pgts_prepare_bulk_${case_name}_${TEST_PORT}_$$"
+    local ready_file="${DATA_DIR}/prepare_bulk_${case_name}.ready"
+    local release_file="${DATA_DIR}/prepare_bulk_${case_name}.release"
+    local output_file="${DATA_DIR}/prepare_bulk_${case_name}.out"
+    local failure=
+    local chain_after_prepare chain_before_unrelated chain_after_unrelated
+    local backend_before backend_after prepared_count
+    local prepared_heap_count prepared_index_count
+    local controller_heap_count controller_index_count
+    local output
+
+    rm -f "${ready_file}" "${release_file}" "${output_file}"
+
+    PGAPPNAME="pgts_prepare_bulk_${case_name}" \
+        timeout --signal=TERM --kill-after=2s 45s \
+        psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 >"${output_file}" 2>&1 << EOF &
+\set QUIET on
+SET pg_textsearch.memtable_pages_threshold = 0;
+SET pg_textsearch.bulk_load_threshold = 1;
+SELECT pg_backend_pid() AS prepare_backend \gset
+BEGIN;
+INSERT INTO ${table_name} (id, content)
+VALUES (1, '${prepared_term} prepared payload');
+PREPARE TRANSACTION '${gid}';
+\echo prepare_backend_before=:prepare_backend
+\! : > '${ready_file}'; while [ ! -f '${release_file}' ]; do sleep 0.05; done
+BEGIN;
+INSERT INTO prepare_bulk_plain (case_name)
+VALUES ('${case_name}');
+SELECT pg_backend_pid() AS unrelated_backend \gset
+COMMIT;
+\echo prepare_backend_after=:unrelated_backend
+\echo prepare_unrelated_commit_complete
+EOF
+    PREPARE_CLIENT_PID=$!
+
+    if ! wait_for_prepare_marker "${ready_file}"; then
+        output=$(cat "${output_file}" 2>/dev/null || true)
+        stop_prepare_client || true
+        prepared_count=$(run_sql_value_bounded "
+            SELECT count(*) FROM pg_prepared_xacts
+            WHERE gid = '${gid}';
+        " || true)
+        if [ "${prepared_count}" = "1" ]; then
+            run_sql_quiet_bounded "ROLLBACK PREPARED '${gid}';" || true
+        fi
+        error "PREPARE bulk-state ${case_name} client did not reach the \
+post-PREPARE barrier. Full output:\n${output}"
+    fi
+
+    chain_after_prepare=$(run_sql_value_bounded "
+        SELECT count(*) FROM bm25_memtable_chain('${index_name}');
+    ")
+    if [ "${chain_after_prepare}" != "0" ]; then
+        failure="${failure} PREPARE left ${chain_after_prepare} chain pages;"
+    fi
+
+    run_sql_quiet_bounded "
+        SET pg_textsearch.bulk_load_threshold = 0;
+        SET pg_textsearch.memtable_pages_threshold = 0;
+        INSERT INTO ${table_name} (id, content)
+        VALUES (2, '${controller_term} controller payload');
+    "
+    chain_before_unrelated=$(run_sql_value_bounded "
+        SELECT count(*) FROM bm25_memtable_chain('${index_name}');
+    ")
+    if ! [[ "${chain_before_unrelated}" =~ ^[1-9][0-9]*$ ]]; then
+        failure="${failure} controller insert did not create a chain;"
+    fi
+
+    : >"${release_file}"
+    if ! wait_for_prepare_client_exit; then
+        failure="${failure} persistent client did not exit within 10 seconds;"
+        stop_prepare_client || true
+    fi
+
+    output=$(cat "${output_file}" 2>/dev/null || true)
+    backend_before=$(echo "${output}" | sed -n \
+        's/^prepare_backend_before=\([0-9]*\)$/\1/p' | head -1)
+    backend_after=$(echo "${output}" | sed -n \
+        's/^prepare_backend_after=\([0-9]*\)$/\1/p' | head -1)
+    if ! [[ "${backend_before}" =~ ^[0-9]+$ ]] ||
+        [ "${backend_before}" != "${backend_after}" ]; then
+        failure="${failure} PREPARE and unrelated transaction used different backends;"
+    fi
+    if ! echo "${output}" | grep -qF "prepare_unrelated_commit_complete"; then
+        failure="${failure} unrelated transaction did not commit;"
+    fi
+
+    chain_after_unrelated=$(run_sql_value_bounded "
+        SELECT count(*) FROM bm25_memtable_chain('${index_name}');
+    ")
+    if [ "${chain_after_unrelated}" != "${chain_before_unrelated}" ]; then
+        failure="${failure} unrelated commit changed chain pages \
+${chain_before_unrelated}->${chain_after_unrelated};"
+    fi
+
+    prepared_count=$(run_sql_value_bounded "
+        SELECT count(*) FROM pg_prepared_xacts
+        WHERE gid = '${gid}';
+    ")
+    if [ "${prepared_count}" = "1" ]; then
+        if [ "${outcome}" = "commit" ]; then
+            run_sql_quiet_bounded "COMMIT PREPARED '${gid}';"
+        else
+            run_sql_quiet_bounded "ROLLBACK PREPARED '${gid}';"
+        fi
+    else
+        failure="${failure} prepared transaction count was ${prepared_count};"
+    fi
+
+    prepared_heap_count=$(run_sql_value_bounded "
+        SELECT count(*) FROM ${table_name}
+        WHERE content LIKE '%${prepared_term}%';
+    ")
+    prepared_index_count=$(run_sql_value_bounded "
+        SELECT count(*)
+        FROM (
+            SELECT id
+            FROM ${table_name}
+            ORDER BY content <@>
+                to_bm25query('${prepared_term}', '${index_name}')
+            LIMIT 10
+        ) hits
+        JOIN ${table_name} docs USING (id)
+        WHERE docs.content LIKE '%${prepared_term}%';
+    ")
+    controller_heap_count=$(run_sql_value_bounded "
+        SELECT count(*) FROM ${table_name}
+        WHERE content LIKE '%${controller_term}%';
+    ")
+    controller_index_count=$(run_sql_value_bounded "
+        SELECT count(*)
+        FROM (
+            SELECT id
+            FROM ${table_name}
+            ORDER BY content <@>
+                to_bm25query('${controller_term}', '${index_name}')
+            LIMIT 10
+        ) hits
+        JOIN ${table_name} docs USING (id)
+        WHERE docs.content LIKE '%${controller_term}%';
+    ")
+
+    if [ "${outcome}" = "commit" ]; then
+        if [ "${prepared_heap_count}" != "1" ] ||
+            [ "${prepared_index_count}" != "1" ]; then
+            failure="${failure} COMMIT PREPARED lost the prepared row \
+(heap=${prepared_heap_count}, index=${prepared_index_count});"
+        fi
+    elif [ "${prepared_heap_count}" != "0" ] ||
+        [ "${prepared_index_count}" != "0" ]; then
+        failure="${failure} ROLLBACK PREPARED retained the prepared row \
+(heap=${prepared_heap_count}, index=${prepared_index_count});"
+    fi
+
+    if [ "${controller_heap_count}" != "1" ] ||
+        [ "${controller_index_count}" != "1" ]; then
+        failure="${failure} controller row was not preserved \
+(heap=${controller_heap_count}, index=${controller_index_count});"
+    fi
+
+    info "PREPARE bulk-state ${case_name} output: ${output}"
+    if [ -n "${failure}" ]; then
+        warn "PREPARE bulk-state ${case_name} failures:${failure}"
+        return 1
+    fi
+
+    log "✅ PREPARE ${outcome} isolated terminal bulk state"
+}
+
+# PREPARE must spill the preparing transaction while errors can still abort
+# preparation, then clear backend-local counters before that backend starts a
+# new transaction.  A controller insert after the PREPARE barrier leaves a
+# fresh chain; the unrelated transaction must not spill that other backend's
+# work.  Both two-phase outcomes must retain normal heap/index visibility.
+run_prepare_bulk_state_reset_test() {
+    local failed=0
+
+    log "Test: PREPARE spills and resets backend-local bulk state"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS prepare_bulk_commit_docs CASCADE;
+        DROP TABLE IF EXISTS prepare_bulk_rollback_docs CASCADE;
+        DROP TABLE IF EXISTS prepare_bulk_plain;
+        CREATE TABLE prepare_bulk_commit_docs (
+            id      bigint PRIMARY KEY,
+            content text NOT NULL
+        );
+        CREATE INDEX prepare_bulk_commit_docs_bm25
+            ON prepare_bulk_commit_docs USING bm25 (content)
+            WITH (text_config='english');
+        CREATE TABLE prepare_bulk_rollback_docs (
+            id      bigint PRIMARY KEY,
+            content text NOT NULL
+        );
+        CREATE INDEX prepare_bulk_rollback_docs_bm25
+            ON prepare_bulk_rollback_docs USING bm25 (content)
+            WITH (text_config='english');
+        CREATE TABLE prepare_bulk_plain (case_name text);
+    "
+
+    if ! run_prepare_bulk_state_case \
+        commit \
+        commit \
+        prepare_bulk_commit_docs \
+        prepare_bulk_commit_docs_bm25 \
+        preparedcommitonly \
+        controllercommitonly; then
+        failed=1
+    fi
+
+    if ! run_prepare_bulk_state_case \
+        rollback \
+        rollback \
+        prepare_bulk_rollback_docs \
+        prepare_bulk_rollback_docs_bm25 \
+        preparedrollbackonly \
+        controllerrollbackonly; then
+        failed=1
+    fi
+
+    run_sql_quiet "
+        DROP TABLE prepare_bulk_commit_docs CASCADE;
+        DROP TABLE prepare_bulk_rollback_docs CASCADE;
+        DROP TABLE prepare_bulk_plain;
+    "
+
+    if [ "${failed}" -ne 0 ]; then
+        error "PREPARE bulk-state isolation regression failed"
+    fi
+}
+
+# Initial CREATE ownership lives only in the creating backend, so it cannot be
+# serialized into a prepared transaction. A normally committed CREATE must
+# clear that ownership so a later transaction in the same backend can prepare.
+run_prepare_initial_create_test() {
+    local reject_gid="pg_textsearch_create_reject_${TEST_PORT}_$$"
+    local later_gid="pg_textsearch_after_create_${TEST_PORT}_$$"
+    local output session_status prepared_count
+    local baseline cache_observation bytes_after
+
+    log "Test: PREPARE rejects reconstructed initial-CREATE ownership"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS prepare_docs CASCADE;
+        DROP TABLE IF EXISTS prepare_plain;
+        CREATE TABLE prepare_docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        );
+        INSERT INTO prepare_docs (content)
+        SELECT 'prepare create ownership ' || g
+        FROM generate_series(1, 25) g;
+        CREATE TABLE prepare_plain (id int);
+    "
+    baseline=$(run_sql_value "SELECT bm25_cache_global_estimated_bytes();")
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+BEGIN;
+CREATE INDEX prepare_docs_bm25 ON prepare_docs
+USING bm25 (content) WITH (text_config='english');
+SAVEPOINT drop_index;
+DROP INDEX prepare_docs_bm25;
+ROLLBACK TO drop_index;
+INSERT INTO prepare_docs (content)
+VALUES ('prepare reconstructed ownership charged cache tail');
+SELECT 'prepare_drop_rollback_cache=' || result || '|' || estimated_bytes
+FROM bm25_cache_cold_build('prepare_docs_bm25');
+PREPARE TRANSACTION '${reject_gid}';
+EOF
+)
+    session_status=$?
+    set -e
+
+    info "Initial-CREATE PREPARE output: ${output}"
+
+    cache_observation=$(echo "${output}" | sed -n \
+        's/^.*prepare_drop_rollback_cache=\([^[:space:]]*\).*$/\1/p' \
+        | head -1)
+    if ! [[ "${cache_observation}" =~ ^OK\|[1-9][0-9]*$ ]]; then
+        error "PREPARE setup did not charge the reconstructed \
+initial-CREATE cache (got '${cache_observation:-missing}'). \
+Full output:\n${output}"
+    fi
+
+    if [ "${session_status}" -eq 0 ]; then
+        run_sql_quiet "ROLLBACK PREPARED '${reject_gid}';"
+        error "PREPARE TRANSACTION accepted initial-CREATE ownership \
+after DROP INDEX rollback; the reproduction was cleaned with \
+ROLLBACK PREPARED. Full output:\n${output}"
+    fi
+    if ! echo "${output}" | grep -qF \
+        "cannot prepare a transaction that created a pg_textsearch index"; then
+        error "PREPARE TRANSACTION failed for an unexpected reason. \
+Full output:\n${output}"
+    fi
+
+    prepared_count=$(run_sql_value "
+        SELECT count(*) FROM pg_prepared_xacts
+        WHERE gid = '${reject_gid}';
+    ")
+    if [ "${prepared_count}" != "0" ]; then
+        run_sql_quiet "ROLLBACK PREPARED '${reject_gid}';"
+        error "Rejected initial CREATE still left a prepared transaction."
+    fi
+    bytes_after=$(run_sql_value "SELECT bm25_cache_global_estimated_bytes();")
+    if [ "${bytes_after}" != "${baseline}" ]; then
+        error "Rejected PREPARE after rolled-back DROP leaked cache \
+accounting (${baseline} -> ${bytes_after})."
+    fi
+    if [ "$(run_sql_value "
+        SELECT count(*) FROM pg_class
+        WHERE relname = 'prepare_docs_bm25';
+    ")" != "0" ]; then
+        error "Rejected initial CREATE did not roll back its index."
+    fi
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+CREATE INDEX prepare_docs_bm25 ON prepare_docs
+USING bm25 (content) WITH (text_config='english');
+SELECT 'committed_create_complete';
+BEGIN;
+INSERT INTO prepare_plain VALUES (1);
+PREPARE TRANSACTION '${later_gid}';
+SELECT 'later_prepare_succeeded';
+EOF
+)
+    session_status=$?
+    set -e
+
+    info "Post-CREATE PREPARE output: ${output}"
+
+    if [ "${session_status}" -ne 0 ] \
+        || ! echo "${output}" | grep -qF "committed_create_complete" \
+        || ! echo "${output}" | grep -qF "later_prepare_succeeded"; then
+        error "Normal CREATE commit left ownership that affected a later \
+transaction. Full output:\n${output}"
+    fi
+
+    prepared_count=$(run_sql_value "
+        SELECT count(*) FROM pg_prepared_xacts
+        WHERE gid = '${later_gid}';
+    ")
+    if [ "${prepared_count}" != "1" ]; then
+        error "Later transaction was not prepared successfully."
+    fi
+
+    run_sql_quiet "ROLLBACK PREPARED '${later_gid}';"
+    run_sql_quiet "
+        DROP TABLE prepare_docs CASCADE;
+        DROP TABLE prepare_plain;
+    "
+    log "✅ PREPARE ownership guard and commit clearing passed"
+}
+
+# Verify both REINDEX abort boundaries. A build-time failure must leave the
+# old cache untouched. If REINDEX finishes and the surrounding transaction
+# later aborts, the cache may remain discarded, but the stable shared state
+# must still serve the restored on-disk index without leaking accounting.
+run_failed_reindex_test() {
+    local output session_status
+    local generation_before generation_after_failure
+    local generation_after_rollback
+    local cache_bytes_before cache_bytes_after_failure
+    local cache_bytes_after_rollback cache_bytes_after_rebuild
+    local hits_after_failure hits_after_rollback
+
+    log "Test: failed and rolled-back REINDEX preserve stable state"
+
+    run_sql_quiet "
+        DROP TABLE IF EXISTS docs CASCADE;
+        DROP FUNCTION IF EXISTS maybe_fail_reindex(text);
+
+        CREATE FUNCTION maybe_fail_reindex(value text)
+        RETURNS text
+        LANGUAGE plpgsql
+        IMMUTABLE
+        PARALLEL UNSAFE
+        AS \$\$
+        BEGIN
+            IF current_setting(
+                    'tapir_test.reindex_fail', true
+                ) = 'on'
+            THEN
+                RAISE EXCEPTION 'forced reindex failure';
+            END IF;
+            RETURN value;
+        END
+        \$\$;
+
+        CREATE TABLE docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        );
+        INSERT INTO docs (content)
+        SELECT 'row ' || g || ' failure rollback'
+        FROM generate_series(1, 200) g;
+        CREATE INDEX docs_bm25 ON docs
+        USING bm25 (maybe_fail_reindex(content))
+        WITH (text_config='english');
+    "
+
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
+\set QUIET on
+\pset footer off
+\pset tuples_only on
+INSERT INTO docs (content)
+SELECT 'tail ' || g || ' failure rollback cached before failed reindex'
+FROM generate_series(201, 225) g;
+SELECT 'failed_reindex_cache_bytes_before=' || estimated_bytes
+FROM bm25_cache_cold_build('docs_bm25');
+SELECT 'failed_reindex_generation_before=' ||
+       bm25_cache_bump_spill_generation('docs_bm25');
+SELECT 'failed_reindex_summary_before=' ||
+       replace(bm25_summarize_index('docs_bm25'), E'\n', ' ');
+\! if psql -X -h "${SOCKET_DIR}" -p ${TEST_PORT} -d "${TEST_DB}" -v ON_ERROR_STOP=1 -q -c "SET tapir_test.reindex_fail = 'on'; REINDEX INDEX docs_bm25;" 2>&1; then echo B-reindex-unexpected-success; else echo B-reindex-failed-as-expected; fi
+SELECT 'failed_reindex_summary_after=' ||
+       replace(bm25_summarize_index('docs_bm25'), E'\n', ' ');
+SELECT 'failed_reindex_generation_after_failure=' ||
+       bm25_cache_bump_spill_generation('docs_bm25');
+SELECT 'failed_reindex_cache_bytes_after_failure=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'failed_reindex_hits_after_failure=' || count(*) FROM (
+    SELECT 1 FROM docs
+    ORDER BY maybe_fail_reindex(content) <@>
+        to_bm25query('rollback', 'docs_bm25')
+) q;
+\! if psql -X -h "${SOCKET_DIR}" -p ${TEST_PORT} -d "${TEST_DB}" -v ON_ERROR_STOP=1 -q -c "BEGIN; REINDEX INDEX docs_bm25; SELECT 'B-reindex-built-before-abort'; SELECT 1 / 0;" 2>&1; then echo B-postbuild-abort-unexpected-success; else echo B-postbuild-abort-observed; fi
+SELECT 'postbuild_abort_summary=' ||
+       replace(bm25_summarize_index('docs_bm25'), E'\n', ' ');
+SELECT 'failed_reindex_generation_after_rollback=' ||
+       bm25_cache_bump_spill_generation('docs_bm25');
+SELECT 'failed_reindex_cache_bytes_after_rollback=' ||
+       bm25_cache_global_estimated_bytes();
+SELECT 'failed_reindex_hits_after_rollback=' || count(*) FROM (
+    SELECT 1 FROM docs
+    ORDER BY maybe_fail_reindex(content) <@>
+        to_bm25query('rollback', 'docs_bm25')
+) q;
+SELECT 'failed_reindex_cache_bytes_after_rebuild=' ||
+       bm25_cache_global_estimated_bytes();
+EOF
+)
+    session_status=$?
+    set -e
+
+    info "Failed-REINDEX session output: ${output}"
+
+    if [ "${session_status}" -ne 0 ]; then
+        error "Backend A failed after the expected REINDEX error \
+(status ${session_status}). Full output:\n${output}"
+    fi
+    if ! echo "${output}" | grep -qF "forced reindex failure"; then
+        error "Nested REINDEX did not report the injected failure. \
+Full output:\n${output}"
+    fi
+    if ! echo "${output}" | grep -qF "B-reindex-failed-as-expected"; then
+        error "Nested REINDEX failure status was not observed. \
+Full output:\n${output}"
+    fi
+    if echo "${output}" | grep -qF "B-reindex-unexpected-success"; then
+        error "Nested REINDEX unexpectedly succeeded. Full output:\n${output}"
+    fi
+    if ! echo "${output}" | grep -qF "B-reindex-built-before-abort" \
+        || ! echo "${output}" | grep -qF "division by zero" \
+        || ! echo "${output}" | grep -qF "B-postbuild-abort-observed"; then
+        error "Post-build transaction abort was not exercised fully. \
+Full output:\n${output}"
+    fi
+    if echo "${output}" | grep -qF "B-postbuild-abort-unexpected-success"; then
+        error "Post-build transaction unexpectedly committed. \
+Full output:\n${output}"
+    fi
+    local marker
+    for marker in \
+        "failed_reindex_summary_before=" \
+        "failed_reindex_summary_after=" \
+        "postbuild_abort_summary="; do
+        if ! echo "${output}" | grep -qF "${marker}"; then
+            error "Failed REINDEX test missed required marker '${marker}'. \
+Full output:\n${output}"
+        fi
+    done
+
+    generation_before=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_generation_before=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    generation_after_failure=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_generation_after_failure=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    generation_after_rollback=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_generation_after_rollback=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    if ! [[ "${generation_before}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${generation_after_failure}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${generation_after_rollback}" =~ ^[0-9]+$ ]]; then
+        error "Could not parse failed-REINDEX generations \
+('${generation_before}' -> '${generation_after_failure}' -> \
+'${generation_after_rollback}')."
+    fi
+    if [ "${generation_after_failure}" -ne $((generation_before + 1)) ]; then
+        error "Failed REINDEX changed or replaced the pre-existing \
+shared state generation (${generation_before} -> \
+${generation_after_failure})."
+    fi
+    if [ "${generation_after_rollback}" -ne \
+        $((generation_after_failure + 2)) ]; then
+        error "Aborting after REINDEX finalization replaced or discarded \
+the pre-existing shared state (${generation_after_failure} -> \
+${generation_after_rollback})."
+    fi
+
+    cache_bytes_before=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_cache_bytes_before=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    cache_bytes_after_failure=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_cache_bytes_after_failure=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    cache_bytes_after_rollback=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_cache_bytes_after_rollback=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    cache_bytes_after_rebuild=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_cache_bytes_after_rebuild=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    if ! [[ "${cache_bytes_before}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${cache_bytes_after_failure}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${cache_bytes_after_rollback}" =~ ^[0-9]+$ ]] \
+        || ! [[ "${cache_bytes_after_rebuild}" =~ ^[0-9]+$ ]]; then
+        error "Could not parse failed-REINDEX cache accounting \
+('${cache_bytes_before}', '${cache_bytes_after_failure}', \
+'${cache_bytes_after_rollback}', '${cache_bytes_after_rebuild}')."
+    fi
+    if [ "${cache_bytes_before}" -le 0 ]; then
+        error "Failed REINDEX setup did not populate the runtime cache."
+    fi
+    if [ "${cache_bytes_after_failure}" -ne "${cache_bytes_before}" ]; then
+        error "Build-time REINDEX failure changed the existing cache \
+accounting (${cache_bytes_before} -> ${cache_bytes_after_failure})."
+    fi
+    if [ "${cache_bytes_after_rollback}" -ne 0 ] \
+        || [ "${cache_bytes_after_rebuild}" -ne "${cache_bytes_before}" ]; then
+        error "Post-finalization REINDEX abort leaked or failed to rebuild \
+cache accounting (${cache_bytes_before} -> \
+${cache_bytes_after_rollback} -> ${cache_bytes_after_rebuild})."
+    fi
+
+    hits_after_failure=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_hits_after_failure=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    hits_after_rollback=$(echo "${output}" | sed -n \
+        's/^.*failed_reindex_hits_after_rollback=\([0-9]*\).*$/\1/p' \
+        | head -1)
+    if [ "${hits_after_failure}" != "225" ] \
+        || [ "${hits_after_rollback}" != "225" ]; then
+        error "Failed or rolled-back REINDEX left the old index unusable \
+(after failure=${hits_after_failure:-missing}, \
+after rollback=${hits_after_rollback:-missing})."
+    fi
+
+    run_sql_quiet "
+        DROP TABLE docs CASCADE;
+        DROP FUNCTION maybe_fail_reindex(text);
+    "
+    log "✅ failed and rolled-back REINDEX preserved stable state"
 }
 
 # prepare_docs_table — fresh, intentionally-bloated docs table.
@@ -165,9 +1589,35 @@ prepare_docs_table() {
             WITH (text_config='english');
     "
     run_sql_quiet "DELETE FROM docs WHERE id > 1000;"
+    run_sql_quiet "ANALYZE docs;"
 }
 
-# run_rewrite_test test_name rewrite_sql expect_heap_shrink
+prepare_parallel_docs_table() {
+    run_sql_quiet "
+        DROP TABLE IF EXISTS docs CASCADE;
+        CREATE TABLE docs (
+            id      bigserial PRIMARY KEY,
+            content text NOT NULL
+        ) WITH (autovacuum_enabled=false);
+
+        INSERT INTO docs (content)
+        SELECT 'parallel row ' || g || ' lorem ipsum dolor sit amet '
+               || repeat(md5(g::text), 2)
+        FROM generate_series(1, 100000) g;
+
+        ALTER TABLE docs SET (parallel_workers = 2);
+        ANALYZE docs;
+        SET max_parallel_maintenance_workers = 2;
+        SET max_parallel_workers = 4;
+        SET maintenance_work_mem = '256MB';
+        SET min_parallel_table_scan_size = 0;
+        CREATE INDEX docs_bm25 ON docs USING bm25 (content)
+            WITH (text_config='english');
+    "
+}
+
+# run_rewrite_test test_name rewrite_sql expect_heap_shrink rewrite_count
+#                  require_parallel
 #
 # Drive both backends from one psql session: Backend A primes its
 # TpLocalIndexState cache via INSERT, samples pre-rewrite heap size,
@@ -194,19 +1644,50 @@ prepare_docs_table() {
 #   $2: SQL Backend B should run (the heap/index rewrite)
 #   $3: 1 if the rewrite is expected to compact the heap, 0 otherwise
 #       (REINDEX INDEX only touches the index relfilenode)
+#   $4: number of rewrites to run while Backend A retains its cached state
+#   $5: 1 if every rewrite must launch a parallel worker, 0 otherwise
 run_rewrite_test() {
     local test_name="$1"
     local rewrite_sql="$2"
     local expect_heap_shrink="$3"
+    local rewrite_count="$4"
+    local require_parallel="$5"
+    local rewrite_steps=""
+    local rewrite_no
 
     log "Test: ${test_name} (issue #390)"
 
-    prepare_docs_table
+    if [ "${require_parallel}" = "1" ]; then
+        prepare_parallel_docs_table
+    else
+        prepare_docs_table
+    fi
 
-    # Bash heredoc with unquoted EOF so ${DATA_DIR}, ${TEST_PORT},
-    # ${TEST_DB}, ${rewrite_sql} all expand at script-render time.
-    # ON_ERROR_STOP=0 so every server-side error reaches $output,
-    # not just the first.
+    for ((rewrite_no = 1; rewrite_no <= rewrite_count; rewrite_no++)); do
+        rewrite_steps+="\\! if psql -X -h \"${SOCKET_DIR}\""
+        rewrite_steps+=" -p ${TEST_PORT} -d \"${TEST_DB}\""
+        rewrite_steps+=" -v ON_ERROR_STOP=1 -q"
+        rewrite_steps+=" -c \"${rewrite_sql}\""
+        rewrite_steps+="; then echo B-rewrite-ok-${rewrite_no};"
+        rewrite_steps+=" else echo B-rewrite-failed-${rewrite_no}; fi"
+        rewrite_steps+=$'\n'
+        rewrite_steps+="SELECT 'post_rewrite_summary_${rewrite_no}=' ||"
+        rewrite_steps+=$'\n'
+        rewrite_steps+="       replace(bm25_summarize_index("
+        rewrite_steps+="'docs_bm25'), E'\\\\n', ' ');"
+        rewrite_steps+=$'\n'
+        rewrite_steps+="SELECT 'post_rewrite_generation_${rewrite_no}=' ||"
+        rewrite_steps+=$'\n'
+        rewrite_steps+="       bm25_cache_bump_spill_generation("
+        rewrite_steps+="'docs_bm25');"
+        rewrite_steps+=$'\n'
+    done
+
+    # Bash heredoc with unquoted EOF so ${SOCKET_DIR}, ${TEST_PORT},
+    # ${TEST_DB}, and ${rewrite_steps} all expand at script-render time.
+    # Backend A stops on its first SQL error. Each nested Backend B
+    # command emits a success marker only if its rewrite exits zero;
+    # psql's \! does not propagate nested command status reliably.
     #
     # NOTE on shell quoting: ${rewrite_sql} is interpolated INSIDE
     # double quotes after `\! psql ... -c`. Any SQL string passed
@@ -214,9 +1695,10 @@ run_rewrite_test() {
     # four current callers use only single-quoted SQL literals — if
     # a future case needs double quotes, switch the inner -c to a
     # here-string fed to psql instead.
-    local output
-    output=$(psql -h "${DATA_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
-        --set ON_ERROR_STOP=0 2>&1 << EOF
+    local output session_status
+    set +e
+    output=$(psql -X -h "${SOCKET_DIR}" -p "${TEST_PORT}" -d "${TEST_DB}" \
+        --set ON_ERROR_STOP=1 2>&1 << EOF
 \set QUIET on
 \pset footer off
 \pset tuples_only on
@@ -232,18 +1714,20 @@ FROM generate_series(1, 500) g;
 -- rewrite, so the post-rewrite "heap shrank" invariant has zero
 -- slack (matches the exact moment Backend B is about to act on).
 SELECT 'pre_heap_pages=' || (pg_relation_size('docs')::bigint / 8192);
+SELECT 'pre_rewrite_generation=' ||
+       bm25_cache_bump_spill_generation('docs_bm25');
 SELECT 'A-primed' AS marker;
 
--- Backend B: heap/index rewrite. Runs in a *separate* psql
--- process via \! while Backend A's session stays open.
-\! psql -h "${DATA_DIR}" -p ${TEST_PORT} -d "${TEST_DB}" -v ON_ERROR_STOP=1 -q -c "${rewrite_sql}" 2>&1
+-- Backend B: one or more heap/index rewrites. Each runs in a separate
+-- psql process via \! while Backend A's session stays open and retains
+-- the local-state wrapper cached before the first rewrite.
+${rewrite_steps}
 
--- Backend A is still the same session; on v1.2.0 its
--- TpLocalIndexState cache still points at the pre-rewrite
--- TpSharedIndexState because no relcache invalidation fires.
+-- Backend A is still the same session. Its cached TpLocalIndexState
+-- must remain valid because REINDEX resets the shared state in place.
 SELECT 'A-post-rewrite' AS marker;
 
--- Backend A: write via the (potentially stale) cache.
+-- Write through the same stable wrapper.
 INSERT INTO docs (content)
 SELECT 'late ' || g || ' lorem moonlight ' || md5(('l'||g)::text)
 FROM generate_series(1, 50) g;
@@ -258,21 +1742,34 @@ SELECT 'spill_segment_root=' || bm25_spill_index('docs_bm25');
 SELECT 'A-spilled' AS marker;
 EOF
 )
+    session_status=$?
+    set -e
 
     info "Backend A session output: ${output}"
 
     # ----- SETUP INVARIANT CHECKS (must pass before bug assertions) -----
 
-    # 1. Corruption regex — fail fast on the production error symptom.
-    if echo "${output}" | grep -qE "could not read blocks|invalid \
-(page|segment)|XX001"; then
-        error "BUG (issue #390): Backend A session produced a \
-storage-corruption error (likely stale CTID). Output: ${output}"
+    # 1. Backend A must itself exit successfully. This catches SQL
+    #    errors before marker/count parsing can accidentally mask them.
+    if [ "${session_status}" -ne 0 ]; then
+        error "Backend A session exited with status ${session_status}. \
+Full output:\n${output}"
     fi
 
-    # 2. Session must have reached every marker; otherwise an
-    #    unexpected non-corruption error or a hanging psql would
-    #    silently weaken later assertions.
+    # 2. No corruption or generic SQL errors may appear anywhere,
+    #    including output from nested Backend B psql processes.
+    if echo "${output}" | grep -qiE "could not read blocks|invalid \
+(page|segment)|XX001|(^|[[:space:]])ERROR:"; then
+        error "Backend session produced an SQL/storage error. \
+Output:\n${output}"
+    fi
+    if echo "${output}" | grep -qF "B-rewrite-failed-"; then
+        error "A nested rewrite command failed. Output:\n${output}"
+    fi
+
+    # 3. Session and every nested rewrite must emit their required
+    #    markers. In particular, a failed nested psql cannot be hidden
+    #    by outer psql continuing after \!.
     local marker
     for marker in "A-primed" "A-post-rewrite" "A-spilled"; do
         if ! echo "${output}" | grep -qF "${marker}"; then
@@ -281,7 +1778,57 @@ storage-corruption error (likely stale CTID). Output: ${output}"
         fi
     done
 
-    # 3. Spill must have produced a real segment. bm25_spill_index
+    for ((rewrite_no = 1; rewrite_no <= rewrite_count; rewrite_no++)); do
+        for marker in \
+            "B-rewrite-ok-${rewrite_no}" \
+            "post_rewrite_summary_${rewrite_no}=" \
+            "post_rewrite_generation_${rewrite_no}="; do
+            if ! echo "${output}" | grep -qF "${marker}"; then
+                error "Rewrite ${rewrite_no} never reached required marker \
+'${marker}'. Full output:\n${output}"
+            fi
+        done
+    done
+
+    # 4. A designated parallel case must prove every nested REINDEX
+    #    actually launched at least one worker.
+    if [ "${require_parallel}" = "1" ]; then
+        local parallel_launches
+        parallel_launches=$(echo "${output}" |
+            grep -Ec "parallel index build: launched [1-9][0-9]* " || true)
+        if [ "${parallel_launches}" -ne "${rewrite_count}" ]; then
+            error "Expected ${rewrite_count} parallel rewrites, observed \
+${parallel_launches}. Full output:\n${output}"
+        fi
+    fi
+
+    # 5. The spill generation belongs to the stable shared state.
+    #    It must advance monotonically across every rewrite; resetting
+    #    to 1 proves the shared state was destructively replaced.
+    local previous_generation current_generation
+    previous_generation=$(echo "${output}" | sed -n \
+        's/^.*pre_rewrite_generation=\([0-9]*\).*$/\1/p' | head -1)
+    if ! [[ "${previous_generation}" =~ ^[0-9]+$ ]]; then
+        error "Failed to parse pre-rewrite spill generation \
+(got '${previous_generation}')."
+    fi
+    for ((rewrite_no = 1; rewrite_no <= rewrite_count; rewrite_no++)); do
+        current_generation=$(echo "${output}" | sed -n \
+            "s/^.*post_rewrite_generation_${rewrite_no}=\\([0-9]*\\).*$/\\1/p" \
+            | head -1)
+        if ! [[ "${current_generation}" =~ ^[0-9]+$ ]]; then
+            error "Failed to parse spill generation after rewrite \
+${rewrite_no} (got '${current_generation}')."
+        fi
+        if [ "${current_generation}" -le "${previous_generation}" ]; then
+            error "Shared-state spill generation did not advance across \
+rewrite ${rewrite_no} (${previous_generation} -> ${current_generation}); \
+the registry state was replaced instead of reset in place."
+        fi
+        previous_generation="${current_generation}"
+    done
+
+    # 6. Spill must have produced a real segment. bm25_spill_index
     #    returns a BlockNumber (always > 0 for a non-empty spill) or
     #    NULL when no segment was written.
     local spill_segment_root
@@ -295,7 +1842,7 @@ populated the memtable before the explicit spill."
     fi
     info "Spill segment root block: ${spill_segment_root}"
 
-    # 4. Pre-rewrite heap page count (parsed from session output).
+    # 7. Pre-rewrite heap page count (parsed from session output).
     local pre_heap_pages
     pre_heap_pages=$(echo "${output}" \
         | sed -n 's/^.*pre_heap_pages=\([0-9]*\).*$/\1/p' | head -1)
@@ -305,7 +1852,7 @@ session output (got '${pre_heap_pages}'). Test setup broken."
     fi
     info "Pre-rewrite heap pages: ${pre_heap_pages}"
 
-    # 5. Bloat threshold. Promoted from warn to error: the entire
+    # 8. Bloat threshold. Promoted from warn to error: the entire
     #    test thesis depends on the OLD heap dwarfing the NEW one.
     #    Without enough bloat, stale CTIDs may still land on valid
     #    blocks and the bug becomes silently invisible.
@@ -315,7 +1862,7 @@ pages, need >= 1000). Test setup is degenerate — bloat is insufficient \
 for stale-CTID detection."
     fi
 
-    # 6. Heap-rewrite invariant: confirms the rewrite actually
+    # 9. Heap-rewrite invariant: confirms the rewrite actually
     #    happened. Skipped for REINDEX INDEX (touches only the index
     #    relfilenode, not the heap).
     if [ "${expect_heap_shrink}" = "1" ]; then
@@ -429,31 +1976,61 @@ main() {
 
     setup_test_db
 
-    # All four heap/index rewrite paths covered by the issue #390
-    # fix (#374/#375/#392) as a class. The first three rewrite the
-    # heap (and reindex); REINDEX INDEX touches only the index
-    # relfilenode. All four exercise the same TpLocalIndexState
-    # invalidation gap.
+    run_cache_locator_top_level_rollback_test
+    run_cache_locator_savepoint_rollback_test
+    run_cache_locator_prepared_rollback_test
+    run_initial_create_drop_rollback_abort_test
+    run_warm_reindex_chain_count_test
+    run_warm_reindex_reseed_before_abort_test
+    run_cold_registry_reindex_rollback_test
+    run_reindex_bulk_counter_preservation_test
+    run_prepare_bulk_state_reset_test
+    run_prepare_initial_create_test
+    run_failed_reindex_test
+
+    # Cover the heap/index rewrite paths from issue #390 as a class,
+    # then exercise repeated serial and actual parallel REINDEX while
+    # Backend A retains the same TpLocalIndexState wrapper.
     run_rewrite_test \
         "ALTER TABLE ADD COLUMN ... GENERATED STORED" \
         "ALTER TABLE docs ADD COLUMN content_tsv tsvector GENERATED \
 ALWAYS AS (to_tsvector('english', content)) STORED;" \
-        1
+        1 \
+        1 \
+        0
 
     run_rewrite_test \
         "VACUUM FULL docs" \
         "VACUUM FULL docs;" \
-        1
+        1 \
+        1 \
+        0
 
     run_rewrite_test \
         "CLUSTER docs USING docs_pkey" \
         "CLUSTER docs USING docs_pkey;" \
-        1
+        1 \
+        1 \
+        0
 
     run_rewrite_test \
-        "REINDEX INDEX docs_bm25" \
-        "REINDEX INDEX docs_bm25;" \
+        "repeated serial REINDEX INDEX docs_bm25" \
+        "SET max_parallel_maintenance_workers = 0; \
+REINDEX INDEX docs_bm25;" \
+        0 \
+        3 \
         0
+
+    run_rewrite_test \
+        "parallel REINDEX INDEX docs_bm25" \
+        "SET max_parallel_maintenance_workers = 2; \
+SET max_parallel_workers = 4; \
+SET maintenance_work_mem = '256MB'; \
+SET min_parallel_table_scan_size = 0; \
+REINDEX INDEX docs_bm25;" \
+        0 \
+        1 \
+        1
 
     log "🎉 multi_backend_reindex.sh: all tests passed"
     exit 0

--- a/test/scripts/state_build_source.sh
+++ b/test/scripts/state_build_source.sh
@@ -11,6 +11,8 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 BUILD_SOURCE="${REPO_ROOT}/src/access/build.c"
 STATE_SOURCE="${REPO_ROOT}/src/index/state.c"
 STATE_HEADER="${REPO_ROOT}/src/index/state.h"
+MOD_SOURCE="${REPO_ROOT}/src/mod.c"
+REGISTRY_SOURCE="${REPO_ROOT}/src/index/registry.c"
 
 if ! grep -Fq "index_create_subid = index->rd_createSubid" \
     "${BUILD_SOURCE}"; then
@@ -155,6 +157,65 @@ for required in \
     "pfree(old_local_state)"; do
     if ! grep -Fq "${required}" <<<"${create_body}"; then
         echo "build-state creation does not replace wrappers safely: ${required}" >&2
+        exit 1
+    fi
+done
+
+dropdb_body="$(
+    sed -n '/if (IsA(parsetree, DropdbStmt))/,/^[[:space:]]*return;/p' \
+        "${MOD_SOURCE}"
+)"
+
+if grep -Fq "get_database_oid(stmt->dbname" <<<"${dropdb_body}"; then
+    echo "DROP DATABASE cleanup resolves a racy name before core execution" >&2
+    exit 1
+fi
+
+for required in \
+    "TpDropDatabaseContext *drop_context" \
+    "palloc(sizeof(*drop_context))" \
+    "active_drop_database_context = drop_context" \
+    "PG_CATCH()" \
+    "active_drop_database_context = drop_context->previous" \
+    "drop_context->database_oid"; do
+    if ! grep -Fq "${required}" <<<"${dropdb_body}"; then
+        echo "DROP DATABASE cleanup does not track core's dropped OID: \
+${required}" >&2
+        exit 1
+    fi
+done
+
+if grep -Fq "TpDropDatabaseContext drop_context" <<<"${dropdb_body}"; then
+    echo "DROP DATABASE keeps mutable hook context across longjmp on stack" >&2
+    exit 1
+fi
+
+object_access_body="$(
+    sed -n '/^tp_object_access(/,/^}/p' "${MOD_SOURCE}"
+)"
+
+for required in \
+    "classId == DatabaseRelationId" \
+    "active_drop_database_context->database_oid = objectId"; do
+    if ! grep -Fq "${required}" <<<"${object_access_body}"; then
+        echo "database object hook does not capture the authoritative OID: \
+${required}" >&2
+        exit 1
+    fi
+done
+
+registry_walk_body="$(
+    sed -n '/^tp_registry_walk(/,/^}/p' "${REGISTRY_SOURCE}"
+)"
+
+for required in \
+    "dshash_seq_status *status" \
+    "palloc(sizeof(*status))" \
+    "dshash_seq_next(status)" \
+    "dshash_seq_term(status)"; do
+    if ! grep -Fq "${required}" <<<"${registry_walk_body}"; then
+        echo "registry walk keeps mutable iterator state across longjmp: \
+${required}" >&2
         exit 1
     fi
 done

--- a/test/scripts/state_build_source.sh
+++ b/test/scripts/state_build_source.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+#
+# Guard lifecycle invariants that require inspecting backend-local wrapper
+# construction rather than exposing pointer identities through SQL.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_SOURCE="${REPO_ROOT}/src/access/build.c"
+STATE_SOURCE="${REPO_ROOT}/src/index/state.c"
+STATE_HEADER="${REPO_ROOT}/src/index/state.h"
+
+if ! grep -Fq "index_create_subid = index->rd_createSubid" \
+    "${BUILD_SOURCE}"; then
+    echo "build ownership is not derived from PostgreSQL relation context" >&2
+    exit 1
+fi
+
+if ! grep -Fq "index_create_subid = index_rel->rd_createSubid" \
+    "${STATE_SOURCE}" ||
+    ! grep -Fq \
+        "index_oid, heap_oid, index_create_subid" "${STATE_SOURCE}"; then
+    echo "cold rebuild ownership is not restored from relation context" >&2
+    exit 1
+fi
+
+get_body="$(
+    sed -n '/^tp_get_local_index_state(/,/^}/p' "${STATE_SOURCE}"
+)"
+
+if grep -Fq \
+    "local_state->created_in_subxact = InvalidSubTransactionId" \
+    <<<"${get_body}"; then
+    echo "cold rebuild discards restored initial-CREATE ownership" >&2
+    exit 1
+fi
+
+finalize_body="$(
+    sed -n '/^tp_finalize_build_mode(/,/^}/p' "${STATE_SOURCE}"
+)"
+
+for required in \
+    "chain_page_count, 0" \
+    "chain_page_count_needs_reseed, 1"; do
+    if ! grep -Fq "${required}" <<<"${finalize_body}"; then
+        echo "build finalization does not invalidate chain count: ${required}" \
+            >&2
+        exit 1
+    fi
+done
+
+if ! grep -Fq "tp_reseed_chain_page_count_if_needed(index_state, index_rel)" \
+    "${BUILD_SOURCE}" ||
+    ! grep -Fq "reseed_chain_page_count_locked(local_state, index_rel)" \
+    "${STATE_SOURCE}" ||
+    ! grep -Fq "chain_page_count_needs_reseed, 0" "${STATE_SOURCE}"; then
+    echo "auto-spill does not lazily reseed the current relfilenode count" >&2
+    exit 1
+fi
+
+for required in \
+    "chain_page_count_spc_oid" \
+    "chain_page_count_db_oid" \
+    "chain_page_count_rel_number"; do
+    if ! grep -Fq "${required}" "${STATE_HEADER}"; then
+        echo "chain count is not tagged with current relfilenode: ${required}" \
+            >&2
+        exit 1
+    fi
+done
+
+for required in \
+    "cursor_locator" \
+    "cursor_locator_valid"; do
+    if ! grep -Fq "${required}" "${STATE_HEADER}"; then
+        echo "cache cursor is not tagged with its relation file: ${required}" \
+            >&2
+        exit 1
+    fi
+done
+
+if ! grep -Fq "cache_locator_matches(memtable, rel)" \
+    "${REPO_ROOT}/src/memtable/cache.c" ||
+    ! grep -Fq "cache_locator_set(memtable, rel)" \
+    "${REPO_ROOT}/src/memtable/cache.c"; then
+    echo "cache apply/build does not validate its relation file" >&2
+    exit 1
+fi
+
+cache_source="$(
+    sed -n '/^tp_cache_apply_to_tail(/,/^tp_cache_cold_build(/p' \
+        "${REPO_ROOT}/src/memtable/cache.c"
+)"
+locator_line=$(grep -n "cache_drop_locator_mismatch" <<<"${cache_source}" |
+    head -1 | cut -d: -f1)
+cap_line=$(grep -n "global_cap_check" <<<"${cache_source}" |
+    head -1 | cut -d: -f1)
+if [ -z "${locator_line}" ] || [ -z "${cap_line}" ] ||
+    [ "${locator_line}" -ge "${cap_line}" ]; then
+    echo "cache locator is not invalidated before hard-cap admission" >&2
+    exit 1
+fi
+
+reseed_body="$(
+    sed -n '/^tp_reseed_chain_page_count_if_needed(/,/^}/p' "${STATE_SOURCE}"
+)"
+
+if grep -Fq "Assert(!local_state->lock_held)" <<<"${reseed_body}"; then
+    echo "chain-count reseed rejects callers already holding LW_EXCLUSIVE" >&2
+    exit 1
+fi
+
+for required in \
+    "bool acquired_lock = false" \
+    "Assert(local_state->lock_mode == LW_EXCLUSIVE)" \
+    "if (acquired_lock)"; do
+    if ! grep -Fq "${required}" <<<"${reseed_body}"; then
+        echo "chain-count reseed does not preserve caller lock ownership: \
+${required}" >&2
+        exit 1
+    fi
+done
+
+if ! grep -Fq \
+    "chain_page_count_matches_relation(local_state, index_rel)" \
+    <<<"${reseed_body}" ||
+    ! grep -Fq \
+        "tp_set_chain_page_count_for_relation(index_state, index_rel, 0)" \
+        "${BUILD_SOURCE}"; then
+    echo "chain count can survive a relfilenode change without reseeding" >&2
+    exit 1
+fi
+
+create_body="$(
+    sed -n '/^create_or_attach_index_state(/,/^}/p' "${STATE_SOURCE}"
+)"
+
+if grep -Eq "^[[:space:]]*local_state = entry->local_state;" \
+    <<<"${create_body}" ||
+    grep -Fq "entry->local_state->" <<<"${create_body}" ||
+    grep -Fq "old_local_state->shared->" <<<"${create_body}"; then
+    echo "build-state creation reuses or dereferences a possibly stale wrapper" >&2
+    exit 1
+fi
+
+for required in \
+    "old_local_state = entry->local_state" \
+    "old_local_state->shared_dp == shared_dp" \
+    "old_local_state->terms_added_this_xact" \
+    "old_local_state->docs_since_global_check" \
+    "LWLockHeldByMe(&shared_state->lock)" \
+    "entry->local_state = local_state" \
+    "pfree(old_local_state)"; do
+    if ! grep -Fq "${required}" <<<"${create_body}"; then
+        echo "build-state creation does not replace wrappers safely: ${required}" >&2
+        exit 1
+    fi
+done
+
+echo "State build source guards passed"

--- a/test/sql/abort.sql
+++ b/test/sql/abort.sql
@@ -32,16 +32,28 @@ SELECT id, ROUND((body <@> to_bm25query('hello', 'abort_test2_idx'))::numeric, 4
     ORDER BY body <@> to_bm25query('hello', 'abort_test2_idx')
     LIMIT 5;
 
--- Scenario 3: Abort during CREATE INDEX
+-- Scenario 3: Abort during CREATE INDEX after charging its runtime cache
+SELECT bm25_cache_global_estimated_bytes()
+    AS abort_create_baseline \gset
 BEGIN;
 CREATE TABLE abort_test3 (id serial PRIMARY KEY, body text);
 INSERT INTO abort_test3 (body) VALUES ('test document');
-CREATE INDEX ON abort_test3
+CREATE INDEX abort_test3_idx ON abort_test3
     USING bm25 (body) WITH (text_config = 'english');
+-- INSERT only appends the durable chain. A cold build must read it to charge
+-- the derived shared-memory cache before abort cleanup is exercised.
+INSERT INTO abort_test3 (body) VALUES ('charged cache tail');
+SELECT result = 'OK' AND estimated_bytes > 0
+    AS create_abort_cache_charged
+FROM bm25_cache_cold_build('abort_test3_idx') \gset
+\echo create_abort_cache_charged=:create_abort_cache_charged
 SELECT 1/0;
 ROLLBACK;
 -- Table and index should not exist after rollback
 SELECT count(*) FROM pg_class WHERE relname = 'abort_test3';
+SELECT bm25_cache_global_estimated_bytes() = :abort_create_baseline
+    AS create_abort_accounting_restored \gset
+\echo create_abort_accounting_restored=:create_abort_accounting_restored
 
 -- Scenario 4: Abort with DDL (DROP TABLE that has a BM25 index)
 CREATE TABLE abort_test4 (id serial PRIMARY KEY, body text);
@@ -91,17 +103,27 @@ SELECT id FROM abort_test2
 SELECT 1/0;
 ROLLBACK;
 
--- Scenario 9: SAVEPOINT rollback of CREATE INDEX with populated memtable
--- Exercises SubXactCallback cleanup of dshash tables in memtable
+-- Scenario 9: SAVEPOINT rollback of CREATE INDEX with a charged cache
+-- Exercises SubXactCallback cleanup of cache dshash tables and accounting.
 BEGIN;
 CREATE TABLE abort_subxact1 (id serial PRIMARY KEY, body text);
+SELECT bm25_cache_global_estimated_bytes()
+    AS abort_subxact_create_baseline \gset
 SAVEPOINT sp1;
 CREATE INDEX abort_subxact1_idx ON abort_subxact1
     USING bm25 (body) WITH (text_config = 'english');
--- Insert data to populate the memtable (creates string_hash + doc_lengths)
+-- Append durable records, then read them into the shared-memory cache.
 INSERT INTO abort_subxact1 (body) VALUES ('memtable data one');
 INSERT INTO abort_subxact1 (body) VALUES ('memtable data two');
+SELECT result = 'OK' AND estimated_bytes > 0
+    AS subxact_create_abort_cache_charged
+FROM bm25_cache_cold_build('abort_subxact1_idx') \gset
+\echo subxact_create_abort_cache_charged=:subxact_create_abort_cache_charged
 ROLLBACK TO sp1;
+SELECT bm25_cache_global_estimated_bytes()
+           = :abort_subxact_create_baseline
+    AS subxact_create_abort_accounting_restored \gset
+\echo subxact_create_abort_accounting_restored=:subxact_create_abort_accounting_restored
 -- Table should still be usable without the index
 INSERT INTO abort_subxact1 (body) VALUES ('after rollback');
 COMMIT;

--- a/test/sql/cache_memory_cap.sql
+++ b/test/sql/cache_memory_cap.sql
@@ -106,10 +106,137 @@ SELECT count(*) AS b_hits FROM (
     LIMIT 100
 ) q;
 
--- Cleanup
-RESET pg_textsearch.memtable_cache_enabled;
+-- Remove the original test indexes before taking a baseline for the
+-- REINDEX accounting regression.  The baseline is intentionally
+-- relative because the global counter belongs to shared memory.
 DROP INDEX cache_cap_a_idx;
 DROP INDEX cache_cap_b_idx;
 DROP TABLE cache_cap_a;
 DROP TABLE cache_cap_b;
+
+SELECT bm25_cache_global_estimated_bytes()
+    AS reindex_original_baseline \gset
+
+-- Keep one populated cache alive across both REINDEX cycles.  This
+-- proves each replaced index releases only its own accounting rather
+-- than relying on the global counter reaching zero.
+CREATE TABLE cache_reindex_control (id int, body text);
+CREATE INDEX cache_reindex_control_idx ON cache_reindex_control
+    USING bm25 (body) WITH (text_config = 'english');
+INSERT INTO cache_reindex_control
+SELECT g, 'control retained ' || g FROM generate_series(1, 10) g;
+SELECT count(*) AS retained_control_hits FROM (
+    SELECT 1 FROM cache_reindex_control
+    ORDER BY body <@>
+        to_bm25query('control', 'cache_reindex_control_idx')
+) q;
+SELECT bm25_cache_global_estimated_bytes()
+           - :reindex_original_baseline
+    AS retained_control_bytes \gset
+SELECT :retained_control_bytes > 0 AS retained_control_charged;
+
+-- Exercise the parallel REINDEX completion path separately.  The
+-- analyzed row count and worker settings match parallel_build.sql so
+-- both the initial build and REINDEX request one parallel worker.
+SET min_parallel_table_scan_size = 0;
+SET maintenance_work_mem = '256MB';
+SET max_parallel_maintenance_workers = 1;
+
+CREATE TABLE cache_reindex_parallel (id int, body text);
+INSERT INTO cache_reindex_parallel
+SELECT g, 'parallel database document ' || g
+FROM generate_series(1, 100000) g;
+ANALYZE cache_reindex_parallel;
+CREATE INDEX cache_reindex_parallel_idx ON cache_reindex_parallel
+    USING bm25 (body) WITH (text_config = 'english');
+
+-- Add an unflushed runtime tail after the parallel build, then force
+-- that tail into the cache so REINDEX replaces a charged entry.
+INSERT INTO cache_reindex_parallel
+SELECT g, 'parallel database tail ' || g
+FROM generate_series(100001, 100025) g;
+SELECT count(*) AS parallel_reindex_hits FROM (
+    SELECT 1 FROM cache_reindex_parallel
+    ORDER BY body <@>
+        to_bm25query('database', 'cache_reindex_parallel_idx')
+) q;
+SELECT bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS parallel_runtime_cache_charged;
+
+REINDEX INDEX cache_reindex_parallel_idx;
+-- Finalization itself must drain the old cache. Checking before DROP
+-- distinguishes in-place REINDEX cleanup from eventual relation teardown.
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS parallel_reindex_drained_before_drop \gset
+\echo parallel_reindex_drained_before_drop=:parallel_reindex_drained_before_drop
+DROP TABLE cache_reindex_parallel;
+
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS parallel_reindex_released,
+       bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS parallel_reindex_exceeds_retained;
+
+-- Cycle 1: segment spill, unflushed tail, cache-building scan,
+-- REINDEX, and drop.
+CREATE TABLE cache_reindex_test (id int, body text);
+CREATE INDEX cache_reindex_test_idx ON cache_reindex_test
+    USING bm25 (body) WITH (text_config = 'english');
+INSERT INTO cache_reindex_test
+SELECT g, 'databases original ' || g FROM generate_series(1, 50) g;
+SELECT bm25_spill_index('cache_reindex_test_idx');
+INSERT INTO cache_reindex_test
+SELECT g, 'databases tail ' || g FROM generate_series(51, 75) g;
+SELECT count(*) FROM (
+    SELECT 1 FROM cache_reindex_test
+    ORDER BY body <@> to_bm25query('databases', 'cache_reindex_test_idx')
+) q;
+REINDEX INDEX cache_reindex_test_idx;
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS serial_reindex_drained_before_drop \gset
+\echo serial_reindex_drained_before_drop=:serial_reindex_drained_before_drop
+DROP TABLE cache_reindex_test;
+
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_1_released,
+       bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_1_exceeds_retained;
+
+-- Repeat the complete cycle to show that each registry replacement
+-- leaks another cache charge on the unfixed code.
+CREATE TABLE cache_reindex_test (id int, body text);
+CREATE INDEX cache_reindex_test_idx ON cache_reindex_test
+    USING bm25 (body) WITH (text_config = 'english');
+INSERT INTO cache_reindex_test
+SELECT g, 'databases original ' || g FROM generate_series(1, 50) g;
+SELECT bm25_spill_index('cache_reindex_test_idx');
+INSERT INTO cache_reindex_test
+SELECT g, 'databases tail ' || g FROM generate_series(51, 75) g;
+SELECT count(*) FROM (
+    SELECT 1 FROM cache_reindex_test
+    ORDER BY body <@> to_bm25query('databases', 'cache_reindex_test_idx')
+) q;
+REINDEX INDEX cache_reindex_test_idx;
+DROP TABLE cache_reindex_test;
+
+SELECT bm25_cache_global_estimated_bytes()
+           = :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_2_released,
+       bm25_cache_global_estimated_bytes()
+           > :reindex_original_baseline + :retained_control_bytes
+           AS reindex_cycle_2_exceeds_retained;
+
+DROP TABLE cache_reindex_control;
+SELECT bm25_cache_global_estimated_bytes() = :reindex_original_baseline
+           AS control_drop_restored_baseline,
+       bm25_cache_global_estimated_bytes() > :reindex_original_baseline
+           AS control_drop_exceeds_baseline;
+
+RESET pg_textsearch.memtable_cache_enabled;
 DROP EXTENSION pg_textsearch CASCADE;


### PR DESCRIPTION
## Summary

- key shared index state by database and index OID
- preserve shared cache state across `REINDEX` while clearing stale accounting and relfilenode-bound cursors
- clean dropped-database state and reset transaction-local state across prepared transactions
- add required serial, parallel, rollback, multi-backend, and cross-database regressions

Closes #464
Closes #470
Closes #486

## Testing

- PostgreSQL 17 and 18: 77/77 regression tests
- `make test-reindex`
- `make test-cross-database-registry` (52 assertions)